### PR TITLE
Decode social protos depending on request

### DIFF
--- a/decoder/player.go
+++ b/decoder/player.go
@@ -479,8 +479,8 @@ func (player *Player) updateFromPublicProfile(publicProfile *pogo.PlayerPublicPr
 	}
 }
 
-func UpdatePlayerRecordWithPlayerSummary(db db.DbDetails, playerSummary *pogo.PlayerSummaryProto, publicProfile *pogo.PlayerPublicProfileProto) error {
 	player, err := getPlayerRecord(db, playerSummary.GetCodename())
+func UpdatePlayerRecordWithPlayerSummary(db db.DbDetails, playerSummary *pogo.PlayerSummaryProto, publicProfile *pogo.PlayerPublicProfileProto, friendCode string, friendshipId string) error {
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -225,10 +225,8 @@ func decode(ctx context.Context, method int, protoData *ProtoData) {
 	case pogo.Method(pogo.ClientAction_CLIENT_ACTION_PROXY_SOCIAL_ACTION):
 		if protoData.Request != nil {
 			result = decodeSocialActionWithRequest(protoData.Request, protoData.Data)
-		} else {
-			result = decodeSocialActionProxy(protoData.Data)
+			processed = true
 		}
-		processed = true
 		break
 	case pogo.Method_METHOD_GET_MAP_FORTS:
 		result = decodeGetMapForts(ctx, protoData.Data)
@@ -293,7 +291,7 @@ func decodeSocialActionWithRequest(request []byte, payload []byte) string {
 
 	}
 
-	return fmt.Sprintf("Can't parse %s", pogo.SocialAction(proxyRequestProto.GetAction()).String())
+	return fmt.Sprintf("Did not process %s", pogo.SocialAction(proxyRequestProto.GetAction()).String())
 }
 
 func decodeGetFriendDetails(payload []byte) string {
@@ -369,69 +367,6 @@ func decodePlayerPublicProfile(publicProfile []byte) (*pogo.PlayerPublicProfileP
 	publicDataErr := proto.Unmarshal(publicProfile, &publicData)
 
 	return &publicData, publicDataErr
-}
-
-func decodeSocialActionProxy(sDec []byte) string {
-	var proxy pogo.ProxyResponseProto
-
-	if err := proto.Unmarshal(sDec, &proxy); err != nil {
-		log.Fatalln("Failed to parse %s", err)
-		return fmt.Sprintf("Failed to parse %s", err)
-	}
-
-	if proxy.Status != pogo.ProxyResponseProto_COMPLETED && proxy.Status != pogo.ProxyResponseProto_COMPLETED_AND_REASSIGNED {
-		return fmt.Sprintf("unsuccessful proxy response %d %s", int(proxy.Status), proxy.Status)
-	}
-
-	players := make([]*pogo.PlayerSummaryProto, 0)
-
-	// for now, we handle both those protos
-	// but we don't know which one we received...
-	// so we parse both, and continue only if one pass without issue
-	var searchPlayerOutProto pogo.SearchPlayerOutProto
-	var getFriendDetailsOutProto pogo.GetFriendDetailsOutProto
-
-	searchPlayerError := proto.Unmarshal(proxy.Payload, &searchPlayerOutProto)
-	getFriendDetailsError := proto.Unmarshal(proxy.Payload, &getFriendDetailsOutProto)
-
-	if searchPlayerError == nil && getFriendDetailsError == nil {
-		return fmt.Sprintf("Could not determine which social proto received")
-	} else if searchPlayerError == nil {
-		if searchPlayerOutProto.GetResult() != pogo.SearchPlayerOutProto_SUCCESS || searchPlayerOutProto.GetPlayer() == nil {
-			return fmt.Sprintf("unsuccessful search player response")
-		}
-
-		players = append(players, searchPlayerOutProto.GetPlayer())
-	} else if getFriendDetailsError == nil {
-		if getFriendDetailsOutProto.GetResult() != pogo.GetFriendDetailsOutProto_SUCCESS || getFriendDetailsOutProto.GetFriend() == nil {
-			return fmt.Sprintf("unsuccessful get friends details")
-		}
-
-		for _, friend := range getFriendDetailsOutProto.GetFriend() {
-			players = append(players, friend.GetPlayer())
-		}
-	} else {
-		return fmt.Sprintf("Failed to parse social proto")
-	}
-
-	failures := 0
-
-	for _, player := range players {
-		var publicData pogo.PlayerPublicProfileProto
-		publicDataErr := proto.Unmarshal(player.GetPublicData(), &publicData)
-
-		if publicDataErr != nil {
-			failures++
-			continue
-		}
-
-		updatePlayerError := decoder.UpdatePlayerRecordWithPlayerSummary(dbDetails, player, &publicData, "", "")
-		if updatePlayerError != nil {
-			failures++
-		}
-	}
-
-	return fmt.Sprintf("%d players decoded on %d", len(players)-failures, len(players))
 }
 
 func decodeFortDetails(ctx context.Context, sDec []byte) string {


### PR DESCRIPTION
Hello,

I've made a little change to the way Golbat is saving social protos. From now on, it will decode the protos according to the request. The request contains the social action ID, or the friend code, which allows to correctly save the player. 