### PR TITLE
Stats history

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -9,7 +9,7 @@ in_memory = false       # Use in-memory storage for pokemon only
 pokemon = true          # Keep pokemon table is kept nice and short
 incidents = true        # Remove incidents after expiry
 quests = true           # Remove quests after expiry
-stats = true            # Remove entries from pokemon_area_stats, pokemon_stats, etc after 7 days
+stats = 7            # Remove entries from ["pokemon_stats", "pokemon_shiny_stats", "pokemon_iv_stats", "pokemon_hundo_stats", "pokemon_nundo_stats" after x days
 
 [logging]
 debug = false

--- a/config.toml.example
+++ b/config.toml.example
@@ -10,7 +10,7 @@ pokemon = true          # Keep pokemon table is kept nice and short
 incidents = true        # Remove incidents after expiry
 quests = true           # Remove quests after expiry
 stats = true            # Enable/Disable stats history
-statsDays = 14            # Remove entries from ["pokemon_stats", "pokemon_shiny_stats", "pokemon_iv_stats", "pokemon_hundo_stats", "pokemon_nundo_stats" after x days
+stats_days = 7          # Remove entries from ["pokemon_stats", "pokemon_shiny_stats", "pokemon_iv_stats", "pokemon_hundo_stats", "pokemon_nundo_stats" after x days
 
 [logging]
 debug = false

--- a/config.toml.example
+++ b/config.toml.example
@@ -9,7 +9,8 @@ in_memory = false       # Use in-memory storage for pokemon only
 pokemon = true          # Keep pokemon table is kept nice and short
 incidents = true        # Remove incidents after expiry
 quests = true           # Remove quests after expiry
-stats = 7            # Remove entries from ["pokemon_stats", "pokemon_shiny_stats", "pokemon_iv_stats", "pokemon_hundo_stats", "pokemon_nundo_stats" after x days
+stats = true            # Enable/Disable stats history
+statsDays = 14            # Remove entries from ["pokemon_stats", "pokemon_shiny_stats", "pokemon_iv_stats", "pokemon_hundo_stats", "pokemon_nundo_stats" after x days
 
 [logging]
 debug = false

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,8 @@ type cleanup struct {
 	Pokemon   bool `toml:"pokemon"`
 	Quests    bool `toml:"quests"`
 	Incidents bool `toml:"incidents"`
-	Stats     int  `toml:"stats"`
+	Stats     bool `toml:"stats"`
+	StatsDays int  `toml:"statsDays"`
 }
 
 type webhook struct {

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,7 @@ type cleanup struct {
 	Pokemon   bool `toml:"pokemon"`
 	Quests    bool `toml:"quests"`
 	Incidents bool `toml:"incidents"`
-	Stats     bool `toml:"stats"`
+	Stats     int  `toml:"stats"`
 }
 
 type webhook struct {

--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,7 @@ type cleanup struct {
 	Quests    bool `toml:"quests"`
 	Incidents bool `toml:"incidents"`
 	Stats     bool `toml:"stats"`
-	StatsDays int  `toml:"statsDays"`
+	StatsDays int  `toml:"stats_days"`
 }
 
 type webhook struct {

--- a/config/reader.go
+++ b/config/reader.go
@@ -40,6 +40,7 @@ func ReadConfig() {
 
 	// Provide a default value
 	Config.Logging.SaveLogs = true
+	Config.Cleanup.StatsDays = 7
 
 	err = toml.Unmarshal([]byte(byteValue), &Config)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -158,7 +158,7 @@ func main() {
 		StartQuestExpiry(db)
 	}
 
-	if config.Config.Cleanup.Stats == true {
+	if config.Config.Cleanup.Stats >= 0 {
 		StartStatsExpiry(db)
 	}
 

--- a/main.go
+++ b/main.go
@@ -158,7 +158,7 @@ func main() {
 		StartQuestExpiry(db)
 	}
 
-	if config.Config.Cleanup.Stats >= 0 {
+	if config.Config.Cleanup.Stats == true {
 		StartStatsExpiry(db)
 	}
 

--- a/stats.go
+++ b/stats.go
@@ -145,6 +145,8 @@ func StartDatabaseArchiver(db *sqlx.DB) {
 	}
 }
 
+var statsHistoryDeleteTime = config.Config.Cleanup.Stats
+
 func StartStatsExpiry(db *sqlx.DB) {
 	ticker := time.NewTicker(3 * time.Hour)
 	go func() {
@@ -171,8 +173,7 @@ func StartStatsExpiry(db *sqlx.DB) {
 			for _, table := range tables {
 				start = time.Now()
 
-				result, err = db.Exec(fmt.Sprintf("DELETE FROM %s WHERE `date` < DATE(NOW() - INTERVAL 7 DAY);", table))
-
+				result, err = db.Exec(fmt.Sprintf("DELETE FROM %s WHERE `date` < DATE(NOW() - INTERVAL %d DAY);", table, statsHistoryDeleteTime))
 				elapsed = time.Since(start)
 
 				if err != nil {

--- a/stats.go
+++ b/stats.go
@@ -145,7 +145,7 @@ func StartDatabaseArchiver(db *sqlx.DB) {
 	}
 }
 
-var statsHistoryDeleteTime = config.Config.Cleanup.Stats
+var statsHistoryDeleteTime = config.Config.Cleanup.StatsDays
 
 func StartStatsExpiry(db *sqlx.DB) {
 	ticker := time.NewTicker(3 * time.Hour)

--- a/stats.go
+++ b/stats.go
@@ -145,8 +145,6 @@ func StartDatabaseArchiver(db *sqlx.DB) {
 	}
 }
 
-var statsHistoryDeleteTime = config.Config.Cleanup.StatsDays
-
 func StartStatsExpiry(db *sqlx.DB) {
 	ticker := time.NewTicker(3 * time.Hour)
 	go func() {
@@ -173,7 +171,7 @@ func StartStatsExpiry(db *sqlx.DB) {
 			for _, table := range tables {
 				start = time.Now()
 
-				result, err = db.Exec(fmt.Sprintf("DELETE FROM %s WHERE `date` < DATE(NOW() - INTERVAL %d DAY);", table, statsHistoryDeleteTime))
+				result, err = db.Exec(fmt.Sprintf("DELETE FROM %s WHERE `date` < DATE(NOW() - INTERVAL %d DAY);", table, config.Config.Cleanup.StatsDays))
 				elapsed = time.Since(start)
 
 				if err != nil {


### PR DESCRIPTION
Ability to adjust the how long historic stats are kept before being removed from the database.

- New config variable `stats_days = 7` # Where the value defined is in days.

If no value is set, or stats_days is omitted from config.toml, default will be 7 days if `stats = true`