### PR TITLE
Do not copy logs and cache into docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,6 @@
 .idea
 Dockerfile
 config.toml
+cache/
+logs/
+golbat

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,14 @@ COPY . .
 
 RUN go mod download
 RUN CGO_ENABLED=0 go build -tags go_json -o /go/bin/golbat
+RUN mkdir /empty-dir
 
 # Now copy it into our base image.
 FROM gcr.io/distroless/static-debian11 as runner
 COPY --from=build /go/bin/golbat /golbat/
+COPY --from=build /empty-dir /golbat/cache
+COPY --from=build /empty-dir /golbat/logs
 COPY /sql /golbat/sql
-COPY /cache /golbat/cache
-COPY /logs /golbat/logs
 
 WORKDIR /golbat
 CMD ["./golbat"]


### PR DESCRIPTION
The cache/logs shouldn't be copied back into new docker image builds, which is what happens when you attach these as volumes, run Golbat for a while, and then re-build the image. This was shoving ~175M of my logs to the docker daemon during build and copying into the image!

I think it only makes sense for people to attach these as volumes at runtime, and doing anything with them at image build time could just end up being an expensive build time no-op.

But even if not, if people do not attach these as volumes, they are always going to be empty on the host side such that there's nothing to copy into the image. But we still need to create the directories.

If you've compiled outside of docker, this also stops the sending of the 130M golbat binary through to the docker daemon when you next build, also.
