### PR TITLE
Accurate shiny stats tracking

### DIFF
--- a/decoder/main.go
+++ b/decoder/main.go
@@ -368,12 +368,11 @@ func UpdatePokemonBatch(ctx context.Context, db db.DbDetails, scanParameters Sca
 			log.Printf("getOrCreatePokemonRecord: %s", err)
 		} else {
 			pokemon.updateFromMap(ctx, db, mapPokemon.Data, int64(mapPokemon.Cell), username)
-
 			storedDiskEncounter := diskEncounterCache.Get(encounterId)
 			if storedDiskEncounter != nil {
 				diskEncounter := storedDiskEncounter.Value()
 				diskEncounterCache.Delete(encounterId)
-				pokemon.updatePokemonFromDiskEncounterProto(ctx, db, diskEncounter)
+				pokemon.updatePokemonFromDiskEncounterProto(ctx, db, diskEncounter, username)
 				log.Infof("Processed stored disk encounter")
 			}
 			savePokemonRecord(ctx, db, pokemon)

--- a/decoder/pokemon.go
+++ b/decoder/pokemon.go
@@ -5,19 +5,21 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"math"
+	"strconv"
+	"time"
+
 	"github.com/UnownHash/gohbem"
 	"github.com/golang/geo/s2"
 	"github.com/jellydator/ttlcache/v3"
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/guregu/null.v4"
+
 	"golbat/config"
 	"golbat/db"
 	"golbat/geo"
 	"golbat/pogo"
 	"golbat/webhooks"
-	"gopkg.in/guregu/null.v4"
-	"math"
-	"strconv"
-	"time"
 )
 
 // Pokemon struct.
@@ -558,9 +560,11 @@ func (pokemon *Pokemon) updateFromMap(ctx context.Context, db db.DbDetails, mapP
 		pokemon.Username = null.StringFrom(username)
 	}
 
-	if mapPokemon.ExpirationTimeMs > 0 {
+	if mapPokemon.ExpirationTimeMs > 0 && !pokemon.ExpireTimestampVerified {
 		pokemon.ExpireTimestamp = null.IntFrom(mapPokemon.ExpirationTimeMs / 1000)
 		pokemon.ExpireTimestampVerified = true
+		// if we have cached an encounter for this pokemon, update the TTL.
+		encounterCache.UpdateTTL(pokemon.Id, pokemon.remainingDuration())
 	} else {
 		pokemon.ExpireTimestampVerified = false
 	}
@@ -680,7 +684,9 @@ func (pokemon *Pokemon) setUnknownTimestamp() {
 	}
 }
 
