### PR TITLE
Prometheus - live stats

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -86,9 +86,11 @@ type pyroscope struct {
 }
 
 type Prometheus struct {
-	Enabled    bool      `koanf:"enabled"`
-	Token      string    `koanf:"token"`
-	BucketSize []float64 `koanf:"bucket_size"`
+	Enabled        bool      `koanf:"enabled"`
+	Token          string    `koanf:"token"`
+	BucketSize     []float64 `koanf:"bucket_size"`
+	LiveStats      bool      `koanf:"live_stats"`
+	LiveStatsSleep int       `koanf:"live_stats_sleep"`
 }
 
 type logging struct {

--- a/config/reader.go
+++ b/config/reader.go
@@ -28,7 +28,8 @@ func ReadConfig() (configDefinition, error) {
 			BlockProfileRate:     5,
 		},
 		Prometheus: Prometheus{
-			BucketSize: []float64{.00005, .000075, .0001, .00025, .0005, .00075, .001, .0025, .005, .01, .05, .1, .25, .5, 1, 2.5, 5, 10},
+			BucketSize:     []float64{.00005, .000075, .0001, .00025, .0005, .00075, .001, .0025, .005, .01, .05, .1, .25, .5, 1, 2.5, 5, 10},
+			LiveStatsSleep: 120,
 		},
 		Logging: logging{
 			Debug:      false,

--- a/db/stats.go
+++ b/db/stats.go
@@ -1,0 +1,175 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	log "github.com/sirupsen/logrus"
+	"time"
+)
+
+type GymStats struct {
+	TeamId   int8    `db:"team_id"`
+	InBattle bool    `db:"in_battle"`
+	Count    float64 `db:"count"`
+}
+
+type RaidStats struct {
+	RaidLevel int64   `db:"raid_level"`
+	Count     float64 `db:"count"`
+}
+
+type IncidentsStats struct {
+	DisplayType int8    `db:"display_type"`
+	Confirmed   bool    `db:"confirmed"`
+	Count       float64 `db:"count"`
+}
+
+type LureStats struct {
+	LureId int32   `db:"lure_id"`
+	Count  float64 `db:"count"`
+}
+
+type QuestStats struct {
+	NoAr float64 `db:"no_ar"`
+	Ar   float64 `db:"ar"`
+}
+
+func GetGymStats(db DbDetails) ([]GymStats, error) {
+	stats := []GymStats{}
+
+	// fetch counts for gyms updated within last hour
+	err := db.GeneralDb.Select(&stats,
+		"SELECT count(*) as count, team_id, in_battle "+
+			"FROM `gym` WHERE updated > UNIX_TIMESTAMP() - 3600 GROUP BY team_id, in_battle;",
+	)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}
+
+func GetRaidStats(db DbDetails) ([]RaidStats, error) {
+	stats := []RaidStats{}
+
+	err := db.GeneralDb.Select(&stats,
+		"SELECT count(*) AS count, COALESCE(raid_level, 0) AS raid_level "+
+			"FROM `gym` WHERE raid_end_timestamp > UNIX_TIMESTAMP() GROUP BY raid_level;",
+	)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}
+
+func GetIncidentsStats(db DbDetails) ([]IncidentsStats, error) {
+	stats := []IncidentsStats{}
+
+	err := db.GeneralDb.Select(&stats,
+		"SELECT count(*) as count, display_type, confirmed "+
+			"FROM `incident` WHERE expiration > UNIX_TIMESTAMP() AND display_type != 0 "+
+			"GROUP BY display_type, confirmed;",
+	)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}
+
+func GetLureStats(db DbDetails) ([]LureStats, error) {
+	stats := []LureStats{}
+
+	err := db.GeneralDb.Select(&stats,
+		"SELECT count(*) as count, lure_id "+
+			"FROM `pokestop` WHERE lure_expire_timestamp > UNIX_TIMESTAMP() GROUP BY lure_id;",
+	)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}
+
+func GetQuestStats(db DbDetails) (QuestStats, error) {
+	stats := QuestStats{}
+	err := db.GeneralDb.Get(&stats,
+		"SELECT COUNT(quest_type) AS no_ar, COUNT(alternative_quest_type) AS ar FROM pokestop;",
+	)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return QuestStats{}, nil
+	}
+
+	if err != nil {
+		return QuestStats{}, err
+	}
+
+	return stats, nil
+}
+
+func PromLiveStatsUpdater(dbDetails DbDetails, sleepTime int) {
+	log.Infof("[Prometheus] LiveStats loop started with %d seconds of sleep", sleepTime)
+	for {
+		start := time.Now()
+
+		gymStats, err := GetGymStats(dbDetails)
+		if err == nil {
+			for _, stat := range gymStats {
+				statsCollector.SetGyms(stat.TeamId, stat.InBattle, stat.Count)
+			}
+		}
+
+		raidStats, err := GetRaidStats(dbDetails)
+		if err == nil {
+			for _, stat := range raidStats {
+				statsCollector.SetRaids(stat.RaidLevel, stat.Count)
+			}
+		}
+
+		incidentsStats, err := GetIncidentsStats(dbDetails)
+		if err == nil {
+			for _, stat := range incidentsStats {
+				statsCollector.SetIncidents(stat.DisplayType, stat.Confirmed, stat.Count)
+			}
+		}
+
+		luresStats, err := GetLureStats(dbDetails)
+		if err == nil {
+			for _, stat := range luresStats {
+				statsCollector.SetLures(stat.LureId, stat.Count)
+			}
+		}
+
+		questStats, err := GetQuestStats(dbDetails)
+		if err == nil {
+			statsCollector.SetQuests(questStats.Ar, questStats.NoAr)
+		}
+
+		elapsed := time.Since(start)
+		log.Infof("[Prometheus] LiveStats fetched in: %s", elapsed)
+
+		time.Sleep(time.Duration(sleepTime) * time.Second)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -184,6 +184,11 @@ func main() {
 	decoder.SetStatsCollector(statsCollector)
 	db2.SetStatsCollector(statsCollector)
 
+	// collect live stats when prometheus and liveStats are enabled
+	if cfg.Prometheus.Enabled && cfg.Prometheus.LiveStats {
+		go db2.PromLiveStatsUpdater(dbDetails, cfg.Prometheus.LiveStatsSleep)
+	}
+
 	decoder.InitialiseOhbem()
 	decoder.LoadStatsGeofences()
 	decoder.LoadNests(dbDetails)

--- a/stats_collector/noop.go
+++ b/stats_collector/noop.go
@@ -39,8 +39,15 @@ func (col *noopCollector) UpdateVerifiedTtl(geo.AreaName, null.String, null.Int)
 func (col *noopCollector) UpdateRaidCount([]geo.AreaName, int64)                 {}
 func (col *noopCollector) UpdateFortCount([]geo.AreaName, string, string)        {}
 func (col *noopCollector) UpdateIncidentCount([]geo.AreaName)                    {}
-func (col *noopCollector) IncDuplicateEncounters(sameAccount bool)               {}
-func (col *noopCollector) IncDbQuery(query string, err error)                    {}
+func (col *noopCollector) IncDuplicateEncounters(bool)                           {}
+func (col *noopCollector) IncDbQuery(string, error)                              {}
+func (col *noopCollector) SetGyms(int8, bool, float64)                           {}
+func (col *noopCollector) SetRaids(int64, float64)                               {}
+func (col *noopCollector) SetIncidents(int8, bool, float64)                      {}
+func (col *noopCollector) SetLures(int32, float64)                               {}
+func (col *noopCollector) SetQuests(float64, float64)                            {}
+func (col *noopCollector) IncPokemons(bool, null.String)                         {}
+func (col *noopCollector) DecPokemons(bool, null.String)                         {}
 
 func NewNoopStatsCollector() StatsCollector {
 	return &noopCollector{}

--- a/stats_collector/stats_collector.go
+++ b/stats_collector/stats_collector.go
@@ -4,10 +4,9 @@ import (
 	"github.com/Depado/ginprom"
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/guregu/null.v4"
-
 	"golbat/config"
 	"golbat/geo"
+	"gopkg.in/guregu/null.v4"
 )
 
 type StatsCollector interface {
@@ -41,6 +40,13 @@ type StatsCollector interface {
 	UpdateIncidentCount(areas []geo.AreaName)
 	IncDuplicateEncounters(sameAccount bool)
 	IncDbQuery(query string, err error)
+	SetGyms(teamId int8, inBattle bool, count float64)
+	SetRaids(level int64, count float64)
+	SetIncidents(kind int8, confirmed bool, count float64)
+	SetLures(lureId int32, count float64)
+	SetQuests(ar float64, noAr float64)
+	IncPokemons(hasIv bool, seenType null.String)
+	DecPokemons(hasIv bool, seenType null.String)
 }
 
 type Config interface {

--- a/util/pogo.go
+++ b/util/pogo.go
@@ -1,0 +1,26 @@
+package util
+
+var TeamIdToName = map[int8]string{
+	0: "harmony",
+	1: "mystic",
+	2: "valor",
+	3: "instinct",
+}
+
+var LureIdToName = map[int32]string{
+	501: "normal",
+	502: "glacial",
+	503: "mossy",
+	504: "magnetic",
+	505: "rainy",
+	506: "sparkly",
+}
+
+var IncidentTypeToName = map[int8]string{
+	1: "grunt",
+	2: "leader",
+	3: "giovanni",
+	7: "coin",
+	8: "kecleon",
+	9: "showcase",
+}


### PR DESCRIPTION
Expose live status to prometheus using looped queries.

Exposed metrics:
- `gyms` - current gyms gauge grouped by team_name, in_battle
- `raids` - current raids gauge grouped by level
- `incidents` - current incidents gauge grouped by kind, confirmed
- `lures` - current lures gauge grouped by type
- `quests` - current quests gauge grouped by ar

Disable by default along prometheus integrity, config defaults as below:
```toml
live_stats = false
live_stats_sleep = 120
```

Solves https://github.com/UnownHash/Golbat/issues/178