### PR TITLE
Implement scan rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,29 +36,39 @@ At this time this is likely to be mostly development discussion.
 The data source should be configured to send to Golbat's 
 URL which will be `http://ip:port/raw`
 
-# Tuning
+# Scan Rules
 
-There can be a tuning section in the config file
+Scan rules can be added to the configuration. These will be processed in order, first match applies - and allows disabling of processing certain types of game objects.
+
+The scan rules can match the object to a geofence, or use the scanner 'mode' when it is supported by raw senders (looking at you Flygon!)
 
 ```toml
-[tuning]
-# process_wild_pokemon = true
-# process_nearby_pokemon = true
+[[scan_rules]]
+areas = ["MainArea"]
+nearby_pokemon = false
+
+[[scan_rules]]
+context = ["Scout"]
+
+[[scan_rules]]
+pokemon = false
 ```
 
-* `process_wild_pokemon` - by default Golbat will process the wilds from the GMO after a 15 second
-delay. This allows time for your MITM to send an encounter to overtake it saving a disk write. If
-you are confident that your MITM is sending encounters, you can disable wilds in all cases
-saving some CPU and memory
-* `process_nearby_pokemon` - by default Golbat will process the nearby pokestop and cell pokemon from the GMO.
-This comes at a cost of ~20% more disk writes than ignoring them.  Many argue these are vanity
-pokemon and not worth the cost.  Some argue that early sight of a rare pokemon is worth the cost.
+Here the main area would not process nearby pokemon. Messages arriving in 'scout' mode would have everything processed; and the default would not process any pokemon (so outside main area not delivered by the scout service)
+
+pokemon - any pokemon processing (disables spawnpoints also)
+wild_pokemon - process wild pokemon from GMO
+nearby_pokemon - process nearby pokemon from GMO
+weather - process weather in GMO
+gyms - process gyms in GMO
+pokestops - process pokestops in GMO
+cells - process cell updates (disabling this also disables automatic fort clearance)
 
 # Optimising maria db
 
 These options can help you quite significantly with performance.
 
-```
+```toml
 # This should be 50% of RAM, leaving space for golbat
 innodb_buffer_pool_size = 64G
 

