### PR TITLE
Fix wrong labels for Prom raw requests stats

### DIFF
--- a/stats_collector/prometheus.go
+++ b/stats_collector/prometheus.go
@@ -266,7 +266,7 @@ type promCollector struct {
 }
 
 func (col *promCollector) IncRawRequests(status, message string) {
-	rawRequests.WithLabelValues("error", "auth").Inc()
+	rawRequests.WithLabelValues(status, message).Inc()
 }
 
 func (col *promCollector) IncDecodeMethods(status, message, method string) {


### PR DESCRIPTION
When I did the stats_collector interface, we all missed a bug where the incorrect labels are being used for prometheus. This fixes it.