-func (pokemon *Pokemon) addEncounterPokemon(ctx context.Context, db db.DbDetails, proto *pogo.PokemonProto) {
+func (pokemon *Pokemon) addEncounterPokemon(ctx context.Context, db db.DbDetails, proto *pogo.PokemonProto, username string) {
+	pokemon.Username = null.StringFrom(username)
+	pokemon.Shiny = null.BoolFrom(proto.PokemonDisplay.Shiny)
 	pokemon.Cp = null.IntFrom(int64(proto.Cp))
 	pokemon.Move1 = null.IntFrom(int64(proto.Move1))
 	pokemon.Move2 = null.IntFrom(int64(proto.Move2))
@@ -919,7 +925,7 @@ func (pokemon *Pokemon) updatePokemonFromEncounterProto(ctx context.Context, db 
 	pokemon.IsEvent = 0
 	// TODO is there a better way to get this from the proto? This is how RDM does it
 	pokemon.addWildPokemon(ctx, db, encounterData.Pokemon, time.Now().Unix()*1000)
-	pokemon.addEncounterPokemon(ctx, db, encounterData.Pokemon.Pokemon)
+	pokemon.addEncounterPokemon(ctx, db, encounterData.Pokemon.Pokemon, username)
 
 	if pokemon.CellId.Valid == false {
 		centerCoord := s2.LatLngFromDegrees(pokemon.Lat, pokemon.Lon)
@@ -927,27 +933,12 @@ func (pokemon *Pokemon) updatePokemonFromEncounterProto(ctx context.Context, db 
 		pokemon.CellId = null.IntFrom(int64(cellID))
 	}
 
-	pokemon.Shiny = null.BoolFrom(encounterData.Pokemon.Pokemon.PokemonDisplay.Shiny)
-	pokemon.Username = null.StringFrom(username)
-
 	pokemon.SeenType = null.StringFrom(SeenType_Encounter)
 }
 
-func (pokemon *Pokemon) updatePokemonFromDiskEncounterProto(ctx context.Context, db db.DbDetails, encounterData *pogo.DiskEncounterOutProto) {
+func (pokemon *Pokemon) updatePokemonFromDiskEncounterProto(ctx context.Context, db db.DbDetails, encounterData *pogo.DiskEncounterOutProto, username string) {
 	pokemon.IsEvent = 0
-	pokemon.addEncounterPokemon(ctx, db, encounterData.Pokemon)
-
-	if encounterData.Pokemon.PokemonDisplay.Shiny {
-		pokemon.Shiny = null.BoolFrom(true)
-		pokemon.Username = null.StringFrom("AccountShiny")
-	} else {
-		if !pokemon.Shiny.Valid {
-			pokemon.Shiny = null.BoolFrom(false)
-		}
-		if !pokemon.Username.Valid {
-			pokemon.Username = null.StringFrom("Account")
-		}
-	}
+	pokemon.addEncounterPokemon(ctx, db, encounterData.Pokemon, username)
 
 	pokemon.SeenType = null.StringFrom(SeenType_LureEncounter)
 }
@@ -1125,11 +1116,14 @@ func UpdatePokemonRecordWithEncounterProto(ctx context.Context, db db.DbDetails,
 
 	pokemon.updatePokemonFromEncounterProto(ctx, db, encounter, username)
 	savePokemonRecord(ctx, db, pokemon)
+	// updateEncounterStats() should only be called for encounters, and called
+	// even if we have the pokemon record already.
+	updateEncounterStats(pokemon)
 
 	return fmt.Sprintf("%d %s Pokemon %d CP%d", encounter.Pokemon.EncounterId, encounterId, pokemon.PokemonId, encounter.Pokemon.Pokemon.Cp)
 }
 
-func UpdatePokemonRecordWithDiskEncounterProto(ctx context.Context, db db.DbDetails, encounter *pogo.DiskEncounterOutProto) string {
+func UpdatePokemonRecordWithDiskEncounterProto(ctx context.Context, db db.DbDetails, encounter *pogo.DiskEncounterOutProto, username string) string {
 	if encounter.Pokemon == nil {
 		return "No encounter"
 	}
@@ -1151,8 +1145,11 @@ func UpdatePokemonRecordWithDiskEncounterProto(ctx context.Context, db db.DbDeta
 		diskEncounterCache.Set(encounterId, encounter, ttlcache.DefaultTTL)
 		return fmt.Sprintf("%s Disk encounter without previous GMO - Pokemon stored for later", encounterId)
 	}
-	pokemon.updatePokemonFromDiskEncounterProto(ctx, db, encounter)
+	pokemon.updatePokemonFromDiskEncounterProto(ctx, db, encounter, username)
 	savePokemonRecord(ctx, db, pokemon)
+	// updateEncounterStats() should only be called for encounters, and called
+	// even if we have the pokemon record already.
+	updateEncounterStats(pokemon)
 
 	return fmt.Sprintf("%s Disk Pokemon %d CP%d", encounterId, pokemon.PokemonId, encounter.Pokemon.Cp)
 }

--- a/encounter_cache/encounter_cache.go
+++ b/encounter_cache/encounter_cache.go
@@ -1,0 +1,116 @@
+// package encounter_cache provides an auto-expiring
+// cache of stats by encounterId.
+package encounter_cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+)
+
+// Value is the object that is inserted into the cache.
+type Value struct {
+	FirstWild      int64
+	FirstEncounter int64
+
+	accountsSeen map[string]bool
+}
+
+// SetAccountSeen() marks an account having seen the
+// encounterId for this cache value. Returns whether
+// the account had already seen it.
+func (v *Value) SetAccountSeen(username string) bool {
+	if v.accountsSeen[username] {
+		return true
+	}
+	v.accountsSeen[username] = true
+	return false
+}
+
+// NumAccountsSeen() returns the number of accounts
+// that have encountered the encounterId for this
+// cache value.
+func (v *Value) NumAccountsSeen() int {
+	return len(v.accountsSeen)
+}
+
+// EncounterCache is an object that represents an auto-expiring
+// cache, providing methods to manage cache entries.
+type EncounterCache struct {
+	// encounterCache is keyed by encounterId (Pokemon.Id).
+	// Note that since these are value types in the cache,
+	// there's built-in way to synchronize changes to the values.
+	// The current use of this cache is guarded by pokemonStripedMutex
+	// to synchronize access.
+	encounterCache *ttlcache.Cache[string, Value]
+}
+
+// UpdateTTL updates the ttl for a cache entry, if an entry
+// is cached for the encounterId. If no entry exists for the
+// encounterId, nothing is done.
+func (cache *EncounterCache) UpdateTTL(encounterId string, ttl time.Duration) {
+	cache.Put(encounterId, cache.Get(encounterId), ttl)
+}
+
+// Put will add or replace a cache entry. A ttl of 0 means to use the default
+// ttl.
+func (cache *EncounterCache) Put(encounterId string, value *Value, ttl time.Duration) {
+	if value != nil {
+		cache.encounterCache.Set(encounterId, *value, ttl)
+	}
+}
+
+// Get will return the cache entry for the encounterId, if it exists.
+// Returns nil if it does not exist.
+func (cache *EncounterCache) Get(encounterId string) *Value {
+	entry := cache.encounterCache.Get(encounterId)
+	if entry == nil {
+		return nil
+	}
+	value := entry.Value()
+	return &value
+}
+
+// GetOrCreate will return the cache entry for the encounterId, if it
+// exists. If it does not exist, a new entry will be allocated and
+// returned, but not insertedt, yet.
+func (cache *EncounterCache) GetOrCreate(encounterId string) *Value {
+	value := cache.Get(encounterId)
+	if value == nil {
+		value = &Value{
+			accountsSeen: make(map[string]bool),
+		}
+	}
+	return value
+}
+
+// Run will run the auto-expiring goroutine until 'ctx' is
+// cancelled.
+func (cache *EncounterCache) Run(ctx context.Context) {
+	doneCh := make(chan bool)
+
+	go func() {
+		defer close(doneCh)
+		cache.encounterCache.Start()
+	}()
+
+	<-ctx.Done()
+	cache.encounterCache.Stop()
+	<-doneCh
+}
+
+// NewEncounterCache creates and returns a new auto-expiring cache,
+// using 'defaultTTL' as the default ttl. If defaultTTL <= 0, a
+// default of 60 minutes will be used.
+func NewEncounterCache(defaultTTL time.Duration) *EncounterCache {
+	if defaultTTL <= 0 {
+		defaultTTL = 60 * time.Minute
+	}
+	return &EncounterCache{
+		encounterCache: ttlcache.New[string, Value](
+			ttlcache.WithTTL[string, Value](defaultTTL),
+			ttlcache.WithDisableTouchOnHit[string, Value](),
+		),
+	}
+}

--- a/main.go
+++ b/main.go
@@ -366,7 +366,7 @@ func decode(ctx context.Context, method int, protoData *ProtoData) {
 		}
 		processed = true
 	case pogo.Method_METHOD_DISK_ENCOUNTER:
-		result = decodeDiskEncounter(ctx, protoData.Data)
+		result = decodeDiskEncounter(ctx, protoData.Data, protoData.Account)
 		processed = true
 	case pogo.Method_METHOD_FORT_SEARCH:
 		result = decodeQuest(ctx, protoData.Data, protoData.HaveAr)
@@ -679,7 +679,7 @@ func decodeEncounter(ctx context.Context, sDec []byte, username string) string {
 	return decoder.UpdatePokemonRecordWithEncounterProto(ctx, dbDetails, decodedEncounterInfo, username)
 }
 
-func decodeDiskEncounter(ctx context.Context, sDec []byte) string {
+func decodeDiskEncounter(ctx context.Context, sDec []byte, username string) string {
 	decodedEncounterInfo := &pogo.DiskEncounterOutProto{}
 	if err := proto.Unmarshal(sDec, decodedEncounterInfo); err != nil {
 		log.Errorf("Failed to parse %s", err)
@@ -695,7 +695,7 @@ func decodeDiskEncounter(ctx context.Context, sDec []byte) string {
 	}
 
 	statsCollector.IncDecodeDiskEncounter("ok", "")
-	return decoder.UpdatePokemonRecordWithDiskEncounterProto(ctx, dbDetails, decodedEncounterInfo)
+	return decoder.UpdatePokemonRecordWithDiskEncounterProto(ctx, dbDetails, decodedEncounterInfo, username)
 }
 
 func decodeStartIncident(ctx context.Context, sDec []byte) string {

--- a/stats_collector/noop.go
+++ b/stats_collector/noop.go
@@ -11,9 +11,6 @@ var _ StatsCollector = (*noopCollector)(nil)
 type noopCollector struct {
 }
 
-func (col *noopCollector) IncPokemonCountShiny(string)                           {}
-func (col *noopCollector) IncPokemonCountShundo(string)                          {}
-func (col *noopCollector) IncPokemonCountSnundo(string)                          {}
 func (col *noopCollector) IncRawRequests(string, string)                         {}
 func (col *noopCollector) IncDecodeMethods(string, string, string)               {}
 func (col *noopCollector) IncDecodeFortDetails(string, string)                   {}
@@ -32,12 +29,17 @@ func (col *noopCollector) IncDecodeOpenInvasion(string, string)                 
 func (col *noopCollector) AddPokemonStatsResetCount(string, float64)             {}
 func (col *noopCollector) IncPokemonCountNew(string)                             {}
 func (col *noopCollector) IncPokemonCountIv(string)                              {}
+func (col *noopCollector) IncPokemonCountShiny(string, string)                   {}
+func (col *noopCollector) IncPokemonCountNonShiny(string, string)                {}
+func (col *noopCollector) IncPokemonCountShundo()                                {}
+func (col *noopCollector) IncPokemonCountSnundo()                                {}
 func (col *noopCollector) IncPokemonCountHundo(string)                           {}
 func (col *noopCollector) IncPokemonCountNundo(string)                           {}
 func (col *noopCollector) UpdateVerifiedTtl(geo.AreaName, null.String, null.Int) {}
 func (col *noopCollector) UpdateRaidCount([]geo.AreaName, int64)                 {}
 func (col *noopCollector) UpdateFortCount([]geo.AreaName, string, string)        {}
 func (col *noopCollector) UpdateIncidentCount([]geo.AreaName)                    {}
+func (col *noopCollector) IncDuplicateEncounters(sameAccount bool)               {}
 
 func NewNoopStatsCollector() StatsCollector {
 	return &noopCollector{}

--- a/stats_collector/prometheus.go
+++ b/stats_collector/prometheus.go
@@ -11,15 +11,14 @@ import (
 	"golbat/geo"
 )
 
-
 var (
 	ns = "golbat"
 
 	rawRequests = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "raw_requests",
-			Help: "Total number of requests received by raw endpoint",
+			Name:      "raw_requests",
+			Help:      "Total number of requests received by raw endpoint",
 		},
 		[]string{"status", "message"},
 	)
@@ -27,112 +26,112 @@ var (
 	decodeMethods = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "decode_methods",
-			Help: "Total number of decoded methods",
+			Name:      "decode_methods",
+			Help:      "Total number of decoded methods",
 		},
 		[]string{"status", "message", "method"},
 	)
 	decodeFortDetails = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "decode_fort_details",
-			Help: "Total number of decoded: FortDetails",
+			Name:      "decode_fort_details",
+			Help:      "Total number of decoded: FortDetails",
 		},
 		[]string{"status", "message"},
 	)
 	decodeGetMapForts = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "decode_get_map_forts",
-			Help: "Total number of decoded: GMF",
+			Name:      "decode_get_map_forts",
+			Help:      "Total number of decoded: GMF",
 		},
 		[]string{"status", "message"},
 	)
 	decodeGetGymInfo = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "decode_get_gym_info",
-			Help: "Total number of decoded: GetGymInfo",
+			Name:      "decode_get_gym_info",
+			Help:      "Total number of decoded: GetGymInfo",
 		},
 		[]string{"status", "message"},
 	)
 	decodeEncounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "decode_encounter",
