### PR TITLE
Allow docker build to make use of vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,7 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+/vendor/
 config.json
 config.toml
 docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.21-alpine as build
 WORKDIR /go/src/app
 COPY . .
 
-RUN go mod download
+RUN if [ ! -f vendor/modules.txt ]; then go mod download; fi
 RUN CGO_ENABLED=0 go build -tags go_json -o /go/bin/golbat
 RUN mkdir /empty-dir
 


### PR DESCRIPTION
Having to download dependencies every time during a docker build after a code change makes the build take longer than if dependencies were simply vendored.

This just adds a check to the Dockerfile to see if vendor/ is being used, and if so, skips downloading.

After this lands, one can manage keeping vendor/ up to date in their workspace via 'go mod vendor' and a docker build will not need to download anything. This reduces the docker build time by ~25% for me, but YMMV.