### PR TITLE
fix: Build functional docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,20 @@
 # Build image
-FROM golang:1.20 as build
+FROM golang:1.20-alpine as build
 
 WORKDIR /go/src/app
 COPY . .
 
+RUN apk add --no-cache \
+    # Important: required for go-sqlite3
+    gcc \
+    # Required for Alpine
+    musl-dev
+
 RUN go mod download
-RUN CGO_ENABLED=0 go build -o /go/bin/golbat
+RUN CGO_ENABLED=1 \
+    go build \
+    -ldflags='-s -w -extldflags "-static"' \
+    -o /go/bin/golbat
 
 # Now copy it into our base image.
 FROM gcr.io/distroless/static-debian11 as runner


### PR DESCRIPTION
### What does this fix?
CGO is explicitly disabled in the Dockerfile but required by go-sqlite3. This results in a non-function docker image for Golbat.

#### Associated log:
```
golbat    | FATL 2023-03-30 03:20:54 Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub
```

Only changing `CGO_ENABLED=1` and building doesn't work because `gcc` isn't included in the `golang:1.20` docker image.

### How has this been tested?

I've build locally and confirmed this is now working as intended.

### Ref links: 
- https://stackoverflow.com/a/68295226
- https://github.com/mattn/go-sqlite3/pull/1052
- https://github.com/mattn/go-sqlite3#installation