### PR TITLE
Enable ar_quest scanning by default

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -4,6 +4,7 @@ api_secret = "golbat"   # Golbat secret required on api calls (blank for none)
 
 stats = false           # Enable creation of pokemon_timing and pokemon_history table (now recommended=false)
 in_memory = false       # Use in-memory storage for pokemon only
+ar_quests = true        # Enable ar_quests scanning by default. Disable to ignore them if your mitm is not sending haveAR flag
 
 [koji]
 url = "http://{koji_url}/api/v1/geofence/feature-collection/{golbat_project}"

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type configDefinition struct {
 	Koji      koji       `koanf:"koji"`
 	Tuning    tuning     `koanf:"tuning"`
 	ScanRules []scanRule `koanf:"scan_rules"`
+	Ar_Quests bool       `koanf:"ar_quests"`
 }
 
 type koji struct {

--- a/main.go
+++ b/main.go
@@ -216,6 +216,7 @@ func decode(ctx context.Context, method int, protoData *ProtoData) {
 	processed := false
 	start := time.Now()
 	result := ""
+        ar_quests := config.Config.Ar_Quests
 
 	switch pogo.Method(method) {
 	case pogo.Method_METHOD_START_INCIDENT:
@@ -243,7 +244,7 @@ func decode(ctx context.Context, method int, protoData *ProtoData) {
 		result = decodeDiskEncounter(ctx, protoData.Data)
 		processed = true
 	case pogo.Method_METHOD_FORT_SEARCH:
-		result = decodeQuest(ctx, protoData.Data, protoData.HaveAr)
+		result = decodeQuest(ctx, protoData.Data, &ar_quests)
 		processed = true
 	case pogo.Method_METHOD_GET_PLAYER:
 		break
@@ -277,7 +278,7 @@ func getScanParameters(protoData *ProtoData) decoder.ScanParameters {
 }
 
 func decodeQuest(ctx context.Context, sDec []byte, haveAr *bool) string {
-	if haveAr == nil {
+	if !*haveAr {
 		log.Infoln("Cannot determine AR quest - ignoring")
 		// We should either assume AR quest, or trace inventory like RDM probably
 		return "No AR quest info"


### PR DESCRIPTION
This is a workaround to get quests until your MITM send _have_ar_ flag. 