-			Help: "Total number of decoded: Encounter",
+			Name:      "decode_encounter",
+			Help:      "Total number of decoded: Encounter",
 		},
 		[]string{"status", "message"},
 	)
 	decodeDiskEncounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "decode_disk_encounter",
-			Help: "Total number of decoded DiskEncounter",
+			Name:      "decode_disk_encounter",
+			Help:      "Total number of decoded DiskEncounter",
 		},
 		[]string{"status", "message"},
 	)
 	decodeQuest = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "decode_quest",
-			Help: "Total number of decoded: Quests",
+			Name:      "decode_quest",
+			Help:      "Total number of decoded: Quests",
 		},
 		[]string{"status", "message"},
 	)
 	decodeSocialActionWithRequest = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "decode_social_action_with_request",
-			Help: "Total number of decoded: SocialActionWithRequest",
+			Name:      "decode_social_action_with_request",
+			Help:      "Total number of decoded: SocialActionWithRequest",
 		},
 		[]string{"status", "message"},
 	)
 	decodeGetFriendDetails = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "decode_get_friend_details",
-			Help: "Total number of decoded: GetFriendDetails",
+			Name:      "decode_get_friend_details",
+			Help:      "Total number of decoded: GetFriendDetails",
 		},
 		[]string{"status", "message"},
 	)
 	decodeSearchPlayer = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "decode_search_player",
