### PR TITLE
Build docker image for multiple platforms

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -30,6 +34,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Hello,

I added to the CI, the build of the arm64 image. GitHub container registry doesn't support pushing multiple manifest separately. So for now, all the images are built sequentially. The building of the arm64 image is six times slower since it uses an emulator to build it. 
Result: https://github.com/UnownHash/Golbat/pkgs/container/golbat/113343220?tag=ci-build-multiple-platforms
<img width="738" alt="image" src="https://github.com/UnownHash/Golbat/assets/757637/c1a19540-45ee-479f-b4ae-dae3244477fb">
