### PR TITLE
Support for Confirmed Incident Lineups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ docker-compose.yml
 /golbat
 /geojson/*
 vbase.proto
-
+__debug_bin

--- a/decoder/incident.go
+++ b/decoder/incident.go
@@ -217,16 +217,6 @@ func (incident *Incident) updateFromPokestopIncidentDisplay(pokestopDisplay *pog
 	}
 }
 
-func (incident *Incident) updateFromOpenInvasionCombatSession(protoReq *pogo.OpenInvasionCombatSessionProto) {
-	if incident == nil {
-		log.Debugf("Updating lineup before it was saved: %s", protoReq.IncidentLookup.IncidentId)
-		incident = &Incident{
-			Id:         protoReq.IncidentLookup.IncidentId,
-			PokestopId: protoReq.IncidentLookup.FortId,
-		}
-	}
-}
-
 func (incident *Incident) updateFromOpenInvasionCombatSessionOut(protoRes *pogo.OpenInvasionCombatSessionOutProto) {
 	incident.Slot1PokemonId = null.NewInt(int64(protoRes.Combat.Opponent.ActivePokemon.PokedexId.Number()), true)
 	incident.Slot1Form = null.NewInt(int64(protoRes.Combat.Opponent.ActivePokemon.PokemonDisplay.Form.Number()), true)
@@ -242,13 +232,6 @@ func (incident *Incident) updateFromOpenInvasionCombatSessionOut(protoRes *pogo.
 }
 
 func (incident *Incident) updateFromStartIncidentOut(proto *pogo.StartIncidentOutProto) {
-	if incident == nil {
-		log.Debugf("Confirming incident before it was saved: %s", proto.Incident.IncidentId)
-		incident = &Incident{
-			Id:         proto.Incident.IncidentId,
-			PokestopId: proto.Incident.FortId,
-		}
-	}
 	incident.Character = int16(proto.Incident.Step[0].GetInvasionBattle().GetCharacter())
 	incident.Confirmed = true
 }

--- a/decoder/incident.go
+++ b/decoder/incident.go
@@ -147,21 +147,22 @@ func createIncidentWebhooks(ctx context.Context, db db.DbDetails, oldIncident *I
 		if stop == nil {
 			stop = &Pokestop{}
 		}
-		lineup := [3]webhookLineup{}
-		lineup[0] = webhookLineup{
-			slot:      1,
-			pokemonId: incident.Slot1PokemonId,
-			form:      incident.Slot1Form,
-		}
-		lineup[1] = webhookLineup{
-			slot:      2,
-			pokemonId: incident.Slot2PokemonId,
-			form:      incident.Slot2Form,
-		}
-		lineup[2] = webhookLineup{
-			slot:      3,
-			pokemonId: incident.Slot3PokemonId,
-			form:      incident.Slot3Form,
+		lineup := [3]webhookLineup{
+			{
+				slot:      1,
+				pokemonId: incident.Slot1PokemonId,
+				form:      incident.Slot1Form,
+			},
+			{
+				slot:      2,
+				pokemonId: incident.Slot2PokemonId,
+				form:      incident.Slot2Form,
+			},
+			{
+				slot:      3,
+				pokemonId: incident.Slot3PokemonId,
+				form:      incident.Slot3Form,
+			},
 		}
 		incidentHook := map[string]interface{}{
 			"id":          incident.Id,
@@ -199,12 +200,14 @@ func (incident *Incident) updateFromPokestopIncidentDisplay(pokestopDisplay *pog
 	incident.StartTime = int64(pokestopDisplay.IncidentStartMs / 1000)
 	incident.ExpirationTime = int64(pokestopDisplay.IncidentExpirationMs / 1000)
 	incident.DisplayType = int16(pokestopDisplay.IncidentDisplayType)
-	characterDisplay := pokestopDisplay.GetCharacterDisplay()
-	if characterDisplay != nil {
-		// team := pokestopDisplay.Open
-		incident.Style = int16(characterDisplay.Style)
-		incident.Character = int16(characterDisplay.Character)
-	} else {
-		incident.Style, incident.Character = 0, 0
+	if !incident.Confirmed {
+		characterDisplay := pokestopDisplay.GetCharacterDisplay()
+		if characterDisplay != nil {
+			// team := pokestopDisplay.Open
+			incident.Style = int16(characterDisplay.Style)
+			incident.Character = int16(characterDisplay.Character)
+		} else {
+			incident.Style, incident.Character = 0, 0
+		}
 	}
 }

--- a/decoder/incident.go
+++ b/decoder/incident.go
@@ -216,3 +216,39 @@ func (incident *Incident) updateFromPokestopIncidentDisplay(pokestopDisplay *pog
 		incident.Style, incident.Character = 0, 0
 	}
 }
+
+func (incident *Incident) updateFromOpenInvasionCombatSession(protoReq *pogo.OpenInvasionCombatSessionProto) {
+	if incident == nil {
+		log.Debugf("Updating lineup before it was saved: %s", protoReq.IncidentLookup.IncidentId)
+		incident = &Incident{
+			Id:         protoReq.IncidentLookup.IncidentId,
+			PokestopId: protoReq.IncidentLookup.FortId,
+		}
+	}
+}
+
+func (incident *Incident) updateFromOpenInvasionCombatSessionOut(protoRes *pogo.OpenInvasionCombatSessionOutProto) {
+	incident.Slot1PokemonId = null.NewInt(int64(protoRes.Combat.Opponent.ActivePokemon.PokedexId.Number()), true)
+	incident.Slot1Form = null.NewInt(int64(protoRes.Combat.Opponent.ActivePokemon.PokemonDisplay.Form.Number()), true)
+	for i, pokemon := range protoRes.Combat.Opponent.ReservePokemon {
+		if i == 0 {
+			incident.Slot2PokemonId = null.NewInt(int64(pokemon.PokedexId.Number()), true)
+			incident.Slot2Form = null.NewInt(int64(pokemon.PokemonDisplay.Form.Number()), true)
+		} else if i == 1 {
+			incident.Slot3PokemonId = null.NewInt(int64(pokemon.PokedexId.Number()), true)
+			incident.Slot3Form = null.NewInt(int64(pokemon.PokemonDisplay.Form.Number()), true)
+		}
+	}
+}
+
+func (incident *Incident) updateFromStartIncidentOut(proto *pogo.StartIncidentOutProto) {
+	if incident == nil {
+		log.Debugf("Confirming incident before it was saved: %s", proto.Incident.IncidentId)
+		incident = &Incident{
+			Id:         proto.Incident.IncidentId,
+			PokestopId: proto.Incident.FortId,
+		}
+	}
+	incident.Character = int16(proto.Incident.Step[0].GetInvasionBattle().GetCharacter())
+	incident.Confirmed = true
+}

--- a/decoder/incident.go
+++ b/decoder/incident.go
@@ -200,7 +200,7 @@ func (incident *Incident) updateFromPokestopIncidentDisplay(pokestopDisplay *pog
 	incident.StartTime = int64(pokestopDisplay.IncidentStartMs / 1000)
 	incident.ExpirationTime = int64(pokestopDisplay.IncidentExpirationMs / 1000)
 	incident.DisplayType = int16(pokestopDisplay.IncidentDisplayType)
-	if incident.Character == 46 && incident.Confirmed {
+	if (incident.Character == int16(pogo.EnumWrapper_CHARACTER_DECOY_GRUNT_MALE) || incident.Character == int16(pogo.EnumWrapper_CHARACTER_DECOY_GRUNT_FEMALE)) && incident.Confirmed {
 		log.Debugf("Incident has already been confirmed as a decoy: %s", incident.Id)
 		return
 	}

--- a/decoder/incident.go
+++ b/decoder/incident.go
@@ -200,6 +200,10 @@ func (incident *Incident) updateFromPokestopIncidentDisplay(pokestopDisplay *pog
 	incident.StartTime = int64(pokestopDisplay.IncidentStartMs / 1000)
 	incident.ExpirationTime = int64(pokestopDisplay.IncidentExpirationMs / 1000)
 	incident.DisplayType = int16(pokestopDisplay.IncidentDisplayType)
+	if incident.Character == 46 && incident.Confirmed {
+		log.Debugf("Incident has already been confirmed as a decoy: %s", incident.Id)
+		return
+	}
 	characterDisplay := pokestopDisplay.GetCharacterDisplay()
 	if characterDisplay != nil {
 		// team := pokestopDisplay.Open

--- a/decoder/incident.go
+++ b/decoder/incident.go
@@ -174,8 +174,8 @@ func createIncidentWebhooks(ctx context.Context, db db.DbDetails, oldIncident *I
 			"lineup":                    nil,
 		}
 
-		if incident.Slot1PokemonId != null.NewInt(0, false) {
-			incidentHook["lineup"] = [3]webhookLineup{
+		if incident.Slot1PokemonId.Valid {
+			incidentHook["lineup"] = []webhookLineup{
 				{
 					slot:      1,
 					pokemonId: incident.Slot1PokemonId,

--- a/decoder/incident.go
+++ b/decoder/incident.go
@@ -200,14 +200,12 @@ func (incident *Incident) updateFromPokestopIncidentDisplay(pokestopDisplay *pog
 	incident.StartTime = int64(pokestopDisplay.IncidentStartMs / 1000)
 	incident.ExpirationTime = int64(pokestopDisplay.IncidentExpirationMs / 1000)
 	incident.DisplayType = int16(pokestopDisplay.IncidentDisplayType)
-	if !incident.Confirmed {
-		characterDisplay := pokestopDisplay.GetCharacterDisplay()
-		if characterDisplay != nil {
-			// team := pokestopDisplay.Open
-			incident.Style = int16(characterDisplay.Style)
-			incident.Character = int16(characterDisplay.Character)
-		} else {
-			incident.Style, incident.Character = 0, 0
-		}
+	characterDisplay := pokestopDisplay.GetCharacterDisplay()
+	if characterDisplay != nil {
+		// team := pokestopDisplay.Open
+		incident.Style = int16(characterDisplay.Style)
+		incident.Character = int16(characterDisplay.Character)
+	} else {
+		incident.Style, incident.Character = 0, 0
 	}
 }

--- a/decoder/incident.go
+++ b/decoder/incident.go
@@ -147,23 +147,7 @@ func createIncidentWebhooks(ctx context.Context, db db.DbDetails, oldIncident *I
 		if stop == nil {
 			stop = &Pokestop{}
 		}
-		lineup := [3]webhookLineup{
-			{
-				slot:      1,
-				pokemonId: incident.Slot1PokemonId,
-				form:      incident.Slot1Form,
-			},
-			{
-				slot:      2,
-				pokemonId: incident.Slot2PokemonId,
-				form:      incident.Slot2Form,
-			},
-			{
-				slot:      3,
-				pokemonId: incident.Slot3PokemonId,
-				form:      incident.Slot3Form,
-			},
-		}
+
 		incidentHook := map[string]interface{}{
 			"id":          incident.Id,
 			"pokestop_id": incident.PokestopId,
@@ -187,9 +171,28 @@ func createIncidentWebhooks(ctx context.Context, db db.DbDetails, oldIncident *I
 			"character":                 incident.Character,
 			"updated":                   incident.Updated,
 			"confirmed":                 incident.Confirmed,
-			"lineup":                    lineup,
+			"lineup":                    nil,
 		}
 
+		if incident.Slot1PokemonId != null.NewInt(0, false) {
+			incidentHook["lineup"] = [3]webhookLineup{
+				{
+					slot:      1,
+					pokemonId: incident.Slot1PokemonId,
+					form:      incident.Slot1Form,
+				},
+				{
+					slot:      2,
+					pokemonId: incident.Slot2PokemonId,
+					form:      incident.Slot2Form,
+				},
+				{
+					slot:      3,
+					pokemonId: incident.Slot3PokemonId,
+					form:      incident.Slot3Form,
+				},
+			}
+		}
 		areas := MatchStatsGeofence(stop.Lat, stop.Lon)
 		webhooks.AddMessage(webhooks.Invasion, incidentHook, areas)
 	}

--- a/decoder/incident.go
+++ b/decoder/incident.go
@@ -8,20 +8,34 @@ import (
 	"golbat/db"
 	"golbat/pogo"
 	"golbat/webhooks"
+	null "gopkg.in/guregu/null.v4"
 	"time"
 )
 
 // Incident struct.
 // REMINDER! Keep hasChangesIncident updated after making changes
 type Incident struct {
-	Id             string `db:"id"`
-	PokestopId     string `db:"pokestop_id"`
-	StartTime      int64  `db:"start"`
-	ExpirationTime int64  `db:"expiration"`
-	DisplayType    int16  `db:"display_type"`
-	Style          int16  `db:"style"`
-	Character      int16  `db:"character"`
-	Updated        int64  `db:"updated"`
+	Id             string   `db:"id"`
+	PokestopId     string   `db:"pokestop_id"`
+	StartTime      int64    `db:"start"`
+	ExpirationTime int64    `db:"expiration"`
+	DisplayType    int16    `db:"display_type"`
+	Style          int16    `db:"style"`
+	Character      int16    `db:"character"`
+	Updated        int64    `db:"updated"`
+	Confirmed      bool     `db:"confirmed"`
+	Slot1PokemonId null.Int `db:"slot_1_pokemon_id"`
+	Slot1Form      null.Int `db:"slot_1_form"`
+	Slot2PokemonId null.Int `db:"slot_2_pokemon_id"`
+	Slot2Form      null.Int `db:"slot_2_form"`
+	Slot3PokemonId null.Int `db:"slot_3_pokemon_id"`
+	Slot3Form      null.Int `db:"slot_3_form"`
+}
+
+type webhookLineup struct {
+	slot      uint8    `json:"slot"`
+	pokemonId null.Int `json:"pokemon_id"`
+	form      null.Int `json:"form"`
 }
 
 //->   `id` varchar(35) NOT NULL,
@@ -42,7 +56,7 @@ func getIncidentRecord(ctx context.Context, db db.DbDetails, incidentId string) 
 
 	incident := Incident{}
 	err := db.GeneralDb.GetContext(ctx, &incident,
-		"SELECT id, pokestop_id, start, expiration, display_type, style, `character`, updated "+
+		"SELECT id, pokestop_id, start, expiration, display_type, style, `character`, updated, confirmed, slot_1_pokemon_id, slot_1_form, slot_2_pokemon_id, slot_2_form, slot_3_pokemon_id, slot_3_form "+
 			"FROM incident "+
 			"WHERE incident.id = ? ", incidentId)
 	if err == sql.ErrNoRows {
@@ -66,7 +80,15 @@ func hasChangesIncident(old *Incident, new *Incident) bool {
 		old.DisplayType != new.DisplayType ||
 		old.Style != new.Style ||
 		old.Character != new.Character ||
-		old.Updated != new.Updated
+		old.Confirmed != new.Confirmed ||
+		old.Updated != new.Updated ||
+		old.Slot1PokemonId != new.Slot1PokemonId ||
+		old.Slot1Form != new.Slot1Form ||
+		old.Slot2PokemonId != new.Slot2PokemonId ||
+		old.Slot2Form != new.Slot2Form ||
+		old.Slot3PokemonId != new.Slot3PokemonId ||
+		old.Slot3Form != new.Slot3Form
+
 }
 
 func saveIncidentRecord(ctx context.Context, db db.DbDetails, incident *Incident) {
@@ -83,8 +105,8 @@ func saveIncidentRecord(ctx context.Context, db db.DbDetails, incident *Incident
 	//log.Println(cmp.Diff(oldIncident, incident))
 
 	if oldIncident == nil {
-		res, err := db.GeneralDb.NamedExec("INSERT INTO incident (id, pokestop_id, start, expiration, display_type, style, `character`, updated) "+
-			"VALUES (:id, :pokestop_id, :start, :expiration, :display_type, :style, :character, :updated)", incident)
+		res, err := db.GeneralDb.NamedExec("INSERT INTO incident (id, pokestop_id, start, expiration, display_type, style, `character`, updated, confirmed, slot_1_pokemon_id, slot_1_form, slot_2_pokemon_id, slot_2_form, slot_3_pokemon_id, slot_3_form) "+
+			"VALUES (:id, :pokestop_id, :start, :expiration, :display_type, :style, :character, :updated, :confirmed, :slot_1_pokemon_id, :slot_1_form, :slot_2_pokemon_id, :slot_2_form, :slot_3_pokemon_id, :slot_3_form)", incident)
 
 		if err != nil {
 			log.Errorf("insert incident: %s", err)
@@ -99,7 +121,14 @@ func saveIncidentRecord(ctx context.Context, db db.DbDetails, incident *Incident
 			"display_type = :display_type, "+
 			"style = :style, "+
 			"`character` = :character, "+
-			"updated = :updated "+
+			"updated = :updated, "+
+			"confirmed = :confirmed, "+
+			"slot_1_pokemon_id = :slot_1_pokemon_id, "+
+			"slot_1_form = :slot_1_form, "+
+			"slot_2_pokemon_id = :slot_2_pokemon_id, "+
+			"slot_2_form = :slot_2_form, "+
+			"slot_3_pokemon_id = :slot_3_pokemon_id, "+
+			"slot_3_form = :slot_3_form "+
 			"WHERE id = :id", incident,
 		)
 		if err != nil {
@@ -118,7 +147,22 @@ func createIncidentWebhooks(ctx context.Context, db db.DbDetails, oldIncident *I
 		if stop == nil {
 			stop = &Pokestop{}
 		}
-
+		lineup := [3]webhookLineup{}
+		lineup[0] = webhookLineup{
+			slot:      1,
+			pokemonId: incident.Slot1PokemonId,
+			form:      incident.Slot1Form,
+		}
+		lineup[1] = webhookLineup{
+			slot:      2,
+			pokemonId: incident.Slot2PokemonId,
+			form:      incident.Slot2Form,
+		}
+		lineup[2] = webhookLineup{
+			slot:      3,
+			pokemonId: incident.Slot3PokemonId,
+			form:      incident.Slot3Form,
+		}
 		incidentHook := map[string]interface{}{
 			"id":          incident.Id,
 			"pokestop_id": incident.PokestopId,
@@ -141,6 +185,8 @@ func createIncidentWebhooks(ctx context.Context, db db.DbDetails, oldIncident *I
 			"grunt_type":                incident.Character, // deprecated, remove old key in the future
 			"character":                 incident.Character,
 			"updated":                   incident.Updated,
+			"confirmed":                 incident.Confirmed,
+			"lineup":                    lineup,
 		}
 
 		areas := MatchStatsGeofence(stop.Lat, stop.Lon)
@@ -155,6 +201,7 @@ func (incident *Incident) updateFromPokestopIncidentDisplay(pokestopDisplay *pog
 	incident.DisplayType = int16(pokestopDisplay.IncidentDisplayType)
 	characterDisplay := pokestopDisplay.GetCharacterDisplay()
 	if characterDisplay != nil {
+		// team := pokestopDisplay.Open
 		incident.Style = int16(characterDisplay.Style)
 		incident.Character = int16(characterDisplay.Character)
 	} else {

--- a/decoder/main.go
+++ b/decoder/main.go
@@ -2,11 +2,11 @@ package decoder
 
 import (
 	"context"
+	"fmt"
 	"github.com/UnownHash/gohbem"
 	"github.com/jellydator/ttlcache/v3"
 	stripedmutex "github.com/nmvalera/striped-mutex"
 	log "github.com/sirupsen/logrus"
-	"fmt"
 	"golbat/config"
 	"golbat/db"
 	"golbat/pogo"
@@ -15,10 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Pupitar/ohbemgo"
-	"github.com/jellydator/ttlcache/v3"
-	stripedmutex "github.com/nmvalera/striped-mutex"
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/guregu/null.v4"
 )
 

--- a/decoder/main.go
+++ b/decoder/main.go
@@ -446,7 +446,7 @@ func shouldSkipCellCheck(cellId uint64, now int64) bool {
 }
 
 func UpdateIncidentLineup(ctx context.Context, db db.DbDetails, id string, proto *pogo.OpenInvasionCombatSessionOutProto) string {
-	incident, err := getIncidentRecord(context.Background(), db, id)
+	incident, err := getIncidentRecord(ctx, db, id)
 	if err != nil {
 		return fmt.Sprintf("getIncident: %s", err)
 	}
@@ -470,7 +470,7 @@ func UpdateIncidentLineup(ctx context.Context, db db.DbDetails, id string, proto
 }
 
 func ConfirmIncident(ctx context.Context, db db.DbDetails, proto *pogo.StartIncidentOutProto) string {
-	incident, err := getIncidentRecord(context.Background(), db, proto.Incident.IncidentId)
+	incident, err := getIncidentRecord(ctx, db, proto.Incident.IncidentId)
 	if err != nil {
 		return fmt.Sprintf("getIncident: %s", err)
 	}
@@ -478,8 +478,8 @@ func ConfirmIncident(ctx context.Context, db db.DbDetails, proto *pogo.StartInci
 		return fmt.Sprintf("incident not found: %s", proto.Incident.IncidentId)
 	}
 	incident.Character = int16(proto.Incident.Step[0].GetInvasionBattle().GetCharacter())
-
 	incident.Confirmed = true
+
 	saveIncidentRecord(ctx, db, incident)
 	return ""
 }

--- a/decoder/main.go
+++ b/decoder/main.go
@@ -461,7 +461,13 @@ func UpdateIncidentLineup(ctx context.Context, db db.DbDetails, protoReq *pogo.O
 		incidentMutex.Unlock()
 		return fmt.Sprintf("getIncident: %s", err)
 	}
-	incident.updateFromOpenInvasionCombatSession(protoReq)
+	if incident == nil {
+		log.Debugf("Updating lineup before it was saved: %s", protoReq.IncidentLookup.IncidentId)
+		incident = &Incident{
+			Id:         protoReq.IncidentLookup.IncidentId,
+			PokestopId: protoReq.IncidentLookup.FortId,
+		}
+	}
 	incident.updateFromOpenInvasionCombatSessionOut(protoRes)
 
 	saveIncidentRecord(ctx, db, incident)
@@ -477,6 +483,13 @@ func ConfirmIncident(ctx context.Context, db db.DbDetails, proto *pogo.StartInci
 	if err != nil {
 		incidentMutex.Unlock()
 		return fmt.Sprintf("getIncident: %s", err)
+	}
+	if incident == nil {
+		log.Debugf("Confirming incident before it was saved: %s", proto.Incident.IncidentId)
+		incident = &Incident{
+			Id:         proto.Incident.IncidentId,
+			PokestopId: proto.Incident.FortId,
+		}
 	}
 	incident.updateFromStartIncidentOut(proto)
 

--- a/decoder/main.go
+++ b/decoder/main.go
@@ -445,7 +445,7 @@ func shouldSkipCellCheck(cellId uint64, now int64) bool {
 	return false
 }
 
-func UpdateInvasionLineup(ctx context.Context, db db.DbDetails, id string, proto *pogo.OpenInvasionCombatSessionOutProto) string {
+func UpdateIncidentLineup(ctx context.Context, db db.DbDetails, id string, proto *pogo.OpenInvasionCombatSessionOutProto) string {
 	incident, err := getIncidentRecord(context.Background(), db, id)
 	if err != nil {
 		return fmt.Sprintf("getIncident: %s", err)

--- a/main.go
+++ b/main.go
@@ -494,19 +494,19 @@ func decodeDiskEncounter(ctx context.Context, sDec []byte) string {
 }
 
 func decodeInvasionConfirmation(ctx context.Context, sDec []byte) string {
-	decodedGiovanni := &pogo.StartIncidentOutProto{}
-	if err := proto.Unmarshal(sDec, decodedGiovanni); err != nil {
+	decodedIncident := &pogo.StartIncidentOutProto{}
+	if err := proto.Unmarshal(sDec, decodedIncident); err != nil {
 		log.Fatalln("Failed to parse", err)
 		return fmt.Sprintf("Failed to parse %s", err)
 	}
 
-	if decodedGiovanni.Status != pogo.StartIncidentOutProto_SUCCESS {
-		res := fmt.Sprintf(`GiovanniOutProto: Ignored non-success value %d:%s`, decodedGiovanni.Status,
-			pogo.StartIncidentOutProto_Status_name[int32(decodedGiovanni.Status)])
+	if decodedIncident.Status != pogo.StartIncidentOutProto_SUCCESS {
+		res := fmt.Sprintf(`GiovanniOutProto: Ignored non-success value %d:%s`, decodedIncident.Status,
+			pogo.StartIncidentOutProto_Status_name[int32(decodedIncident.Status)])
 		return res
 	}
 
-	return decoder.ConfirmIncident(ctx, dbDetails, decodedGiovanni)
+	return decoder.ConfirmIncident(ctx, dbDetails, decodedIncident)
 }
 
 func decodeInvasionLineupWithRequest(ctx context.Context, request []byte, payload []byte) string {

--- a/main.go
+++ b/main.go
@@ -529,7 +529,7 @@ func decodeOpenInvasion(ctx context.Context, request []byte, payload []byte) str
 		return res
 	}
 
-	return decoder.UpdateIncidentLineup(ctx, dbDetails, decodeOpenInvasionRequest.IncidentLookup.IncidentId, decodedOpenInvasionResponse)
+	return decoder.UpdateIncidentLineup(ctx, dbDetails, decodeOpenInvasionRequest, decodedOpenInvasionResponse)
 }
 
 func decodeGMO(ctx context.Context, protoData *ProtoData, scanParameters decoder.ScanParameters) string {

--- a/main.go
+++ b/main.go
@@ -219,6 +219,7 @@ func decode(ctx context.Context, method int, protoData *ProtoData) {
 	switch pogo.Method(method) {
 	case pogo.Method_METHOD_START_INCIDENT:
 		result = decodeStartIncident(ctx, protoData.Data)
+		processed = true
 	case pogo.Method_METHOD_INVASION_OPEN_COMBAT_SESSION:
 		result = decodeOpenInvasion(ctx, protoData.Request, protoData.Data)
 		processed = true

--- a/sql/17_invasion_lineups.up.sql
+++ b/sql/17_invasion_lineups.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `incident`
+  ADD COLUMN `confirmed` tinyint unsigned NOT NULL DEFAULT 0,
+  ADD COLUMN `slot_1_pokemon_id` smallint unsigned,
+  ADD COLUMN  `slot_1_form` smallint unsigned,
+  ADD COLUMN `slot_2_pokemon_id` smallint unsigned,
+  ADD COLUMN  `slot_2_form` smallint unsigned,
+  ADD COLUMN `slot_3_pokemon_id` smallint unsigned,
+  ADD COLUMN  `slot_3_form` smallint unsigned;


### PR DESCRIPTION
Golbat support to decode proto methods 1200 and 1202

**1200** can confirm the incident character, such as Giovanni or a Decoy
**1202** confirms the entire incident's lineup to inform users about the reward

Webhook Additions:
```json
    {
      "confirmed": true,
      "lineup": [
        { "slot": 1, "pokemon_id": 2, "form": 3 },
        { "slot": 2, "pokemon_id": 124, "form": 124 },
        { "slot": 3, "pokemon_id": 97, "form": 42 }
      ]
    }
```
<img width="254" alt="Screenshot 2023-04-04 at 11 25 54 PM" src="https://user-images.githubusercontent.com/58572875/229973661-9c153516-d416-4b70-bea7-0f1ffbc6d7fb.png">

Change Notes:
- migration to add some columns to the incident table
- update invasion lineups and confirmation status when they're opened
- sends webhooks
- requires mitm that sends these protos
- 1202 also requires the mitm to send `OpenInvasionCombatSessionProto` (the request) in order to confirm the `incident_id` for the decoder

Closes #12
Closes #80 

Confirmed working with https://github.com/WatWowMap/ReactMap/pull/682