-			Help: "Total number of decoded: SearchPlayer",
+			Name:      "decode_search_player",
+			Help:      "Total number of decoded: SearchPlayer",
 		},
 		[]string{"status", "message"},
 	)
 	decodeGMO = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "decode_gmo",
-			Help: "Total number of decoded: GMO",
+			Name:      "decode_gmo",
+			Help:      "Total number of decoded: GMO",
 		},
 		[]string{"status", "message"},
 	)
 	decodeGMOType = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "decode_gmo_type",
-			Help: "Total number of decoded: GMO sub-cat",
+			Name:      "decode_gmo_type",
+			Help:      "Total number of decoded: GMO sub-cat",
 		},
 		[]string{"type"},
 	)
 	decodeStartIncident = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "decode_start_incident",
-			Help: "Total number of decoded: StartIncident",
+			Name:      "decode_start_incident",
+			Help:      "Total number of decoded: StartIncident",
 		},
 		[]string{"status", "message"},
 	)
 	decodeOpenInvasion = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "decode_open_invasion",
-			Help: "Total number of decoded: OpenInvasion",
+			Name:      "decode_open_invasion",
+			Help:      "Total number of decoded: OpenInvasion",
 		},
 		[]string{"status", "message"},
 	)
@@ -140,8 +139,8 @@ var (
 	pokemonStatsResetCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "pokemon_stats_reset_count",
-			Help: "Total number of stats reset",
+			Name:      "pokemon_stats_reset_count",
+			Help:      "Total number of stats reset",
 		},
 		[]string{"area"},
 	)
