### PR TITLE
feat: custom headers for webhooks

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -52,6 +52,7 @@ url = "http://localhost:4201"
 #[[webhooks]]
 #url = "http://localhost:4202"
 #types = ["raid"]
+#headers = ["X-Poracle-Secret:abc", "Other-Header:def"]
 
 #[[webhooks]]
 #url = "http://localhost:4202"

--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,7 @@ type Webhook struct {
 	Url       string            `koanf:"url"`
 	Types     []string          `koanf:"types"`
 	Areas     []string          `koanf:"areas"`
-	Headers   string            `koanf:"headers"`
+	Headers   []string          `koanf:"headers"`
 	HeaderMap map[string]string `koanf:"-"`
 	AreaNames []geo.AreaName    `koanf:"-"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -54,10 +54,12 @@ type cleanup struct {
 }
 
 type Webhook struct {
-	Url       string         `koanf:"url"`
-	Types     []string       `koanf:"types"`
-	Areas     []string       `koanf:"areas"`
-	AreaNames []geo.AreaName `koanf:"-"`
+	Url       string            `koanf:"url"`
+	Types     []string          `koanf:"types"`
+	Areas     []string          `koanf:"areas"`
+	Headers   string            `koanf:"headers"`
+	HeaderMap map[string]string `koanf:"-"`
+	AreaNames []geo.AreaName    `koanf:"-"`
 }
 
 type pvp struct {

--- a/config/reader.go
+++ b/config/reader.go
@@ -9,6 +9,7 @@ import (
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/providers/structs"
 	"github.com/knadh/koanf/v2"
+	"github.com/sirupsen/logrus"
 
 	"golbat/geo"
 )
@@ -90,6 +91,7 @@ func ReadConfig() (configDefinition, error) {
 	for i := 0; i < len(Config.Webhooks); i++ {
 		hook := &Config.Webhooks[i]
 		hook.AreaNames = splitIntoAreaAndFenceName(hook.Areas)
+		hook.HeaderMap = splitIntoHeaderMap(hook.Headers)
 	}
 
 	// translate scan areas to array of geo.AreaName struct
@@ -129,4 +131,17 @@ func splitIntoAreaAndFenceName(areaNames []string) (areas []geo.AreaName) {
 		}
 	}
 	return
+}
+
+func splitIntoHeaderMap(rawHeader string) map[string]string {
+	headerMap := make(map[string]string)
+	for _, header := range strings.Split(rawHeader, ",") {
+		split := strings.Split(header, ":")
+		if len(split) == 2 {
+			headerMap[split[0]] = split[1]
+		} else {
+			logrus.Errorf("Invalid header: %s", header)
+		}
+	}
+	return headerMap
 }

--- a/config/reader.go
+++ b/config/reader.go
@@ -9,7 +9,6 @@ import (
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/providers/structs"
 	"github.com/knadh/koanf/v2"
-	"github.com/sirupsen/logrus"
 
 	"golbat/geo"
 )
@@ -140,7 +139,7 @@ func splitIntoHeaderMap(rawHeader string) map[string]string {
 		if len(split) == 2 {
 			headerMap[split[0]] = split[1]
 		} else {
-			logrus.Errorf("Invalid header: %s", header)
+			fmt.Println(fmt.Errorf("invalid header: %s", header))
 		}
 	}
 	return headerMap

--- a/config/reader.go
+++ b/config/reader.go
@@ -132,9 +132,9 @@ func splitIntoAreaAndFenceName(areaNames []string) (areas []geo.AreaName) {
 	return
 }
 
-func splitIntoHeaderMap(rawHeader string) map[string]string {
+func splitIntoHeaderMap(rawHeader []string) map[string]string {
 	headerMap := make(map[string]string)
-	for _, header := range strings.Split(rawHeader, ",") {
+	for _, header := range rawHeader {
 		split := strings.Split(header, ":")
 		if len(split) == 2 {
 			headerMap[split[0]] = split[1]

--- a/webhooks/webhook.go
+++ b/webhooks/webhook.go
@@ -68,6 +68,7 @@ type webhook struct {
 	url         string
 	areaNames   []geo.AreaName
 	typesWanted []WebhookType
+	headerMap   map[string]string
 	httpClient  *http.Client
 }
 
@@ -119,6 +120,9 @@ func (wh *webhook) sendCollection(collection webhookCollection) error {
 	req.Header.Set("X-Golbat", "hey!")
 	req.Header.Set("Content-Type", "application/json")
 
+	for key, value := range wh.headerMap {
+		req.Header.Set(key, value)
+	}
 	resp, err := wh.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send webhook to %s: %s", wh.url, err)
@@ -171,5 +175,6 @@ func webhookFromConfigWebhook(configWh config.Webhook) (*webhook, error) {
 		typesWanted: typesWanted,
 		areaNames:   configWh.AreaNames,
 		httpClient:  &http.Client{},
+		headerMap:   configWh.HeaderMap,
 	}, nil
 }


### PR DESCRIPTION
This adds support for adding custom headers to the webhook requests. 
- Keys and values are separated by a `:` 

Example:
```toml
[[webhooks]]
url = "http://localhost:3032"
headers = ["X-Poracle-Secret:abc", "Other-Header:def"]
```