### PR TITLE
Populate CP on spawn reroll

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ type pvp struct {
 	IncludeHundosUnderCap bool         `toml:"include_hundos_under_cap"`
 	LevelCaps             []int        `toml:"level_caps"`
 	Leagues               []pvpLeagues `toml:"leagues"`
+	RankingComparator     string       `toml:"ranking_comparator"`
 }
 
 type pvpLeagues struct {

--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,7 @@ type pvp struct {
 	IncludeHundosUnderCap bool         `koanf:"include_hundos_under_cap"`
 	LevelCaps             []int        `koanf:"level_caps"`
 	Leagues               []pvpLeagues `koanf:"leagues"`
-  RankingComparator     string       `koanf:"ranking_comparator"`
+	RankingComparator     string       `koanf:"ranking_comparator"`
 }
 
 type pvpLeagues struct {

--- a/decoder/main.go
+++ b/decoder/main.go
@@ -2,7 +2,7 @@ package decoder
 
 import (
 	"context"
-	"github.com/Pupitar/ohbemgo"
+	"github.com/UnownHash/gohbem"
 	"github.com/jellydator/ttlcache/v3"
 	stripedmutex "github.com/nmvalera/striped-mutex"
 	log "github.com/sirupsen/logrus"
@@ -61,7 +61,7 @@ var s2cellStripedMutex = stripedmutex.New(1024)
 
 var s2CellLookup = sync.Map{}
 
-var ohbem *ohbemgo.Ohbem
+var ohbem *gohbem.Ohbem
 
 func init() {
 	initDataCache()
@@ -134,16 +134,16 @@ func InitialiseOhbem() {
 			log.Errorf("PVP level caps not configured")
 			return
 		}
-		leagues := make(map[string]ohbemgo.League)
+		leagues := make(map[string]gohbem.League)
 
 		for _, league := range config.Config.Pvp.Leagues {
-			leagues[league.Name] = ohbemgo.League{
+			leagues[league.Name] = gohbem.League{
 				Cap:            league.Cap,
 				LittleCupRules: league.LittleCupRules,
 			}
 		}
 
-		o := &ohbemgo.Ohbem{Leagues: leagues, LevelCaps: config.Config.Pvp.LevelCaps,
+		o := &gohbem.Ohbem{Leagues: leagues, LevelCaps: config.Config.Pvp.LevelCaps,
 			IncludeHundosUnderCap: config.Config.Pvp.IncludeHundosUnderCap}
 
 		if err := o.FetchPokemonData(); err != nil {

--- a/decoder/main.go
+++ b/decoder/main.go
@@ -145,6 +145,14 @@ func InitialiseOhbem() {
 
 		o := &gohbem.Ohbem{Leagues: leagues, LevelCaps: config.Config.Pvp.LevelCaps,
 			IncludeHundosUnderCap: config.Config.Pvp.IncludeHundosUnderCap}
+		switch config.Config.Pvp.RankingComparator {
+		case "prefer_higher_cp":
+			o.RankingComparator = gohbem.RankingComparatorPreferHigherCp
+		case "prefer_lower_cp":
+			o.RankingComparator = gohbem.RankingComparatorPreferLowerCp
+		default:
+			o.RankingComparator = gohbem.RankingComparatorDefault
+		}
 
 		if err := o.FetchPokemonData(); err != nil {
 			log.Errorf("ohbem.FetchPokemonData: %s", err)

--- a/decoder/pokemon.go
+++ b/decoder/pokemon.go
@@ -484,7 +484,7 @@ func (pokemon *Pokemon) updateFromWild(ctx context.Context, db db.DbDetails, wil
 		pokemon.SeenType = null.StringFrom(SeenType_Wild)
 		updateStats(ctx, db, encounterId, stats_seenWild)
 	}
-	if pokemon.setPokemonDisplay(int16(wildPokemon.Pokemon.PokemonId), wildPokemon.Pokemon.PokemonDisplay) {
+	if pokemon.setPokemonDisplay(ctx, db, int16(wildPokemon.Pokemon.PokemonId), wildPokemon.Pokemon.PokemonDisplay) {
 		updateStats(ctx, db, pokemon.Id, stats_statsReset)
 	}
 	pokemon.addWildPokemon(ctx, db, wildPokemon, timestampMs)
@@ -519,7 +519,7 @@ func (pokemon *Pokemon) updateFromMap(ctx context.Context, db db.DbDetails, mapP
 	pokemon.SeenType = null.StringFrom(SeenType_LureWild) // TODO may have been encounter... this needs fixing
 
 	if mapPokemon.PokemonDisplay != nil {
-		if pokemon.setPokemonDisplay(pokemon.PokemonId, mapPokemon.PokemonDisplay) {
+		if pokemon.setPokemonDisplay(ctx, db, pokemon.PokemonId, mapPokemon.PokemonDisplay) {
 			updateStats(ctx, db, pokemon.Id, stats_statsReset)
 		}
 		// The mapPokemon and nearbyPokemon GMOs don't contain actual shininess.
@@ -553,7 +553,7 @@ func (pokemon *Pokemon) updateFromNearby(ctx context.Context, db db.DbDetails, n
 	encounterId := strconv.FormatUint(nearbyPokemon.EncounterId, 10)
 	pokestopId := nearbyPokemon.FortId
 	pokemonId := int16(nearbyPokemon.PokedexNumber)
-	if pokemon.setPokemonDisplay(pokemonId, nearbyPokemon.PokemonDisplay) {
+	if pokemon.setPokemonDisplay(ctx, db, pokemonId, nearbyPokemon.PokemonDisplay) {
 		updateStats(ctx, db, pokemon.Id, stats_statsReset)
 	}
 	pokemon.Username = null.StringFrom(username)
@@ -670,7 +670,7 @@ func (pokemon *Pokemon) addEncounterPokemon(ctx context.Context, db db.DbDetails
 	pokemon.Height = null.FloatFrom(float64(proto.HeightM))
 	pokemon.Size = null.IntFrom(int64(proto.Size))
 	pokemon.Weight = null.FloatFrom(float64(proto.WeightKg))
-	pokemon.setPokemonDisplay(int16(proto.PokemonId), proto.PokemonDisplay)
+	pokemon.setPokemonDisplay(ctx, db, int16(proto.PokemonId), proto.PokemonDisplay)
 	oldWeather := pokemon.EncounterWeather
 	pokemon.EncounterWeather = uint8(proto.PokemonDisplay.WeatherBoostedCondition)
 	isUnboostedPartlyCloudy := false
@@ -938,7 +938,7 @@ func (pokemon *Pokemon) updatePokemonFromDiskEncounterProto(ctx context.Context,
 	updateStats(ctx, db, pokemon.Id, stats_lureEncounter)
 }
 
-func (pokemon *Pokemon) setPokemonDisplay(pokemonId int16, display *pogo.PokemonDisplayProto) bool {
+func (pokemon *Pokemon) setPokemonDisplay(ctx context.Context, db db.DbDetails, pokemonId int16, display *pogo.PokemonDisplayProto) bool {
 	if !pokemon.isNewRecord() {
 		// If we would like to support detect A/B spawn in the future, fill in more code here from Chuck
 		var oldId int16
@@ -980,7 +980,7 @@ func (pokemon *Pokemon) setPokemonDisplay(pokemonId int16, display *pogo.Pokemon
 	pokemon.Gender = null.IntFrom(int64(display.Gender))
 	pokemon.Form = null.IntFrom(int64(display.Form))
 	pokemon.Costume = null.IntFrom(int64(display.Costume))
-	return pokemon.setWeather(int64(display.WeatherBoostedCondition))
+	return pokemon.setWeather(ctx, db, int64(display.WeatherBoostedCondition))
 }
 
 func (pokemon *Pokemon) compressIv() null.Int {
@@ -994,7 +994,7 @@ func (pokemon *Pokemon) compressIv() null.Int {
 	}
 }
 
-func (pokemon *Pokemon) setWeather(weather int64) bool {
+func (pokemon *Pokemon) setWeather(ctx context.Context, db db.DbDetails, weather int64) bool {
 	shouldReencounter := false // whether reencountering might give more information. Returns false for new record
 	if !pokemon.isNewRecord() && pokemon.Weather.ValueOrZero() != weather {
 		var reset, isBoosted bool
@@ -1044,19 +1044,36 @@ func (pokemon *Pokemon) setWeather(weather int64) bool {
 			pokemon.Pvp = null.NewString("", false)
 		}
 	}
-	if !pokemon.Cp.Valid && pokemon.AtkIv.Valid && ohbem != nil {
+	if !pokemon.Cp.Valid && ohbem != nil {
 		var displayPokemon int64
+		useInactive := false
 		if pokemon.IsDitto {
 			displayPokemon = pokemon.DisplayPokemonId.Int64
+			if weather == int64(pogo.GameplayWeatherProto_NONE) {
+				weather, err := findWeatherRecordByLatLon(ctx, db, pokemon.Lat, pokemon.Lon)
+				if err != nil || weather == nil || !weather.GameplayCondition.Valid {
+					log.Warnf("Failed to obtain weather for Pokemon %s: %s", pokemon.Id, err)
+				} else if weather.GameplayCondition.Int64 == int64(pogo.GameplayWeatherProto_PARTLY_CLOUDY) {
+					useInactive = true
+				}
+			}
 		} else {
 			displayPokemon = int64(pokemon.PokemonId)
 		}
-		if cp, err := ohbem.CalculateCp(int(displayPokemon), int(pokemon.Form.ValueOrZero()), 0,
-			int(pokemon.AtkIv.Int64), int(pokemon.DefIv.Int64), int(pokemon.StaIv.Int64),
-			float64(pokemon.Level.Int64)); err == nil {
-			pokemon.Cp = null.IntFrom(int64(cp))
+		var ivAvailable bool
+		if useInactive {
+			ivAvailable = pokemon.IvInactive.Valid
 		} else {
-			log.Warnf("Pokemon %s %d CP unset due to error %s", pokemon.Id, displayPokemon, err)
+			ivAvailable = pokemon.AtkIv.Valid
+		}
+		if ivAvailable {
+			if cp, err := ohbem.CalculateCp(int(displayPokemon), int(pokemon.Form.ValueOrZero()), 0,
+				int(pokemon.AtkIv.Int64), int(pokemon.DefIv.Int64), int(pokemon.StaIv.Int64),
+				float64(pokemon.Level.Int64)); err == nil {
+				pokemon.Cp = null.IntFrom(int64(cp))
+			} else {
+				log.Warnf("Pokemon %s %d CP unset due to error %s", pokemon.Id, displayPokemon, err)
+			}
 		}
 	}
 	pokemon.Weather = null.IntFrom(weather)

--- a/decoder/pokemon.go
+++ b/decoder/pokemon.go
@@ -244,6 +244,11 @@ func savePokemonRecordAsAtTime(ctx context.Context, db db.DbDetails, pokemon *Po
 		pokemon.FirstSeenTimestamp = now
 	}
 
+	pokemon.Updated = null.IntFrom(now)
+	if oldPokemon == nil || oldPokemon.PokemonId != pokemon.PokemonId || oldPokemon.Cp != pokemon.Cp {
+		pokemon.Changed = now
+	}
+
 	changePvpField := false
 	if ohbem != nil {
 		// Calculating PVP data
@@ -267,11 +272,6 @@ func savePokemonRecordAsAtTime(ctx context.Context, db db.DbDetails, pokemon *Po
 			pokemon.Pvp = null.NewString("", false)
 			changePvpField = true
 		}
-	}
-
-	pokemon.Updated = null.IntFrom(now)
-	if oldPokemon == nil || oldPokemon.PokemonId != pokemon.PokemonId || oldPokemon.Cp != pokemon.Cp {
-		pokemon.Changed = now
 	}
 
 	var oldSeenType string

--- a/decoder/pokemon.go
+++ b/decoder/pokemon.go
@@ -262,22 +262,6 @@ func savePokemonRecordAsAtTime(ctx context.Context, db db.DbDetails, pokemon *Po
 				pokemon.Pvp = null.StringFrom(string(pvpBytes))
 				changePvpField = true
 			}
-			var displayPokemon int64
-			if pokemon.IsDitto {
-				displayPokemon = pokemon.DisplayPokemonId.Int64
-			} else {
-				displayPokemon = int64(pokemon.PokemonId)
-			}
-			if cp, err := ohbem.CalculateCp(int(displayPokemon), int(pokemon.Form.Int64), 0, int(pokemon.AtkIv.Int64),
-				int(pokemon.DefIv.Int64), int(pokemon.StaIv.Int64), float64(pokemon.Level.Int64)); err == nil {
-				if !pokemon.Cp.Valid {
-					pokemon.Cp = null.IntFrom(int64(cp))
-				} else if pokemon.Cp.Int64 != int64(cp) {
-					log.Warnf("Unexpected CP seen: %d != %d for (%d,%d,%d,%d,%d,%d,%d)", cp, pokemon.Cp.Int64,
-						pokemon.PokemonId, pokemon.DisplayPokemonId.ValueOrZero(), pokemon.Form.Int64,
-						pokemon.AtkIv.Int64, pokemon.DefIv.Int64, pokemon.StaIv.Int64, pokemon.Level.Int64)
-				}
-			}
 		}
 		if !pokemon.AtkIv.Valid && (oldPokemon == nil || oldPokemon.AtkIv.Valid) {
 			pokemon.Pvp = null.NewString("", false)
@@ -1058,6 +1042,21 @@ func (pokemon *Pokemon) setWeather(weather int64) bool {
 				}
 			}
 			pokemon.Pvp = null.NewString("", false)
+		}
+	}
+	if !pokemon.Cp.Valid && pokemon.AtkIv.Valid && ohbem != nil {
+		var displayPokemon int64
+		if pokemon.IsDitto {
+			displayPokemon = pokemon.DisplayPokemonId.Int64
+		} else {
+			displayPokemon = int64(pokemon.PokemonId)
+		}
+		if cp, err := ohbem.CalculateCp(int(displayPokemon), int(pokemon.Form.ValueOrZero()), 0,
+			int(pokemon.AtkIv.Int64), int(pokemon.DefIv.Int64), int(pokemon.StaIv.Int64),
+			float64(pokemon.Level.Int64)); err == nil {
+			pokemon.Cp = null.IntFrom(int64(cp))
+		} else {
+			log.Warnf("Pokemon %s %d CP unset due to error %s", pokemon.Id, displayPokemon, err)
 		}
 	}
 	pokemon.Weather = null.IntFrom(weather)

--- a/decoder/pokemon.go
+++ b/decoder/pokemon.go
@@ -1067,9 +1067,10 @@ func (pokemon *Pokemon) setWeather(ctx context.Context, db db.DbDetails, weather
 				if !pokemon.IvInactive.Valid {
 					return
 				}
+				// You should see boosted IV for 0P Ditto
 				cp, err = ohbem.CalculateCp(int(displayPokemon), int(pokemon.Form.ValueOrZero()), 0,
 					int(pokemon.IvInactive.Int64&15), int(pokemon.IvInactive.Int64>>4&15),
-					int(pokemon.IvInactive.Int64>>8&15), float64(pokemon.Level.Int64))
+					int(pokemon.IvInactive.Int64>>8&15), float64(pokemon.Level.Int64+5))
 			} else {
 				if !pokemon.AtkIv.Valid {
 					return

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module golbat
 go 1.18
 
 require (
-	github.com/Pupitar/ohbemgo v0.8.0
+	github.com/UnownHash/gohbem v0.10.0
 	github.com/getsentry/sentry-go v0.19.0
 	github.com/gin-gonic/gin v1.9.0
 	github.com/go-sql-driver/mysql v1.7.0
@@ -19,6 +19,7 @@ require (
 	github.com/ringsaturn/tzf v0.13.0
 	github.com/ringsaturn/tzf-rel v0.0.2023-b
 	github.com/sirupsen/logrus v1.9.0
+	github.com/tidwall/rtree v1.10.0
 	github.com/toorop/gin-logrus v0.0.0-20210225092905-2c785434f26f
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	google.golang.org/protobuf v1.30.0
@@ -46,7 +47,6 @@ require (
 	github.com/pyroscope-io/godeltaprof v0.1.0 // indirect
 	github.com/tidwall/geoindex v1.7.0 // indirect
 	github.com/tidwall/geojson v1.4.3 // indirect
-	github.com/tidwall/rtree v1.10.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/twpayne/go-polyline v1.1.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/Pupitar/ohbemgo v0.8.0 h1:4GTlu/nxzYsY8207JiWYKrFyOJWajXi7auFVUVZqVKQ=
 github.com/Pupitar/ohbemgo v0.8.0/go.mod h1:ND5GlUBS+Gwr70KLQIvirT2UmUkyNPp+bYUy6s0pqKM=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
+github.com/UnownHash/gohbem v0.10.0 h1:sJpPCJY0sgMY1WR6QP8LGHSnWzozcucga2FPe8bEYTM=
+github.com/UnownHash/gohbem v0.10.0/go.mod h1:I7SrAlxOo56fGlUD7pLtitcGcmRd7rr9/HWpgmseqSc=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,6 @@ github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/Pupitar/ohbemgo v0.8.0 h1:4GTlu/nxzYsY8207JiWYKrFyOJWajXi7auFVUVZqVKQ=
-github.com/Pupitar/ohbemgo v0.8.0/go.mod h1:ND5GlUBS+Gwr70KLQIvirT2UmUkyNPp+bYUy6s0pqKM=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/UnownHash/gohbem v0.10.0 h1:sJpPCJY0sgMY1WR6QP8LGHSnWzozcucga2FPe8bEYTM=
 github.com/UnownHash/gohbem v0.10.0/go.mod h1:I7SrAlxOo56fGlUD7pLtitcGcmRd7rr9/HWpgmseqSc=


### PR DESCRIPTION
This PR will allow Golbat to add CP immediately upon seeing the spawn rerolls (if the previously scanned IVs are available). CP was reset in #65 but could not be recalculated due to not having gohbem support. Now this is possible with gohbem v0.10.0.

~~Untested but should be fine?~~ Tested and is fine.