@@ -149,58 +148,62 @@ var (
 	pokemonCountNew = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "pokemon_count_new",
-			Help: "Total new Pokemon count",
+			Name:      "pokemon_count_new",
+			Help:      "Total new Pokemon count",
 		},
 		[]string{"area"},
 	)
 	pokemonCountIv = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "pokemon_count_iv",
-			Help: "Total Pokemon with IV",
+			Name:      "pokemon_count_iv",
+			Help:      "Total Pokemon with IV",
 		},
 		[]string{"area"},
 	)
-	/*
-		pokemonCountShiny = prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: ns,
-				Name: "pokemon_count_shiny",
-				Help: "Total Shiny count",
-			},
-			[]string{"area"},
-		)
-		pokemonCountShundo = prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: ns,
-				Name: "pokemon_count_shundo",
-				Help: "Total Shundo count",
-			},
-			[]string{"area"},
-		)
-		pokemonCountSnundo = prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: ns,
-				Name: "pokemon_count_snundo",
-				Help: "Total Snundo count",
-			},
-			[]string{"area"},
-		)
-	*/
+	pokemonCountShiny = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "pokemon_count_shiny",
+			Help:      "Total Shiny count by pokemon dex id",
+		},
+		[]string{"pokemon_id", "form_id"},
+	)
+	pokemonCountNonShiny = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "pokemon_count_non_shiny",
+			Help:      "Total Non-Shiny count by pokemon dex id",
+		},
+		[]string{"pokemon_id", "form_id"},
+	)
+	pokemonCountShundo = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "pokemon_count_shundo",
+			Help:      "Total Shundo count",
+		},
+	)
+	pokemonCountSnundo = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "pokemon_count_snundo",
+			Help:      "Total Snundo count",
+		},
+	)
 	pokemonCountHundo = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "pokemon_count_hundo",