--- a/config/config.go
+++ b/config/config.go
@@ -3,20 +3,21 @@ package config
 import "golbat/geo"
 
 type configDefinition struct {
-	Port      int       `toml:"port"`
-	Webhooks  []webhook `toml:"webhooks"`
-	Database  database  `toml:"database"`
-	Stats     bool      `toml:"stats"`
-	Logging   logging   `toml:"logging"`
-	Sentry    sentry    `toml:"sentry"`
-	Pyroscope pyroscope `toml:"pyroscope"`
-	InMemory  bool      `toml:"in_memory"`
-	Cleanup   cleanup   `toml:"cleanup"`
-	RawBearer string    `toml:"raw_bearer"`
-	ApiSecret string    `toml:"api_secret"`
-	Pvp       pvp       `toml:"pvp"`
-	Koji      koji      `toml:"koji"`
-	Tuning    tuning    `toml:"tuning"`
+	Port      int        `toml:"port"`
+	Webhooks  []webhook  `toml:"webhooks"`
+	Database  database   `toml:"database"`
+	Stats     bool       `toml:"stats"`
+	Logging   logging    `toml:"logging"`
+	Sentry    sentry     `toml:"sentry"`
+	Pyroscope pyroscope  `toml:"pyroscope"`
+	InMemory  bool       `toml:"in_memory"`
+	Cleanup   cleanup    `toml:"cleanup"`
+	RawBearer string     `toml:"raw_bearer"`
+	ApiSecret string     `toml:"api_secret"`
+	Pvp       pvp        `toml:"pvp"`
+	Koji      koji       `toml:"koji"`
+	Tuning    tuning     `toml:"tuning"`
+	ScanRules []scanRule `toml:"scan"`
 }
 
 type koji struct {
@@ -85,6 +86,15 @@ type tuning struct {
 	ExtendedTimeout bool `toml:"extended_timeout"`
 	ProcessWilds    bool `toml:"process_wild_pokemon"`
 	ProcessNearby   bool `toml:"process_nearby_pokemon"`
+}
+
+type scanRule struct {
+	Areas          []string       `toml:"areas"`
+	AreaNames      []geo.AreaName `toml:"-"`
+	ScanContext    []string       `toml:"context"`
+	ProcessPokemon bool           `toml:"process_pokemon"`
+	ProcessWilds   bool           `toml:"process_wild_pokemon"`
+	ProcessNearby  bool           `toml:"process_nearby_pokemon"`
 }
 
 var Config = configDefinition{

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ type configDefinition struct {
 	Pvp       pvp        `toml:"pvp"`
 	Koji      koji       `toml:"koji"`
 	Tuning    tuning     `toml:"tuning"`
-	ScanRules []scanRule `toml:"scan"`
+	ScanRules []scanRule `toml:"scan_rules"`
 }
 
 type koji struct {
@@ -92,9 +92,9 @@ type scanRule struct {
 	Areas          []string       `toml:"areas"`
 	AreaNames      []geo.AreaName `toml:"-"`
 	ScanContext    []string       `toml:"context"`
-	ProcessPokemon bool           `toml:"process_pokemon"`
-	ProcessWilds   bool           `toml:"process_wild_pokemon"`
-	ProcessNearby  bool           `toml:"process_nearby_pokemon"`
+	ProcessPokemon bool           `toml:"pokemon"`
+	ProcessWilds   bool           `toml:"wild_pokemon"`
+	ProcessNearby  bool           `toml:"nearby_pokemon"`
 }
 
 var Config = configDefinition{

--- a/config/config.go
+++ b/config/config.go
@@ -89,15 +89,16 @@ type tuning struct {
 }
 
 type scanRule struct {
-	Areas          []string       `toml:"areas"`
-	AreaNames      []geo.AreaName `toml:"-"`
-	ScanContext    []string       `toml:"context"`
-	ProcessPokemon *bool          `toml:"pokemon"`
-	ProcessWilds   *bool          `toml:"wild_pokemon"`
-	ProcessNearby  *bool          `toml:"nearby_pokemon"`
-	ProcessWeather *bool          `toml:"weather"`
-	ProcessForts   *bool          `toml:"forts"`
-	ProcessCells   *bool          `toml:"cells"`
+	Areas            []string       `toml:"areas"`
+	AreaNames        []geo.AreaName `toml:"-"`
+	ScanContext      []string       `toml:"context"`
+	ProcessPokemon   *bool          `toml:"pokemon"`
+	ProcessWilds     *bool          `toml:"wild_pokemon"`
+	ProcessNearby    *bool          `toml:"nearby_pokemon"`
+	ProcessWeather   *bool          `toml:"weather"`
+	ProcessCells     *bool          `toml:"cells"`
+	ProcessPokestops *bool          `toml:"pokestops"`
+	ProcessGyms      *bool          `toml:"gyms"`
 }
 
 var Config = configDefinition{

--- a/config/config.go
+++ b/config/config.go
@@ -92,9 +92,12 @@ type scanRule struct {
 	Areas          []string       `toml:"areas"`
 	AreaNames      []geo.AreaName `toml:"-"`
 	ScanContext    []string       `toml:"context"`
-	ProcessPokemon bool           `toml:"pokemon"`
-	ProcessWilds   bool           `toml:"wild_pokemon"`
-	ProcessNearby  bool           `toml:"nearby_pokemon"`
+	ProcessPokemon *bool          `toml:"pokemon"`
+	ProcessWilds   *bool          `toml:"wild_pokemon"`
+	ProcessNearby  *bool          `toml:"nearby_pokemon"`
+	ProcessWeather *bool          `toml:"weather"`
+	ProcessForts   *bool          `toml:"forts"`
+	ProcessCells   *bool          `toml:"cells"`
 }
 
 var Config = configDefinition{

--- a/config/reader.go
+++ b/config/reader.go
@@ -54,6 +54,12 @@ func ReadConfig() {
 		hook := &Config.Webhooks[i]
 		hook.AreaNames = splitIntoAreaAndFenceName(hook.Areas)
 	}
+
+	// translate scan areas to array of geo.AreaName struct
+	for i := 0; i < len(Config.ScanRules); i++ {
+		rule := &Config.ScanRules[i]
+		rule.AreaNames = splitIntoAreaAndFenceName(rule.Areas)
+	}
 }
 
 func splitIntoAreaAndFenceName(areaNames []string) (areas []geo.AreaName) {

--- a/decoder/main.go
+++ b/decoder/main.go
@@ -252,7 +252,7 @@ func UpdateFortBatch(ctx context.Context, db db.DbDetails, p []RawFortData) {
 	}
 }
 
-func UpdatePokemonBatch(ctx context.Context, db db.DbDetails, wildPokemonList []RawWildPokemonData, nearbyPokemonList []RawNearbyPokemonData, mapPokemonList []RawMapPokemonData, username string) {
+func UpdatePokemonBatch(ctx context.Context, db db.DbDetails, scanParameters ScanParameters, wildPokemonList []RawWildPokemonData, nearbyPokemonList []RawNearbyPokemonData, mapPokemonList []RawMapPokemonData, username string) {
 	for _, wild := range wildPokemonList {
 		encounterId := strconv.FormatUint(wild.Data.EncounterId, 10)
 		pokemonMutex, _ := pokemonStripedMutex.GetLock(encounterId)
@@ -260,7 +260,7 @@ func UpdatePokemonBatch(ctx context.Context, db db.DbDetails, wildPokemonList []
 
 		spawnpointUpdateFromWild(ctx, db, wild.Data, int64(wild.Timestamp))
 
-		if config.Config.Tuning.ProcessWilds {
+		if scanParameters.processWild {
 			pokemon, err := getOrCreatePokemonRecord(ctx, db, encounterId)
 			if err != nil {
 				log.Errorf("getOrCreatePokemonRecord: %s", err)
@@ -294,7 +294,7 @@ func UpdatePokemonBatch(ctx context.Context, db db.DbDetails, wildPokemonList []
 		pokemonMutex.Unlock()
 	}
 
-	if config.Config.Tuning.ProcessNearby {
+	if scanParameters.processNearby {
 		for _, nearby := range nearbyPokemonList {
 			encounterId := strconv.FormatUint(nearby.Data.EncounterId, 10)
 			pokemonMutex, _ := pokemonStripedMutex.GetLock(encounterId)

--- a/decoder/main.go
+++ b/decoder/main.go
@@ -260,7 +260,7 @@ func UpdatePokemonBatch(ctx context.Context, db db.DbDetails, scanParameters Sca
 
 		spawnpointUpdateFromWild(ctx, db, wild.Data, int64(wild.Timestamp))
 
-		if scanParameters.processWild {
+		if scanParameters.ProcessWild {
 			pokemon, err := getOrCreatePokemonRecord(ctx, db, encounterId)
 			if err != nil {
 				log.Errorf("getOrCreatePokemonRecord: %s", err)
@@ -294,7 +294,7 @@ func UpdatePokemonBatch(ctx context.Context, db db.DbDetails, scanParameters Sca
 		pokemonMutex.Unlock()
 	}
 
-	if scanParameters.processNearby {
+	if scanParameters.ProcessNearby {
 		for _, nearby := range nearbyPokemonList {
 			encounterId := strconv.FormatUint(nearby.Data.EncounterId, 10)
 			pokemonMutex, _ := pokemonStripedMutex.GetLock(encounterId)

--- a/decoder/main.go
+++ b/decoder/main.go
@@ -179,7 +179,7 @@ func nullFloatAlmostEqual(a, b null.Float, tolerance float64) bool {
 	}
 }
 
-func UpdateFortBatch(ctx context.Context, db db.DbDetails, p []RawFortData) {
+func UpdateFortBatch(ctx context.Context, db db.DbDetails, scanParameters ScanParameters, p []RawFortData) {
 	// Logic is:
 	// 1. Filter out pokestops that are unchanged (last modified time)
 	// 2. Fetch current stops from database
@@ -189,7 +189,7 @@ func UpdateFortBatch(ctx context.Context, db db.DbDetails, p []RawFortData) {
 
 	for _, fort := range p {
 		fortId := fort.Data.FortId
-		if fort.Data.FortType == pogo.FortType_CHECKPOINT {
+		if fort.Data.FortType == pogo.FortType_CHECKPOINT && scanParameters.ProcessPokestops {
 			pokestopMutex, _ := pokestopStripedMutex.GetLock(fortId)
 
 			pokestopMutex.Lock()
@@ -230,7 +230,7 @@ func UpdateFortBatch(ctx context.Context, db db.DbDetails, p []RawFortData) {
 			pokestopMutex.Unlock()
 		}
 
-		if fort.Data.FortType == pogo.FortType_GYM {
+		if fort.Data.FortType == pogo.FortType_GYM && scanParameters.ProcessGyms {
 			gymMutex, _ := gymStripedMutex.GetLock(fortId)
 
 			gymMutex.Lock()

--- a/decoder/scanarea.go
+++ b/decoder/scanarea.go
@@ -7,15 +7,16 @@ import (
 )
 
 type ScanParameters struct {
-	ProcessPokemon bool
-	ProcessWild    bool
-	ProcessNearby  bool
-	ProcessWeather bool
-	ProcessForts   bool
-	ProcessCells   bool
+	ProcessPokemon   bool
+	ProcessWild      bool
+	ProcessNearby    bool
+	ProcessWeather   bool
+	ProcessPokestops bool
+	ProcessGyms      bool
+	ProcessCells     bool
 }
 
-func FindScanArea(scanContext string, lat, lon float64) ScanParameters {
+func FindScanConfiguration(scanContext string, lat, lon float64) ScanParameters {
 	var areas []geo.AreaName
 	areaLookedUp := false
 
@@ -51,21 +52,23 @@ func FindScanArea(scanContext string, lat, lon float64) ScanParameters {
 			return *value
 		}
 		return ScanParameters{
-			ProcessPokemon: defaultTrue(rule.ProcessPokemon),
-			ProcessWild:    defaultTrue(rule.ProcessWilds),
-			ProcessNearby:  defaultTrue(rule.ProcessNearby),
-			ProcessCells:   defaultTrue(rule.ProcessCells),
-			ProcessWeather: defaultTrue(rule.ProcessWeather),
-			ProcessForts:   defaultTrue(rule.ProcessForts),
+			ProcessPokemon:   defaultTrue(rule.ProcessPokemon),
+			ProcessWild:      defaultTrue(rule.ProcessWilds),
+			ProcessNearby:    defaultTrue(rule.ProcessNearby),
+			ProcessCells:     defaultTrue(rule.ProcessCells),
+			ProcessWeather:   defaultTrue(rule.ProcessWeather),
+			ProcessPokestops: defaultTrue(rule.ProcessPokestops),
+			ProcessGyms:      defaultTrue(rule.ProcessGyms),
 		}
 	}
 
 	return ScanParameters{
-		ProcessPokemon: true,
-		ProcessWild:    true,
-		ProcessNearby:  true,
-		ProcessCells:   true,
-		ProcessWeather: true,
-		ProcessForts:   true,
+		ProcessPokemon:   true,
+		ProcessWild:      true,
+		ProcessNearby:    true,
+		ProcessCells:     true,
+		ProcessWeather:   true,
+		ProcessGyms:      true,
+		ProcessPokestops: true,
 	}
 }

--- a/decoder/scanarea.go
+++ b/decoder/scanarea.go
@@ -1,0 +1,56 @@
+package decoder
+
+import (
+	"golbat/config"
+	"golbat/geo"
+	"strings"
+)
+
+type ScanParameters struct {
+	ProcessPokemon bool
+	processWild    bool
+	processNearby  bool
+}
+
+func FindScanArea(scanContext string, lat, lon float64) ScanParameters {
+	var areas []geo.AreaName
+	areaLookedUp := false
+
+	for _, rule := range config.Config.ScanRules {
+		if len(rule.AreaNames) > 0 {
+			if !areaLookedUp {
+				areas = geo.MatchGeofences(statsFeatureCollection, lat, lon)
+				areaLookedUp = true
+			}
+			if !geo.AreaMatchWithWildcards(areas, rule.AreaNames) {
+				continue
+			}
+		}
+		if len(rule.ScanContext) > 0 {
+			found := false
+			for _, context := range rule.ScanContext {
+				if strings.EqualFold(context, scanContext) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+
+		// We have a match
+
+		return ScanParameters{
+			ProcessPokemon: rule.ProcessPokemon,
+			processWild:    rule.ProcessWilds,
+			processNearby:  rule.ProcessNearby,
+		}
+	}
+
+	return ScanParameters{
+		ProcessPokemon: true,
+		processWild:    true,
+		processNearby:  true,
+	}
+}

--- a/decoder/scanarea.go
+++ b/decoder/scanarea.go
@@ -22,7 +22,7 @@ func FindScanArea(scanContext string, lat, lon float64) ScanParameters {
 	for _, rule := range config.Config.ScanRules {
 		if len(rule.AreaNames) > 0 {
 			if !areaLookedUp {
-				areas = geo.MatchGeofences(statsFeatureCollection, lat, lon)
+				areas = MatchStatsGeofence(lat, lon)
 				areaLookedUp = true
 			}
 			if !geo.AreaMatchWithWildcards(areas, rule.AreaNames) {

--- a/decoder/scanarea.go
+++ b/decoder/scanarea.go
@@ -8,8 +8,11 @@ import (
 
 type ScanParameters struct {
 	ProcessPokemon bool
-	processWild    bool
-	processNearby  bool
+	ProcessWild    bool
+	ProcessNearby  bool
+	ProcessWeather bool
+	ProcessForts   bool
+	ProcessCells   bool
 }
 
 func FindScanArea(scanContext string, lat, lon float64) ScanParameters {
@@ -41,16 +44,28 @@ func FindScanArea(scanContext string, lat, lon float64) ScanParameters {
 
 		// We have a match
 
+		defaultTrue := func(value *bool) bool {
+			if value == nil {
+				return true
+			}
+			return *value
+		}
 		return ScanParameters{
-			ProcessPokemon: rule.ProcessPokemon,
-			processWild:    rule.ProcessWilds,
-			processNearby:  rule.ProcessNearby,
+			ProcessPokemon: defaultTrue(rule.ProcessPokemon),
+			ProcessWild:    defaultTrue(rule.ProcessWilds),
+			ProcessNearby:  defaultTrue(rule.ProcessNearby),
+			ProcessCells:   defaultTrue(rule.ProcessCells),
+			ProcessWeather: defaultTrue(rule.ProcessWeather),
+			ProcessForts:   defaultTrue(rule.ProcessForts),
 		}
 	}
 
 	return ScanParameters{
 		ProcessPokemon: true,
-		processWild:    true,
-		processNearby:  true,
+		ProcessWild:    true,
+		ProcessNearby:  true,
+		ProcessCells:   true,
+		ProcessWeather: true,
+		ProcessForts:   true,
 	}
 }

--- a/geo/matchAreas.go
+++ b/geo/matchAreas.go
@@ -1,0 +1,22 @@
+package geo
+
+func AreaMatchWithWildcards(areas []AreaName, areasToMatch []AreaName) bool {
+	for _, hookArea := range areasToMatch {
+		for _, messageArea := range areas {
+			if hookArea.Name == "*" {
+				if hookArea.Parent == messageArea.Parent {
+					return true
+				}
+			} else if hookArea.Parent == "*" {
+				if hookArea.Name == messageArea.Name {
+					return true
+				}
+			} else {
+				if hookArea.Parent == messageArea.Parent && hookArea.Name == messageArea.Name {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/main.go
+++ b/main.go
@@ -520,9 +520,11 @@ func decodeGMO(ctx context.Context, protoData *ProtoData) string {
 		newClientWeather = append(newClientWeather, decoder.RawClientWeatherData{Cell: clientWeather.S2CellId, Data: clientWeather})
 	}
 
-	scanParameters := decoder.FindScanArea(protoData.ScanContext, protoData.Lat, protoData.Lon)
+	scanParameters := decoder.FindScanConfiguration(protoData.ScanContext, protoData.Lat, protoData.Lon)
 
-	decoder.UpdateFortBatch(ctx, dbDetails, newForts)
+	if scanParameters.ProcessGyms || scanParameters.ProcessPokestops {
+		decoder.UpdateFortBatch(ctx, dbDetails, scanParameters, newForts)
+	}
 	if scanParameters.ProcessPokemon {
 		decoder.UpdatePokemonBatch(ctx, dbDetails, scanParameters, newWildPokemon, newNearbyPokemon, newMapPokemon, protoData.Account)
 	}

--- a/main.go
+++ b/main.go
@@ -526,11 +526,15 @@ func decodeGMO(ctx context.Context, protoData *ProtoData) string {
 	if scanParameters.ProcessPokemon {
 		decoder.UpdatePokemonBatch(ctx, dbDetails, scanParameters, newWildPokemon, newNearbyPokemon, newMapPokemon, protoData.Account)
 	}
-	decoder.UpdateClientWeatherBatch(ctx, dbDetails, newClientWeather)
-	decoder.UpdateClientMapS2CellBatch(ctx, dbDetails, newMapCells)
+	if scanParameters.ProcessWeather {
+		decoder.UpdateClientWeatherBatch(ctx, dbDetails, newClientWeather)
+	}
+	if scanParameters.ProcessCells {
+		decoder.UpdateClientMapS2CellBatch(ctx, dbDetails, newMapCells)
 
-	if !(len(newMapPokemon) == 0 && len(newNearbyPokemon) == 0 && len(newForts) == 0) {
-		decoder.ClearRemovedForts(ctx, dbDetails, newMapCells)
+		if !(len(newMapPokemon) == 0 && len(newNearbyPokemon) == 0 && len(newForts) == 0) {
+			decoder.ClearRemovedForts(ctx, dbDetails, newMapCells)
+		}
 	}
 	return fmt.Sprintf("%d cells containing %d forts %d mon %d nearby", len(decodedGmo.MapCell), len(newForts), len(newWildPokemon), len(newNearbyPokemon))
 }

--- a/routes.go
+++ b/routes.go
@@ -18,12 +18,15 @@ import (
 )
 
 type ProtoData struct {
-	Data    []byte
-	Request []byte
-	HaveAr  *bool
-	Account string
-	Level   int
-	Uuid    string
+	Data        []byte
+	Request     []byte
+	HaveAr      *bool
+	Account     string
+	Level       int
+	Uuid        string
+	ScanContext string
+	Lat         float64
+	Lon         float64
 }
 
 type InboundRawData struct {
@@ -59,6 +62,8 @@ func Raw(c *gin.Context) {
 	uuid := ""
 	account := ""
 	level := 30
+	scanContext := ""
+	var latTarget, lonTarget float64
 	var globalHaveAr *bool
 	var protoData []InboundRawData
 
@@ -113,6 +118,18 @@ func Raw(c *gin.Context) {
 					level = int(lvl)
 				}
 			}
+			if v := raw["scan_context"]; v != nil {
+				scanContext, _ = v.(string)
+			}
+
+			if v := raw["lat_target"]; v != nil {
+				latTarget, _ = v.(float64)
+			}
+
+			if v := raw["lon_target"]; v != nil {
+				lonTarget, _ = v.(float64)
+			}
+
 			contents := raw["contents"].([]interface{}) // Other MITM
 			for _, v := range contents {
 				entry := v.(map[string]interface{})
@@ -183,10 +200,13 @@ func Raw(c *gin.Context) {
 			}
 
 			protoData := ProtoData{
-				Account: account,
-				Level:   level,
-				HaveAr:  haveAr,
-				Uuid:    uuid,
+				Account:     account,
+				Level:       level,
+				HaveAr:      haveAr,
+				Uuid:        uuid,
+				Lat:         latTarget,
+				Lon:         lonTarget,
+				ScanContext: scanContext,
 			}
 			protoData.Data, _ = b64.StdEncoding.DecodeString(payload)
 			if request != "" {

--- a/webhooks/collector.go
+++ b/webhooks/collector.go
@@ -81,7 +81,7 @@ func collectHooks() []WebhookQueue {
 				totalCollection = append(totalCollection, currentCollection[GymDetails].Messages...)
 			} else {
 				for _, message := range currentCollection[GymDetails].Messages {
-					if doAreasMatch(message.Areas, hook.AreaNames) {
+					if geo.AreaMatchWithWildcards(message.Areas, hook.AreaNames) {
 						totalCollection = append(totalCollection, message)
 					}
 				}
@@ -92,7 +92,7 @@ func collectHooks() []WebhookQueue {
 				totalCollection = append(totalCollection, currentCollection[Raid].Messages...)
 			} else {
 				for _, message := range currentCollection[Raid].Messages {
-					if doAreasMatch(message.Areas, hook.AreaNames) {
+					if geo.AreaMatchWithWildcards(message.Areas, hook.AreaNames) {
 						totalCollection = append(totalCollection, message)
 					}
 				}
@@ -103,7 +103,7 @@ func collectHooks() []WebhookQueue {
 				totalCollection = append(totalCollection, currentCollection[Weather].Messages...)
 			} else {
 				for _, message := range currentCollection[Weather].Messages {
-					if doAreasMatch(message.Areas, hook.AreaNames) {
+					if geo.AreaMatchWithWildcards(message.Areas, hook.AreaNames) {
 						totalCollection = append(totalCollection, message)
 					}
 				}
@@ -114,7 +114,7 @@ func collectHooks() []WebhookQueue {
 				totalCollection = append(totalCollection, currentCollection[Pokemon].Messages...)
 			} else {
 				for _, message := range currentCollection[Pokemon].Messages {
-					if doAreasMatch(message.Areas, hook.AreaNames) {
+					if geo.AreaMatchWithWildcards(message.Areas, hook.AreaNames) {
 						totalCollection = append(totalCollection, message)
 					}
 				}
@@ -126,7 +126,7 @@ func collectHooks() []WebhookQueue {
 				totalCollection = append(totalCollection, currentCollection[Quest].Messages...)
 			} else {
 				for _, message := range currentCollection[Quest].Messages {
-					if doAreasMatch(message.Areas, hook.AreaNames) {
+					if geo.AreaMatchWithWildcards(message.Areas, hook.AreaNames) {
 						totalCollection = append(totalCollection, message)
 					}
 				}
@@ -137,7 +137,7 @@ func collectHooks() []WebhookQueue {
 				totalCollection = append(totalCollection, currentCollection[Invasion].Messages...)
 			} else {
 				for _, message := range currentCollection[Invasion].Messages {
-					if doAreasMatch(message.Areas, hook.AreaNames) {
+					if geo.AreaMatchWithWildcards(message.Areas, hook.AreaNames) {
 						totalCollection = append(totalCollection, message)
 					}
 				}
@@ -148,7 +148,7 @@ func collectHooks() []WebhookQueue {
 				totalCollection = append(totalCollection, currentCollection[Pokestop].Messages...)
 			} else {
 				for _, message := range currentCollection[Pokestop].Messages {
-					if doAreasMatch(message.Areas, hook.AreaNames) {
+					if geo.AreaMatchWithWildcards(message.Areas, hook.AreaNames) {
 						totalCollection = append(totalCollection, message)
 					}
 				}
@@ -159,7 +159,7 @@ func collectHooks() []WebhookQueue {
 				totalCollection = append(totalCollection, currentCollection[FortUpdate].Messages...)
 			} else {
 				for _, message := range currentCollection[FortUpdate].Messages {
-					if doAreasMatch(message.Areas, hook.AreaNames) {
+					if geo.AreaMatchWithWildcards(message.Areas, hook.AreaNames) {
 						totalCollection = append(totalCollection, message)
 					}
 				}
@@ -181,25 +181,4 @@ func collectHooks() []WebhookQueue {
 	}
 
 	return destinations
-}
-
-func doAreasMatch(messageAreas []geo.AreaName, hookAreas []geo.AreaName) bool {
-	for _, hookArea := range hookAreas {
-		for _, messageArea := range messageAreas {
-			if hookArea.Name == "*" {
-				if hookArea.Parent == messageArea.Parent {
-					return true
-				}
-			} else if hookArea.Parent == "*" {
-				if hookArea.Name == messageArea.Name {
-					return true
-				}
-			} else {
-				if hookArea.Parent == messageArea.Parent && hookArea.Name == messageArea.Name {
-					return true
-				}
-			}
-		}
-	}
-	return false
 }


### PR DESCRIPTION
Scan rules can be added to the configuration. These will be processed in order, first match applies - and allows disabling of processing certain types of game objects.

The scan rules can match the object to a geofence, or use the scanner 'mode' when it is supported by raw senders (looking at you Flygon!)

```toml
[[scan_rules]]
areas = ["MainArea"]
nearby_pokemon = false

[[scan_rules]]
context = ["Scout"]

[[scan_rules]]
pokemon = false
```

Here the main area would not process nearby pokemon.  Messages arriving in 'scout' mode would have everything processed; and the default would not process any pokemon (so outside main area not delivered by the scout service)

* pokemon - any pokemon processing (disables spawnpoints also)
* wild_pokemon - process wild pokemon from GMO
* nearby_pokemon -  process nearby pokemon from GMO
* weather - process weather in GMO
* gyms - process gyms in GMO
* pokestops - process pokestops in GMO
* cells - process cell updates (disabling this also disables automatic fort clearance)

This supercedes the tuning options
