### PR TITLE
Penultimate Ditto scanning: Ditto scanning even if spawn rerolls

### DIFF
--- a/decoder/pokemon.go
+++ b/decoder/pokemon.go
@@ -703,11 +703,11 @@ func (pokemon *Pokemon) addEncounterPokemon(ctx context.Context, db db.DbDetails
 	// archive should be set to false for [normal]>0P or 0P>B0
 	setDittoAttributes := func(mode string, to0P, archive, setDitto bool) {
 		if mode == "B0" || mode == "0P" {
-			log.Debugf("[POKEMON] %s: %s Ditto found, disguised as %d. (%x,%d,%x%x%x)",
+			log.Debugf("[POKEMON] %s: %s Ditto found, current display %d. (%x,%d,%x%x%x)",
 				pokemon.Id, mode, pokemon.PokemonId, pokemon.EncounterWeather,
 				level, proto.IndividualStamina, proto.IndividualDefense, proto.IndividualAttack)
 		} else {
-			log.Infof("[POKEMON] %s: %s Ditto found, disguised as %d. (%x,%d,%x%x%x,%03x)>(%x,%d,%x%x%x)",
+			log.Infof("[POKEMON] %s: %s Ditto found, current display %d. (%x,%d,%x%x%x,%03x)>(%x,%d,%x%x%x)",
 				pokemon.Id, mode, pokemon.PokemonId, oldWeather, pokemon.Level.Int64, pokemon.StaIv.ValueOrZero(),
 				pokemon.DefIv.ValueOrZero(), pokemon.AtkIv.ValueOrZero(), pokemon.IvInactive.ValueOrZero(),
 				pokemon.EncounterWeather, level,

--- a/decoder/pokemon.go
+++ b/decoder/pokemon.go
@@ -702,7 +702,7 @@ func (pokemon *Pokemon) addEncounterPokemon(ctx context.Context, db db.DbDetails
 	// Disguise IV depends on Ditto weather boost instead, and caught Ditto is boosted only in PP state.
 	// archive should be set to false for [normal]>0P or 0P>B0
 	setDittoAttributes := func(mode string, to0P, archive, setDitto bool) {
-		if len(mode) <= 2 { // B0 or 0P Ditto
+		if mode == "B0" || mode == "0P" {
 			log.Debugf("[POKEMON] %s: %s Ditto found, disguised as %d. (%x,%d,%x%x%x)",
 				pokemon.Id, mode, pokemon.PokemonId, pokemon.EncounterWeather,
 				level, proto.IndividualStamina, proto.IndividualDefense, proto.IndividualAttack)

--- a/decoder/pokemon.go
+++ b/decoder/pokemon.go
@@ -678,7 +678,7 @@ func (pokemon *Pokemon) addEncounterPokemon(ctx context.Context, db db.DbDetails
 		weather, err := findWeatherRecordByLatLon(ctx, db, pokemon.Lat, pokemon.Lon)
 		if err != nil || weather == nil || !weather.GameplayCondition.Valid {
 			log.Warnf("Failed to obtain weather for Pokemon %s: %s", pokemon.Id, err)
-		} else if weather.GameplayCondition.Int64 != int64(pogo.GameplayWeatherProto_PARTLY_CLOUDY) {
+		} else if weather.GameplayCondition.Int64 == int64(pogo.GameplayWeatherProto_PARTLY_CLOUDY) {
 			isUnboostedPartlyCloudy = true
 		} else {
 			pokemon.EncounterWeather = EncounterWeather_UnboostedNotPartlyCloudy

--- a/decoder/pokemon.go
+++ b/decoder/pokemon.go
@@ -807,8 +807,10 @@ func (pokemon *Pokemon) addEncounterPokemon(ctx context.Context, db db.DbDetails
 					} else if oldWeather&EncounterWeather_Rerolled != 0 {
 						// in case of BN>0P, we set Ditto to be a hidden 0P state, hoping we rediscover later
 						setDittoAttributes("BN>0P or B0>00/[0N]", false, true, false)
+					} else if pokemon.EncounterWeather == EncounterWeather_UnboostedPartlyCloudy {
+						setDittoAttributes("BN>0P or B0>[0N]", false, true, false)
 					} else if pokemon.EncounterWeather == EncounterWeather_UnboostedNotPartlyCloudy {
-						setDittoAttributes("BN>[0P] or B0>00/0N", true, false, true)
+						setDittoAttributes("B0>[00]/0N", false, true, true)
 					} else {
 						// set Ditto as it is most likely B0>00 if species did not reroll
 						setDittoAttributes("BN>0P or B0>[00]/0N", false, true, true)

--- a/decoder/pokemon.go
+++ b/decoder/pokemon.go
@@ -945,7 +945,7 @@ func (pokemon *Pokemon) setPokemonDisplay(pokemonId int16, display *pogo.Pokemon
 		if oldId != pokemonId || pokemon.Form != null.IntFrom(int64(display.Form)) ||
 			pokemon.Costume != null.IntFrom(int64(display.Costume)) ||
 			pokemon.Gender != null.IntFrom(int64(display.Gender)) {
-			log.Infof("Pokemon %s changed from (%d,%d,%d,%d) to (%d,%d,%d,%d)", pokemon.Id, oldId,
+			log.Debugf("Pokemon %s changed from (%d,%d,%d,%d) to (%d,%d,%d,%d)", pokemon.Id, oldId,
 				pokemon.Form.ValueOrZero(), pokemon.Costume.ValueOrZero(), pokemon.Gender.ValueOrZero(),
 				pokemonId, display.Form, display.Costume, display.Gender)
 			// TODO: repopulate weight/size/height?


### PR DESCRIPTION
The main highlight of this PR is that when spotlight hour ends (or when a Ditto event begins), more Ditto than before can be immediately detected using IV scanned during spotlight hour (or before the event begins).

Technical details: It should more reliably detect `00/0N>[B0] or 0P>BN` even if spawn rerolls. There's also another extremely rare mode `BN>[0P] or B0>00/0N` that is also newly supported by this PR.

Other minor improvement: If a Ditto rerolls into its own disguise, we can now sometimes catch it and reset it to non-Ditto.

Already tested for the past spotlight hour.