### PR TITLE
Use GetFocuses() and add showcase pokemon form

### DIFF
--- a/sql/24_showcase_pokemon_form_id.up.sql
+++ b/sql/24_showcase_pokemon_form_id.up.sql
@@ -1,0 +1,3 @@
+alter table `pokestop`
+    add `showcase_pokemon_form_id` smallint unsigned DEFAULT NULL AFTER `showcase_pokemon_id`;
+


### PR DESCRIPTION
The Focus field has been deprecated in favor of Focuses. Focuses can have multiple types, so this PR adds support for finding the first pokemon in the Focuses array. If Focuses array is empty, I'm having this fall back to Focus for now just in case.

Also: Showcases can feature specific forms. It would be nice to be able to show the restricted form on the map.

This adds showcase_pokemon_form_id to the `pokestop` table and ShowcasePokemonForm to the Pokestop object and the corresponding code to update them, etc.

This requires updated Protos, so a commit from Fabio for them is included.