-			Help: "Total Hundo count",
+			Name:      "pokemon_count_hundo",
+			Help:      "Total Hundo count",
 		},
 		[]string{"area"},
 	)
 	pokemonCountNundo = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "pokemon_count_nundo",
-			Help: "Total Nundo count",
+			Name:      "pokemon_count_nundo",
+			Help:      "Total Nundo count",
 		},
 		[]string{"area"},
 	)
@@ -208,8 +211,8 @@ var (
 	verifiedPokemonTTL = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "verified_pokemon_ttl",
-			Help: "Verified Pokemon count by area, type and with a flag stating if a Pokemon had TTL over 30 minutes",
+			Name:      "verified_pokemon_ttl",
+			Help:      "Verified Pokemon count by area, type and with a flag stating if a Pokemon had TTL over 30 minutes",
 		},
 		[]string{"area", "type", "above30"},
 	)
@@ -217,8 +220,8 @@ var (
 	verifiedPokemonTTLCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "verified_pokemon_ttl_counter",
-			Help: "Verified Pokemon counter by area, type and with a flag stating if a Pokemon had TTL over 30 minutes",
+			Name:      "verified_pokemon_ttl_counter",
+			Help:      "Verified Pokemon counter by area, type and with a flag stating if a Pokemon had TTL over 30 minutes",
 		},
 		[]string{"area", "type", "above30"},
 	)
@@ -226,26 +229,34 @@ var (
 	raidCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "raid_count",
-			Help: "Total number of created raids",
+			Name:      "raid_count",
+			Help:      "Total number of created raids",
 		},
 		[]string{"area", "level"},
 	)
 	fortCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "fort_count",
-			Help: "Total number of forts additions, removals and updates",
+			Name:      "fort_count",
+			Help:      "Total number of forts additions, removals and updates",
 		},
 		[]string{"area", "type", "change"},
 	)
 	incidentCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "incident_count",
-			Help: "Total number of incidents updates",
+			Name:      "incident_count",
+			Help:      "Total number of incidents updates",
 		},
 		[]string{"area"},
+	)
+	duplicateEncounters = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "duplicate_encounters",
+			Help:      "Total number of duplicate encounters",
+		},
+		[]string{"sameacct"},
 	)
 )
 
@@ -326,19 +337,21 @@ func (col *promCollector) IncPokemonCountIv(area string) {
 	pokemonCountIv.WithLabelValues(area).Inc()
 }
 
