### PR TITLE
Raise max pokemon id

### DIFF
--- a/decoder/stats.go
+++ b/decoder/stats.go
@@ -33,14 +33,15 @@ type pokemonTimings struct {
 
 var pokemonCount = make(map[geo.AreaName]*areaPokemonCountDetail)
 
-const maxPokemonNo = 1000
+// max dex id
+const maxPokemonNo = 1050
 
 type areaPokemonCountDetail struct {
-	hundos  [maxPokemonNo]int
-	nundos  [maxPokemonNo]int
-	shiny   [maxPokemonNo]int
-	count   [maxPokemonNo]int
-	ivCount [maxPokemonNo]int
+	hundos  [maxPokemonNo + 1]int
+	nundos  [maxPokemonNo + 1]int
+	shiny   [maxPokemonNo + 1]int
+	count   [maxPokemonNo + 1]int
+	ivCount [maxPokemonNo + 1]int
 }
 
 var pokemonTimingCache *ttlcache.Cache[string, pokemonTimings]


### PR DESCRIPTION
As it is, it looks like we would crash if we tried to count stats for Goldhengo (dex #1000) or anything later. Paldea currently takes us up to 1017, but there are at least 4 more that will be in the 2nd part of the Scarlet/Violet DLC.

So, this PR raises the max pokedex number to 1050 to be safe.