### PR TITLE
Showcase decode

### DIFF
--- a/decoder/pokestop.go
+++ b/decoder/pokestop.go
@@ -58,7 +58,10 @@ type Pokestop struct {
 	AlternativeQuestTitle      null.String `db:"alternative_quest_title" json:"alternative_quest_title"`
 	AlternativeQuestExpiry     null.Int    `db:"alternative_quest_expiry" json:"alternative_quest_expiry"`
 	Description                null.String `db:"description" json:"description"`
-
+	ShowcasePokemon            null.Int    `db:"showcase_pokemon_id" json:"showcase_pokemon_id"`
+	ShowcaseRankingStandard    null.Int    `db:"showcase_ranking_standard" json:"showcase_ranking_standard"`
+	ShowcaseExpiry             null.Int    `db:"showcase_expiry" json:"showcase_expiry"`
+	ShowcaseRankings           null.String `db:"showcase_rankings" json:"showcase_rankings"`
 	//`id` varchar(35) NOT NULL,
 	//`lat` double(18,14) NOT NULL,
 	//`lon` double(18,14) NOT NULL,
@@ -169,7 +172,11 @@ func hasChangesPokestop(old *Pokestop, new *Pokestop) bool {
 		old.AlternativeQuestExpiry != new.AlternativeQuestExpiry ||
 		old.Description != new.Description ||
 		!floatAlmostEqual(old.Lat, new.Lat, floatTolerance) ||
-		!floatAlmostEqual(old.Lon, new.Lon, floatTolerance)
+		!floatAlmostEqual(old.Lon, new.Lon, floatTolerance) ||
+		old.ShowcaseRankingStandard != new.ShowcaseRankingStandard ||
+		old.ShowcasePokemon != new.ShowcasePokemon ||
+		old.ShowcaseRankings != new.ShowcaseRankings ||
+		old.ShowcaseExpiry != new.ShowcaseExpiry
 }
 
 var LureTime int64 = 1800
@@ -532,6 +539,49 @@ func (stop *Pokestop) updatePokestopFromGetMapFortsOutProto(fortData *pogo.GetMa
 	return stop
 }
 
+func (stop *Pokestop) updatePokestopFromGetContestDataOutProto(contest *pogo.ContestProto) {
+	stop.ShowcaseRankingStandard = null.IntFrom(int64(contest.GetMetric().GetRankingStandard()))
+	stop.ShowcaseExpiry = null.IntFrom(contest.GetSchedule().GetContestCycle().GetEndTimeMs() / 1000)
+	stop.ShowcasePokemon = null.IntFrom(int64(contest.GetFocus().GetPokemon().GetPokedexId()))
+}
+
+func (stop *Pokestop) updatePokestopFromGetPokemonSizeContestEntryOutProto(contestData *pogo.GetPokemonSizeContestEntryOutProto) {
+	type contestEntry struct {
+		Rank      int     `json:"rank"`
+		Score     float64 `json:"score"`
+		PokemonId int     `json:"pokemon_id"`
+		Form      int     `json:"form"`
+		Costume   int     `json:"costume"`
+		Gender    int     `json:"gender"`
+	}
+	type contestJson struct {
+		TotalEntries   int            `json:"total_entries"`
+		LastUpdate     int64          `json:"last_update"`
+		ContestEntries []contestEntry `json:"contest_entries"`
+	}
+
+	j := contestJson{LastUpdate: time.Now().Unix()}
+	j.TotalEntries = int(contestData.TotalEntries)
+
+	for _, entry := range contestData.GetContestEntries() {
+		rank := entry.GetRank()
+		if rank > 3 {
+			break
+		}
+		j.ContestEntries = append(j.ContestEntries, contestEntry{
+			Rank:      int(rank),
+			Score:     entry.GetScore(),
+			PokemonId: int(entry.GetPokedexId()),
+			Form:      int(entry.GetPokemonDisplay().Form),
+			Costume:   int(entry.GetPokemonDisplay().Costume),
+			Gender:    int(entry.GetPokemonDisplay().Gender),
+		})
+
+	}
+	jsonString, _ := json.Marshal(j)
+	stop.ShowcaseRankings = null.StringFrom(string(jsonString))
+}
+
 func createPokestopFortWebhooks(oldStop *Pokestop, stop *Pokestop) {
 	fort := InitWebHookFortFromPokestop(stop)
 	oldFort := InitWebHookFortFromPokestop(oldStop)
@@ -609,16 +659,26 @@ func createPokestopWebhooks(oldStop *Pokestop, stop *Pokestop) {
 					return "Unknown"
 				}
 			}(),
-			"url":                    stop.Url.ValueOrZero(),
-			"lure_expiration":        stop.LureExpireTimestamp.ValueOrZero(),
-			"last_modified":          stop.LastModifiedTimestamp.ValueOrZero(),
-			"enabled":                stop.Enabled.ValueOrZero(),
-			"lure_id":                stop.LureId,
-			"ar_scan_eligible":       stop.ArScanEligible.ValueOrZero(),
-			"power_up_level":         stop.PowerUpLevel.ValueOrZero(),
-			"power_up_points":        stop.PowerUpPoints.ValueOrZero(),
-			"power_up_end_timestamp": stop.PowerUpPoints.ValueOrZero(),
-			"updated":                stop.Updated,
+			"url":                       stop.Url.ValueOrZero(),
+			"lure_expiration":           stop.LureExpireTimestamp.ValueOrZero(),
+			"last_modified":             stop.LastModifiedTimestamp.ValueOrZero(),
+			"enabled":                   stop.Enabled.ValueOrZero(),
+			"lure_id":                   stop.LureId,
+			"ar_scan_eligible":          stop.ArScanEligible.ValueOrZero(),
+			"power_up_level":            stop.PowerUpLevel.ValueOrZero(),
+			"power_up_points":           stop.PowerUpPoints.ValueOrZero(),
+			"power_up_end_timestamp":    stop.PowerUpPoints.ValueOrZero(),
+			"updated":                   stop.Updated,
+			"showcase_pokemon_id":       stop.ShowcasePokemon,
+			"showcase_ranking_standard": stop.ShowcaseRankingStandard,
+			"showcase_expiry":           stop.ShowcaseExpiry,
+			"showcase_rankings": func() interface{} {
+				if !stop.ShowcaseRankings.Valid {
+					return nil
+				} else {
+					return json.RawMessage(stop.ShowcaseRankings.ValueOrZero())
+				}
+			}(),
 		}
 
 		webhooks.AddMessage(webhooks.Pokestop, pokestopHook, areas)