-/*
-func (col *promCollector) IncPokemonCountShiny(area string) {
-	pokemonCountShiny.WithLabelValues(area).Inc()
+func (col *promCollector) IncPokemonCountShiny(pokemonId, formId string) {
+	pokemonCountShiny.WithLabelValues(pokemonId, formId).Inc()
 }
 
-func (col *promCollector) IncPokemonCountShundo(area string) {
-	pokemonCountShundo.WithLabelValues(area).Inc()
+func (col *promCollector) IncPokemonCountNonShiny(pokemonId, formId string) {
+	pokemonCountNonShiny.WithLabelValues(pokemonId, formId).Inc()
 }
 
-func (col *promCollector) IncPokemonCountSnundo(area string) {
-	pokemonCountSnundo.WithLabelValues(area).Inc()
+func (col *promCollector) IncPokemonCountShundo() {
+	pokemonCountShundo.Inc()
 }
-*/
+
+func (col *promCollector) IncPokemonCountSnundo() {
+	pokemonCountSnundo.Inc()
+}
 
 func (col *promCollector) IncPokemonCountHundo(area string) {
 	pokemonCountHundo.WithLabelValues(area).Inc()
@@ -401,6 +414,16 @@ func (col *promCollector) UpdateIncidentCount(areas []geo.AreaName) {
 	}
 }
 
+func (col *promCollector) IncDuplicateEncounters(sameAccount bool) {
+	var v string
+	if sameAccount {
+		v = "y"
+	} else {
+		v = "n"
+	}
+	duplicateEncounters.WithLabelValues(v).Inc()
+}
+
 func initPrometheus() {
 	prometheus.MustRegister(
 		rawRequests, decodeMethods, decodeFortDetails, decodeGetMapForts, decodeGetGymInfo, decodeEncounter,
@@ -410,8 +433,10 @@ func initPrometheus() {
 		pokemonStatsResetCount,
 
 		pokemonCountNew, pokemonCountIv, pokemonCountHundo, pokemonCountNundo,
+		pokemonCountShiny, pokemonCountNonShiny, pokemonCountShundo, pokemonCountSnundo,
 
 		verifiedPokemonTTL, verifiedPokemonTTLCounter, raidCount, fortCount, incidentCount,
+		duplicateEncounters,
 	)
 }
 

--- a/stats_collector/stats_collector.go
+++ b/stats_collector/stats_collector.go
@@ -29,17 +29,17 @@ type StatsCollector interface {
 	AddPokemonStatsResetCount(area string, val float64)
 	IncPokemonCountNew(area string)
 	IncPokemonCountIv(area string)
-	/*
-		IncPokemonCountShiny(area string)
-		IncPokemonCountShundo(area string)
-		IncPokemonCountSnundo(area string)
-	*/
+	IncPokemonCountShiny(pokemonId, formId string)
+	IncPokemonCountNonShiny(pokemonId, formId string)
+	IncPokemonCountShundo()
+	IncPokemonCountSnundo()
 	IncPokemonCountHundo(area string)
 	IncPokemonCountNundo(area string)
 	UpdateVerifiedTtl(area geo.AreaName, seenType null.String, expireTimestamp null.Int)
 	UpdateRaidCount(areas []geo.AreaName, raidLevel int64)
 	UpdateFortCount(areas []geo.AreaName, fortType string, changeType string)
 	UpdateIncidentCount(areas []geo.AreaName)
+	IncDuplicateEncounters(sameAccount bool)
 }
 
 type Config interface {


### PR DESCRIPTION
This PR computes shiny stats, but does so by the combination of 'encounterId,accountUsername'. We need to look at every unique encounterId/accountUsername pair, so this is hooked in before we check if an encounter is a duplicate, and only in the encounter paths.

This converts the existing 'pokemonTimings' cache which is keyed by encounterId into a more general encounter cache, adding the map of accounts that have seen the encounter to it.

Shiny stats are not computed per area. After discussion, we determined that area is not very useful and it's too expensive to compute just for these stats. There can be a lot of duplicate encounters, and this avoids the work to compute the areas on duplicates.

For the DB/in-memory stats, they will be updated with area 'world'.

For prometheus, this sends shiny,shundo,snundo stats. For 'any shiny', I'm sending metrics by dex+form Id. And non-shiny counts are submitted as well by dex+form Id. The purpose for this is so that we can compute accurate shiny odds per dex/form.

A metric is also added to count the number of times the same encounterId is seen for both same and different accounts.