### PR TITLE
Fix Dockerfile copy syntax for compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.21-alpine as build
 
 WORKDIR /go/src/app
-COPY go.mod go.sum .
+COPY go.mod go.sum ./
 RUN if [ ! -f vendor/modules.txt ]; then go mod download; fi
 
 COPY . .


### PR DESCRIPTION
Per documentation a destination for multiple files must always end in /.
No idea why my installation doesn't complain about that though.