@@ -647,7 +707,9 @@ func savePokestopRecord(ctx context.Context, db db.DbDetails, pokestop *Pokestop
 				"alternative_quest_conditions, alternative_quest_rewards, alternative_quest_template,"+
 				"alternative_quest_title, cell_id, lure_id, sponsor_id, partner_id, ar_scan_eligible,"+
 				"power_up_points, power_up_level, power_up_end_timestamp, updated, first_seen_timestamp,"+
-				"quest_expiry, alternative_quest_expiry, description)"+
+				"quest_expiry, alternative_quest_expiry, description,"+
+				"showcase_pokemon_id, showcase_ranking_standard, showcase_expiry, showcase_rankings"+
+				")"+
 				"VALUES ("+
 				":id, :lat, :lon, :name, :url, :enabled, :lure_expire_timestamp, :last_modified_timestamp, :quest_type,"+
 				":quest_timestamp, :quest_target, :quest_conditions, :quest_rewards, :quest_template, :quest_title,"+
@@ -656,7 +718,8 @@ func savePokestopRecord(ctx context.Context, db db.DbDetails, pokestop *Pokestop
 				":alternative_quest_title, :cell_id, :lure_id, :sponsor_id, :partner_id, :ar_scan_eligible,"+
 				":power_up_points, :power_up_level, :power_up_end_timestamp,"+
 				"UNIX_TIMESTAMP(), UNIX_TIMESTAMP(),"+
-				":quest_expiry, :alternative_quest_expiry, :description )",
+				":quest_expiry, :alternative_quest_expiry, :description,"+
+				":showcase_pokemon_id, :showcase_ranking_standard, :showcase_expiry, :showcase_rankings)",
 			pokestop)
 
 		if err != nil {
@@ -700,7 +763,11 @@ func savePokestopRecord(ctx context.Context, db db.DbDetails, pokestop *Pokestop
 				"power_up_end_timestamp = :power_up_end_timestamp,"+
 				"quest_expiry = :quest_expiry,"+
 				"alternative_quest_expiry = :alternative_quest_expiry,"+
-				"description = :description"+
+				"description = :description,"+
+				"showcase_pokemon_id = :showcase_pokemon_id,"+
+				"showcase_ranking_standard = :showcase_ranking_standard,"+
+				"showcase_expiry = :showcase_expiry,"+
+				"showcase_rankings = :showcase_rankings"+
 				" WHERE id = :id",
 			pokestop,
 		)
@@ -813,4 +880,76 @@ func UpdatePokestopRecordWithGetMapFortsOutProto(ctx context.Context, db db.DbDe
 
 func GetPokestopPositions(details db.DbDetails, geofence geo.Geofence) ([]db.QuestLocation, error) {
 	return db.GetPokestopPositions(details, geofence)
+}
+
+func UpdatePokestopWithContestData(ctx context.Context, db db.DbDetails, request *pogo.GetContestDataProto, contestData *pogo.GetContestDataOutProto) string {
+	if contestData.ContestIncident == nil || len(contestData.ContestIncident.Contests) == 0 {
+		return "No contests found"
+	}
+
+	var fortId string
+	if request != nil {
+		fortId = request.FortId
+	} else {
+		fortId = getFortIdFromContest(contestData.ContestIncident.Contests[0].ContestId)
+	}
+
+	if fortId == "" {
+		return "No fortId found"
+	}
+
+	if len(contestData.ContestIncident.Contests) > 1 {
+		log.Errorf("More than one contest found")
+		return fmt.Sprintf("More than one contest found in %s", fortId)
+	}
+
+	contest := contestData.ContestIncident.Contests[0]
+
+	pokestopMutex, _ := pokestopStripedMutex.GetLock(fortId)
+	pokestopMutex.Lock()
+	defer pokestopMutex.Unlock()
+
+	pokestop, err := GetPokestopRecord(ctx, db, fortId)
+	if err != nil {
+		log.Printf("Get pokestop %s", err)
+		return "Error getting pokestop"
+	}
+
+	if pokestop == nil {
+		log.Infof("Contest data for pokestop %s not found", fortId)
+		return fmt.Sprintf("Contest data for pokestop %s not found", fortId)
+	}
+
+	pokestop.updatePokestopFromGetContestDataOutProto(contest)
+	savePokestopRecord(ctx, db, pokestop)
+
+	return fmt.Sprintf("Contest %s", fortId)
+}
+
+func getFortIdFromContest(id string) string {
+	return strings.Split(id, "-")[0]
+}
+
+func UpdatePokestopWithPokemonSizeContestEntry(ctx context.Context, db db.DbDetails, request *pogo.GetPokemonSizeContestEntryProto, contestData *pogo.GetPokemonSizeContestEntryOutProto) string {
+	fortId := getFortIdFromContest(request.GetContestId())
+
+	pokestopMutex, _ := pokestopStripedMutex.GetLock(fortId)
+	pokestopMutex.Lock()
+	defer pokestopMutex.Unlock()
+
+	pokestop, err := GetPokestopRecord(ctx, db, fortId)
+	if err != nil {
+		log.Printf("Get pokestop %s", err)
+		return "Error getting pokestop"
+	}
+
+	if pokestop == nil {
+		log.Infof("Contest data for pokestop %s not found", fortId)
+		return fmt.Sprintf("Contest data for pokestop %s not found", fortId)
+	}
+
+	pokestop.updatePokestopFromGetPokemonSizeContestEntryOutProto(contestData)
+	savePokestopRecord(ctx, db, pokestop)
+
+	return fmt.Sprintf("Contest Detail %s", fortId)
 }

--- a/main.go
+++ b/main.go
@@ -240,6 +240,7 @@ func decode(ctx context.Context, method int, protoData *ProtoData) {
 	}
 
 	processed := false
+	ignore := false
 	start := time.Now()
 	result := ""
 
@@ -274,11 +275,13 @@ func decode(ctx context.Context, method int, protoData *ProtoData) {
 		result = decodeQuest(ctx, protoData.Data, protoData.HaveAr)
 		processed = true
 	case pogo.Method_METHOD_GET_PLAYER:
+		ignore = true
 		break
 	case pogo.Method_METHOD_GET_HOLOHOLO_INVENTORY:
+		ignore = true
 		break
 	case pogo.Method_METHOD_CREATE_COMBAT_CHALLENGE:
-		// ignore
+		ignore = true
 		break
 	case pogo.Method(pogo.ClientAction_CLIENT_ACTION_PROXY_SOCIAL_ACTION):
 		if protoData.Request != nil {
@@ -307,11 +310,13 @@ func decode(ctx context.Context, method int, protoData *ProtoData) {
 	default:
 		log.Debugf("Did not know hook type %s", pogo.Method(method))
 	}
-	elapsed := time.Since(start)
-	if processed == true {
-		log.Debugf("%s/%s %s - %s - %s", protoData.Uuid, protoData.Account, pogo.Method(method), elapsed, result)
-	} else {
-		log.Debugf("%s/%s %s - %s - %s", protoData.Uuid, protoData.Account, pogo.Method(method), elapsed, "**Did not process**")
+	if !ignore {
+		elapsed := time.Since(start)
+		if processed == true {
+			log.Debugf("%s/%s %s - %s - %s", protoData.Uuid, protoData.Account, pogo.Method(method), elapsed, result)
+		} else {
+			log.Debugf("%s/%s %s - %s - %s", protoData.Uuid, protoData.Account, pogo.Method(method), elapsed, "**Did not process**")
+		}
 	}
 }
 

--- a/protos.md
+++ b/protos.md
@@ -47,6 +47,15 @@ requires the proto request to be present in the raw.
 
 - Decode routes
 
+`Method_METHOD_GET_CONTEST_DATA`
+
+- Decode contest high level data: pokemon, ranking method, end time
+
+`METHOD_GET_POKEMON_SIZE_CONTEST_ENTRY`
+
+- Decode top 3 player scores for a contest. This requires the proto request
+to be present in the raw.
+
 # Social actions
 
 - The master `ClientAction_CLIENT_ACTION_PROXY_SOCIAL_ACTION` proto will be

--- a/sql/20_showcase.up.sql
+++ b/sql/20_showcase.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `pokestop`
+    ADD COLUMN `showcase_pokemon_id` smallint unsigned DEFAULT NULL,
+    ADD COLUMN `showcase_ranking_standard` tinyint(1) DEFAULT NULL,
+    ADD COLUMN `showcase_expiry` int unsigned DEFAULT NULL,
+    ADD COLUMN `showcase_rankings` text DEFAULT NULL;


### PR DESCRIPTION
** NOTE: ATLAS DOES NOT CURRENTLY SUPPORT THIS PROTO **

This PR captures my work around decoding the showcase detail protocols.  My intention is to provide a minimum viable decode, rather than a future proof one.  I will work with map makers, etc to get the right level of information and no more.  This is because there is still a lot we haven

Some observations:
* Max number of entries is not in the proto
* Size is the only contest type
* incident id is not in any of the contest protocols, meaning any attempt to store this data on the incident row would require searching for it which may be fragile (or incident may not be present yet)
* Some showcases have >100 entries, and storing these seems to be of low value
* The request is needed for `GetPokemonSizeContestEntry` since the only way to get the 'fortId' is from the contest id in the request
* All the information about the contest can be obtained from GetPokemonSizeContestEntry aside from the end time and schedule information (which are only in `GetContestData`)

Implementation:
* Decode GetPokemonData to store the pokemon id, metric, and end time. This can be done just with the response 
* From GetPokemonSizeContestEntry (requires request)
  * Decode top 3 ranking pokemon and store these including form, costume etc (for fancy display) in a json field.

This would creates just four extra fields on pokestop:

```golang
ShowcasePokemon            null.Int    `db:"showcase_pokemon_id" json:"showcase_pokemon_id"`
ShowcaseRankingStandard    null.Int    `db:"showcase_ranking_standard" json:"showcase_ranking_standard"`
ShowcaseExpiry             null.Int    `db:"showcase_expiry" json:"showcase_expiry"`
ShowcaseRankings           null.String `db:"showcase_rankings" json:"showcase_rankings"`
```

