### PR TITLE
Update spawnpoints regardless of wild pokemon processing

### DIFF
--- a/decoder/main.go
+++ b/decoder/main.go
@@ -252,7 +252,6 @@ func UpdateFortBatch(ctx context.Context, db db.DbDetails, p []RawFortData) {
 }
 
 func UpdatePokemonBatch(ctx context.Context, db db.DbDetails, wildPokemonList []RawWildPokemonData, nearbyPokemonList []RawNearbyPokemonData, mapPokemonList []RawMapPokemonData, username string) {
-
 	for _, wild := range wildPokemonList {
 		encounterId := strconv.FormatUint(wild.Data.EncounterId, 10)
 		pokemonMutex, _ := pokemonStripedMutex.GetLock(encounterId)
@@ -266,7 +265,7 @@ func UpdatePokemonBatch(ctx context.Context, db db.DbDetails, wildPokemonList []
 				log.Errorf("getOrCreatePokemonRecord: %s", err)
 			} else {
 				if pokemon == nil || pokemon.isNewRecord() || pokemon.wildSignificantUpdate(wild.Data) {
-					updateTime := time.Now().Unix()
+					updateTime := int64(wild.Timestamp / 1000)
 					go func(wildPokemon *pogo.WildPokemonProto, cellId int64, timestampMs int64) {
 						time.Sleep(15 * time.Second)
 						pokemonMutex, _ := pokemonStripedMutex.GetLock(encounterId)

--- a/decoder/main.go
+++ b/decoder/main.go
@@ -252,8 +252,11 @@ func UpdateFortBatch(ctx context.Context, db db.DbDetails, p []RawFortData) {
 }
 
 func UpdatePokemonBatch(ctx context.Context, db db.DbDetails, wildPokemonList []RawWildPokemonData, nearbyPokemonList []RawNearbyPokemonData, mapPokemonList []RawMapPokemonData, username string) {
-	if config.Config.Tuning.ProcessWilds {
-		for _, wild := range wildPokemonList {
+
+	for _, wild := range wildPokemonList {
+		spawnpointUpdateFromWild(ctx, db, wild.Data, int64(wild.Timestamp))
+
+		if config.Config.Tuning.ProcessWilds {
 			encounterId := strconv.FormatUint(wild.Data.EncounterId, 10)
 			pokemonMutex, _ := pokemonStripedMutex.GetLock(encounterId)
 			pokemonMutex.Lock()

--- a/decoder/main.go
+++ b/decoder/main.go
@@ -178,6 +178,12 @@ var ignoreNearNullFloats = cmp.Comparer(func(x, y null.Float) bool {
 	}
 })
 
+const floatTolerance = 0.000001
+
+func floatAlmostEqual(a, b, tolerance float64) bool {
+	return math.Abs(a-b) < tolerance
+}
+
 func UpdateFortBatch(ctx context.Context, db db.DbDetails, p []RawFortData) {
 	// Logic is:
 	// 1. Filter out pokestops that are unchanged (last modified time)

--- a/decoder/main.go
+++ b/decoder/main.go
@@ -270,8 +270,8 @@ func UpdatePokemonBatch(ctx context.Context, db db.DbDetails, wildPokemonList []
 			if err != nil {
 				log.Errorf("getOrCreatePokemonRecord: %s", err)
 			} else {
-				if pokemon == nil || pokemon.isNewRecord() || pokemon.wildSignificantUpdate(wild.Data) {
-					updateTime := int64(wild.Timestamp / 1000)
+				updateTime := int64(wild.Timestamp / 1000)
+				if pokemon.isNewRecord() || pokemon.wildSignificantUpdate(wild.Data, updateTime) {
 					go func(wildPokemon *pogo.WildPokemonProto, cellId int64, timestampMs int64) {
 						time.Sleep(15 * time.Second)
 						pokemonMutex, _ := pokemonStripedMutex.GetLock(encounterId)
@@ -285,7 +285,7 @@ func UpdatePokemonBatch(ctx context.Context, db db.DbDetails, wildPokemonList []
 							log.Errorf("getOrCreatePokemonRecord: %s", err)
 						} else {
 							// Update if there is still a change required & this update is the most recent
-							if pokemon.wildSignificantUpdate(wildPokemon) && pokemon.Updated.ValueOrZero() < updateTime {
+							if pokemon.wildSignificantUpdate(wildPokemon, updateTime) && pokemon.Updated.ValueOrZero() < updateTime {
 								log.Debugf("DELAYED UPDATE: Updating pokemon %s from wild", encounterId)
 
 								pokemon.updateFromWild(ctx, db, wildPokemon, cellId, timestampMs, username)

--- a/decoder/nests.go
+++ b/decoder/nests.go
@@ -80,7 +80,8 @@ func ReloadNestsAndClearStats(dbDetails db.DbDetails) {
 func LoadNests(dbDetails db.DbDetails) {
 	nests, err := db.LoadNests(dbDetails)
 	if err != nil {
-		panic(err)
+		log.Errorf("Load Nests returns error = %s", err)
+		return
 	}
 
 	newFeatureCollection := geojson.NewFeatureCollection()

--- a/decoder/pokemon.go
+++ b/decoder/pokemon.go
@@ -423,15 +423,18 @@ func (pokemon *Pokemon) addWildPokemon(ctx context.Context, db db.DbDetails, wil
 
 // wildSignificantUpdate returns true if the wild pokemon is significantly different from the current pokemon and
 // should be written.
-func (pokemon *Pokemon) wildSignificantUpdate(wildPokemon *pogo.WildPokemonProto) bool {
+func (pokemon *Pokemon) wildSignificantUpdate(wildPokemon *pogo.WildPokemonProto, time int64) bool {
 	pokemonDisplay := wildPokemon.Pokemon.PokemonDisplay
+	// We would accept a wild update if the pokemon has changed; or to extend an unknown spawn time that is expired
+
 	return pokemon.SeenType.ValueOrZero() == SeenType_Cell ||
 		pokemon.SeenType.ValueOrZero() == SeenType_NearbyStop ||
 		pokemon.PokemonId != int16(wildPokemon.Pokemon.PokemonId) ||
 		pokemon.Form.ValueOrZero() != int64(pokemonDisplay.Form) ||
 		pokemon.Weather.ValueOrZero() != int64(pokemonDisplay.WeatherBoostedCondition) ||
 		pokemon.Costume.ValueOrZero() != int64(pokemonDisplay.Costume) ||
-		pokemon.Gender.ValueOrZero() != int64(pokemonDisplay.Gender)
+		pokemon.Gender.ValueOrZero() != int64(pokemonDisplay.Gender) ||
+		(!pokemon.ExpireTimestampVerified && pokemon.ExpireTimestamp.ValueOrZero() < time)
 }
 
 func (pokemon *Pokemon) updateFromWild(ctx context.Context, db db.DbDetails, wildPokemon *pogo.WildPokemonProto, cellId int64, timestampMs int64, username string) {

--- a/decoder/pokemon.go
+++ b/decoder/pokemon.go
@@ -424,10 +424,14 @@ func (pokemon *Pokemon) addWildPokemon(ctx context.Context, db db.DbDetails, wil
 // wildSignificantUpdate returns true if the wild pokemon is significantly different from the current pokemon and
 // should be written.
 func (pokemon *Pokemon) wildSignificantUpdate(wildPokemon *pogo.WildPokemonProto) bool {
+	pokemonDisplay := wildPokemon.Pokemon.PokemonDisplay
 	return pokemon.SeenType.ValueOrZero() == SeenType_Cell ||
+		pokemon.SeenType.ValueOrZero() == SeenType_NearbyStop ||
 		pokemon.PokemonId != int16(wildPokemon.Pokemon.PokemonId) ||
-		pokemon.Form.ValueOrZero() != int64(wildPokemon.Pokemon.PokemonDisplay.Form) ||
-		pokemon.Weather.ValueOrZero() != int64(wildPokemon.Pokemon.PokemonDisplay.WeatherBoostedCondition)
+		pokemon.Form.ValueOrZero() != int64(pokemonDisplay.Form) ||
+		pokemon.Weather.ValueOrZero() != int64(pokemonDisplay.WeatherBoostedCondition) ||
+		pokemon.Costume.ValueOrZero() != int64(pokemonDisplay.Costume) ||
+		pokemon.Gender.ValueOrZero() != int64(pokemonDisplay.Gender)
 }
 
 func (pokemon *Pokemon) updateFromWild(ctx context.Context, db db.DbDetails, wildPokemon *pogo.WildPokemonProto, cellId int64, timestampMs int64, username string) {
@@ -502,7 +506,7 @@ func (pokemon *Pokemon) calculateIv(a int64, d int64, s int64) {
 	pokemon.Iv = null.FloatFrom(float64(a+d+s) / .45)
 }
 
-// wildSignificantUpdate returns true if the wild pokemon is significantly different from the current pokemon and
+// nearbySignificantUpdate returns true if the wild pokemon is significantly different from the current pokemon and
 // should be written.
 func (pokemon *Pokemon) nearbySignificantUpdate(nearbyPokemon *pogo.NearbyPokemonProto) bool {
 	return (pokemon.SeenType.ValueOrZero() == SeenType_Cell && nearbyPokemon.FortId != "") ||

--- a/decoder/pokemon.go
+++ b/decoder/pokemon.go
@@ -506,15 +506,6 @@ func (pokemon *Pokemon) calculateIv(a int64, d int64, s int64) {
 	pokemon.Iv = null.FloatFrom(float64(a+d+s) / .45)
 }
 
-// nearbySignificantUpdate returns true if the wild pokemon is significantly different from the current pokemon and
-// should be written.
-func (pokemon *Pokemon) nearbySignificantUpdate(nearbyPokemon *pogo.NearbyPokemonProto) bool {
-	return (pokemon.SeenType.ValueOrZero() == SeenType_Cell && nearbyPokemon.FortId != "") ||
-		pokemon.PokemonId != int16(nearbyPokemon.PokedexNumber) ||
-		pokemon.Form.ValueOrZero() != int64(nearbyPokemon.PokemonDisplay.Form) ||
-		pokemon.Weather.ValueOrZero() != int64(nearbyPokemon.PokemonDisplay.WeatherBoostedCondition)
-}
-
 func (pokemon *Pokemon) updateFromNearby(ctx context.Context, db db.DbDetails, nearbyPokemon *pogo.NearbyPokemonProto, cellId int64, username string) {
 	pokemon.IsEvent = 0
 	encounterId := strconv.FormatUint(nearbyPokemon.EncounterId, 10)
@@ -591,10 +582,7 @@ const SeenType_LureEncounter string = "lure_encounter" // Pokemon has been encou
 // information held.
 // db - the database connection to be used
 // wildPokemon - the Pogo Proto to be decoded
-// spawnId - the spawn id the Pokemon was seen at
 // timestampMs - the timestamp to be used for calculations
-// timestampAccurate - whether the timestamp is considered accurate (eg came from a GMO), and so can be used to create
-// a new exact spawnpoint record
 func (pokemon *Pokemon) updateSpawnpointInfo(ctx context.Context, db db.DbDetails, wildPokemon *pogo.WildPokemonProto, timestampMs int64) {
 	spawnId, err := strconv.ParseInt(wildPokemon.SpawnPointId, 16, 64)
 	if err != nil {

--- a/decoder/spawnpoint.go
+++ b/decoder/spawnpoint.go
@@ -89,8 +89,9 @@ func spawnpointUpdateFromWild(ctx context.Context, db db.DbDetails, wildPokemon 
 				Lon: wildPokemon.Longitude,
 			}
 			spawnpointUpdate(ctx, db, &spawnpoint)
+		} else {
+			spawnpointSeen(ctx, db, spawnId)
 		}
-		spawnpointSeen(ctx, db, spawnId)
 	}
 }
 

--- a/decoder/spawnpoint.go
+++ b/decoder/spawnpoint.go
@@ -57,8 +57,8 @@ func getSpawnpointRecord(ctx context.Context, db db.DbDetails, spawnpointId int6
 }
 
 func hasChangesSpawnpoint(old *Spawnpoint, new *Spawnpoint) bool {
-	return old.Lat != new.Lat ||
-		old.Lon != new.Lon ||
+	return !floatAlmostEqual(old.Lat, new.Lat, floatTolerance) ||
+		!floatAlmostEqual(old.Lon, new.Lon, floatTolerance) ||
 		old.DespawnSec != new.DespawnSec
 }
 

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func main() {
 		return
 	}
 
-	log.Infof("Opening database for processing")
+	log.Infof("Opening database for processing, max pool = %d", config.Config.Database.MaxPool)
 
 	// Get a database handle.
 


### PR DESCRIPTION
After being pushed to get the DB performance updates in, some minor issues have arisen. This PR is intended to resolve these.
 * In doing this, have made spawnpoint learning faster
 * Last seen now updates only once per hour to reduce it updating multiple times for the same pokemon appearing
 * Despawn time could bounce around, so will only be updated if it moves by more than a few seconds