### PR TITLE
Fix start/end latlon

### DIFF
--- a/decoder/routes.go
+++ b/decoder/routes.go
@@ -161,20 +161,21 @@ func (route *Route) updateFromSharedRouteProto(sharedRouteProto *pogo.SharedRout
 	route.DurationSeconds = sharedRouteProto.GetRouteDurationSeconds()
 	route.EndFortId = sharedRouteProto.GetEndPoi().GetAnchor().GetFortId()
 	route.EndImage = sharedRouteProto.GetEndPoi().GetImageUrl()
-	route.EndLat = sharedRouteProto.GetEndPoi().GetAnchor().GetLatDegrees()
-	route.EndLon = sharedRouteProto.GetEndPoi().GetAnchor().GetLngDegrees()
+	waypoints := sharedRouteProto.GetWaypoints()
+	route.EndLat = waypoints[len(waypoints)-1].LatDegrees
+	route.EndLon = waypoints[len(waypoints)-1].LngDegrees
 	route.Image = sharedRouteProto.GetImage().GetImageUrl()
 	route.ImageBorderColor = sharedRouteProto.GetImage().GetBorderColorHex()
 	route.Reversible = sharedRouteProto.GetReversible()
 	route.StartFortId = sharedRouteProto.GetStartPoi().GetAnchor().GetFortId()
 	route.StartImage = sharedRouteProto.GetStartPoi().GetImageUrl()
-	route.StartLat = sharedRouteProto.GetStartPoi().GetAnchor().GetLatDegrees()
-	route.StartLon = sharedRouteProto.GetStartPoi().GetAnchor().GetLngDegrees()
+	route.StartLat = waypoints[0].LatDegrees
+	route.StartLon = waypoints[0].LngDegrees
 	route.Type = int8(sharedRouteProto.GetType())
 	route.Updated = time.Now().Unix()
 	route.Version = sharedRouteProto.GetVersion()
-	waypoints, _ := json.Marshal(sharedRouteProto.GetWaypoints())
-	route.Waypoints = string(waypoints)
+	waypointsJson, _ := json.Marshal(waypoints)
+	route.Waypoints = string(waypointsJson)
 
 	if len(sharedRouteProto.GetTags()) > 0 {
 		tags, _ := json.Marshal(sharedRouteProto.GetTags())


### PR DESCRIPTION
Currently in #133, `(Start|End)(Lat|Lon)` is set to the coordinates of the PoIs instead of the coordinates of the actual route. Since these four columns are used for indexing, the actual starting points and ending points should be used instead.

## What evidence do I have for justifying this change?

1. As can be seen in gameplay (for example [this one](https://www.youtube.com/watch?v=fv5CYL6hvb4&t=177s)), the starting point is only near the PoI instead of being exactly on it. <!--[Having this redundant information also confuses downstream implementations](https://github.com/WatWowMap/ReactMap/commit/e42ff33a845e7bd3ea94886b535bc1c7877b9edc).-->
2. In the proto, these information are under `start_poi` and `end_poi`, which means that they are information belonging to that poi. For example, there are three *separate* images for each of the route, the start poi, and the end poi.
3. Only lat lon is provided for the forts while elevation is also provided for the route coordinates, further indicating that the forts are not part of the route.
4. In [the dump](https://github.com/UnownHash/Golbat/issues/129#issuecomment-1651560267), poi lat lon has truncated precisions whereas waypoint lat lon has full accuracy. This indicates that they come from different data source.
5. I have personally looked at a route and confirmed that the lat lon reported there belong exclusively to the PoIs and not the route.