### PR TITLE
Add DB call count stats

### DIFF
--- a/db/dbDetails.go
+++ b/db/dbDetails.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"golbat/stats_collector"
+
 	"github.com/jmoiron/sqlx"
 )
 
@@ -8,4 +10,10 @@ type DbDetails struct {
 	PokemonDb       *sqlx.DB
 	UsePokemonCache bool
 	GeneralDb       *sqlx.DB
+}
+
+var statsCollector stats_collector.StatsCollector
+
+func SetStatsCollector(collector stats_collector.StatsCollector) {
+	statsCollector = collector
 }

--- a/db/gym.go
+++ b/db/gym.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+
 	"github.com/jmoiron/sqlx"
 )
 
@@ -9,6 +10,7 @@ func FindOldGyms(ctx context.Context, db DbDetails, cellId int64) ([]string, err
 	fortIds := []FortId{}
 	err := db.GeneralDb.SelectContext(ctx, &fortIds,
 		"SELECT id FROM gym WHERE deleted = 0 AND cell_id = ? AND updated < UNIX_TIMESTAMP() - 3600;", cellId)
+	statsCollector.IncDbQuery("select old-gyms", err)
 	if err != nil {
 		return nil, err
 	}
@@ -29,6 +31,7 @@ func ClearOldGyms(ctx context.Context, db DbDetails, gymIds []string) error {
 	query = db.GeneralDb.Rebind(query)
 
 	_, err := db.GeneralDb.ExecContext(ctx, query, args...)
+	statsCollector.IncDbQuery("clear old-gyms", err)
 	if err != nil {
 		return err
 	}

--- a/db/nests.go
+++ b/db/nests.go
@@ -14,6 +14,7 @@ func LoadNests(db DbDetails) ([]Nest, error) {
 	fortIds := []Nest{}
 	err := db.GeneralDb.Select(&fortIds,
 		"SELECT nest_id, lat, lon, name, st_astext(polygon) as polygon_astext FROM nests WHERE active = 1")
+	statsCollector.IncDbQuery("select nest-polygons", err)
 	if err != nil {
 		return nil, err
 	}

--- a/decoder/gym.go
+++ b/decoder/gym.go
@@ -115,6 +115,7 @@ func getGymRecord(ctx context.Context, db db.DbDetails, fortId string) (*Gym, er
 	gym := Gym{}
 	err := db.GeneralDb.GetContext(ctx, &gym, "SELECT id, lat, lon, name, url, last_modified_timestamp, raid_end_timestamp, raid_spawn_timestamp, raid_battle_timestamp, updated, raid_pokemon_id, guarding_pokemon_id, available_slots, team_id, raid_level, enabled, ex_raid_eligible, in_battle, raid_pokemon_move_1, raid_pokemon_move_2, raid_pokemon_form, raid_pokemon_alignment, raid_pokemon_cp, raid_is_exclusive, cell_id, deleted, total_cp, first_seen_timestamp, raid_pokemon_gender, sponsor_id, partner_id, raid_pokemon_costume, raid_pokemon_evolution, ar_scan_eligible, power_up_level, power_up_points, power_up_end_timestamp, description FROM gym WHERE id = ?", fortId)
 
+	statsCollector.IncDbQuery("select gym", err)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -478,6 +479,7 @@ func saveGymRecord(ctx context.Context, db db.DbDetails, gym *Gym) {
 		res, err := db.GeneralDb.NamedExecContext(ctx, "INSERT INTO gym (id,lat,lon,name,url,last_modified_timestamp,raid_end_timestamp,raid_spawn_timestamp,raid_battle_timestamp,updated,raid_pokemon_id,guarding_pokemon_id,available_slots,team_id,raid_level,enabled,ex_raid_eligible,in_battle,raid_pokemon_move_1,raid_pokemon_move_2,raid_pokemon_form,raid_pokemon_alignment,raid_pokemon_cp,raid_is_exclusive,cell_id,deleted,total_cp,first_seen_timestamp,raid_pokemon_gender,sponsor_id,partner_id,raid_pokemon_costume,raid_pokemon_evolution,ar_scan_eligible,power_up_level,power_up_points,power_up_end_timestamp,description) "+
 			"VALUES (:id,:lat,:lon,:name,:url,UNIX_TIMESTAMP(),:raid_end_timestamp,:raid_spawn_timestamp,:raid_battle_timestamp,:updated,:raid_pokemon_id,:guarding_pokemon_id,:available_slots,:team_id,:raid_level,:enabled,:ex_raid_eligible,:in_battle,:raid_pokemon_move_1,:raid_pokemon_move_2,:raid_pokemon_form,:raid_pokemon_alignment,:raid_pokemon_cp,:raid_is_exclusive,:cell_id,0,:total_cp,UNIX_TIMESTAMP(),:raid_pokemon_gender,:sponsor_id,:partner_id,:raid_pokemon_costume,:raid_pokemon_evolution,:ar_scan_eligible,:power_up_level,:power_up_points,:power_up_end_timestamp,:description)", gym)
 
+		statsCollector.IncDbQuery("insert gym", err)
 		if err != nil {
 			log.Errorf("insert gym: %s", err)
 			return
@@ -524,6 +526,7 @@ func saveGymRecord(ctx context.Context, db db.DbDetails, gym *Gym) {
 			"description = :description "+
 			"WHERE id = :id", gym,
 		)
+		statsCollector.IncDbQuery("update gym", err)
 		if err != nil {
 			log.Errorf("Update gym %s", err)
 		}

--- a/decoder/incident.go
+++ b/decoder/incident.go
@@ -61,6 +61,7 @@ func getIncidentRecord(ctx context.Context, db db.DbDetails, incidentId string) 
 		"SELECT id, pokestop_id, start, expiration, display_type, style, `character`, updated, confirmed, slot_1_pokemon_id, slot_1_form, slot_2_pokemon_id, slot_2_form, slot_3_pokemon_id, slot_3_form "+
 			"FROM incident "+
 			"WHERE incident.id = ? ", incidentId)
+	statsCollector.IncDbQuery("select incident", err)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -114,7 +115,7 @@ func saveIncidentRecord(ctx context.Context, db db.DbDetails, incident *Incident
 			log.Errorf("insert incident: %s", err)
 			return
 		}
-
+		statsCollector.IncDbQuery("insert incident", err)
 		_, _ = res, err
 	} else {
 		res, err := db.GeneralDb.NamedExec("UPDATE incident SET "+
@@ -133,6 +134,7 @@ func saveIncidentRecord(ctx context.Context, db db.DbDetails, incident *Incident
 			"slot_3_form = :slot_3_form "+
 			"WHERE id = :id", incident,
 		)
+		statsCollector.IncDbQuery("update incident", err)
 		if err != nil {
 			log.Errorf("Update incident %s", err)
 		}

--- a/decoder/player.go
+++ b/decoder/player.go
@@ -2,14 +2,15 @@ package decoder
 
 import (
 	"database/sql"
-	"github.com/jellydator/ttlcache/v3"
-	log "github.com/sirupsen/logrus"
 	"golbat/db"
 	"golbat/pogo"
-	"gopkg.in/guregu/null.v4"
 	"reflect"
 	"strconv"
 	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/guregu/null.v4"
 )
 
 // Player struct. Name is the primary key.
@@ -198,6 +199,7 @@ func getPlayerRecord(db db.DbDetails, name string, friendshipId string, friendCo
 		`,
 		name,
 	)
+	statsCollector.IncDbQuery("select player_name", err)
 	if err == sql.ErrNoRows {
 		if friendshipId != "" {
 			err = db.GeneralDb.Get(&player,
@@ -208,6 +210,7 @@ func getPlayerRecord(db db.DbDetails, name string, friendshipId string, friendCo
 				`,
 				friendshipId,
 			)
+			statsCollector.IncDbQuery("select player_friendship_id", err)
 		} else if friendCode != "" {
 			err = db.GeneralDb.Get(&player,
 				`
@@ -217,6 +220,7 @@ func getPlayerRecord(db db.DbDetails, name string, friendshipId string, friendCo
 				`,
 				friendCode,
 			)
+			statsCollector.IncDbQuery("select player_friend_code", err)
 		}
 
 		if err == sql.ErrNoRows {
@@ -362,6 +366,7 @@ func savePlayerRecord(db db.DbDetails, player *Player) {
 			player,
 		)
 
+		statsCollector.IncDbQuery("insert player", err)
 		if err != nil {
 			log.Errorf("insert player error: %s", err)
 			return
@@ -452,6 +457,7 @@ func savePlayerRecord(db db.DbDetails, player *Player) {
 			player,
 		)
 
+		statsCollector.IncDbQuery("update player", err)
 		if err != nil {
 			log.Errorf("Update player error %s", err)
 		}

--- a/decoder/pokemon.go
+++ b/decoder/pokemon.go
@@ -153,6 +153,7 @@ func getPokemonRecord(ctx context.Context, db db.DbDetails, encounterId string) 
 			"expire_timestamp_verified, shiny, username, pvp, is_event, seen_type "+
 			"FROM pokemon WHERE id = ?", encounterId)
 
+	statsCollector.IncDbQuery("select pokemon", err)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -309,6 +310,7 @@ func savePokemonRecordAsAtTime(ctx context.Context, db db.DbDetails, pokemon *Po
 				":first_seen_timestamp, :changed, :cell_id, :expire_timestamp_verified, :shiny, :username, %s :is_event,"+
 				":seen_type)", pvpField, pvpValue), pokemon)
 
+			statsCollector.IncDbQuery("insert pokemon", err)
 			if err != nil {
 				log.Errorf("insert pokemon: [%s] %s", pokemon.Id, err)
 				log.Errorf("Full structure: %+v", pokemon)
@@ -360,6 +362,7 @@ func savePokemonRecordAsAtTime(ctx context.Context, db db.DbDetails, pokemon *Po
 				"is_event = :is_event "+
 				"WHERE id = :id", pvpUpdate), pokemon,
 			)
+			statsCollector.IncDbQuery("update pokemon", err)
 			if err != nil {
 				log.Errorf("Update pokemon [%s] %s", pokemon.Id, err)
 				log.Errorf("Full structure: %+v", pokemon)

--- a/decoder/pokestop.go
+++ b/decoder/pokestop.go
@@ -121,10 +121,10 @@ func GetPokestopRecord(ctx context.Context, db db.DbDetails, fortId string) (*Po
 			"ar_scan_eligible, power_up_points, power_up_level, power_up_end_timestamp, quest_expiry, alternative_quest_expiry, description "+
 			"FROM pokestop "+
 			"WHERE pokestop.id = ? ", fortId)
+	statsCollector.IncDbQuery("select pokestop", err)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
-
 	if err != nil {
 		return nil, err
 	}
@@ -730,6 +730,7 @@ func savePokestopRecord(ctx context.Context, db db.DbDetails, pokestop *Pokestop
 				":showcase_pokemon_id, :showcase_ranking_standard, :showcase_expiry, :showcase_rankings)",
 			pokestop)
 
+		statsCollector.IncDbQuery("insert pokestop", err)
 		if err != nil {
 			log.Errorf("insert pokestop: %s", err)
 			return
@@ -779,6 +780,7 @@ func savePokestopRecord(ctx context.Context, db db.DbDetails, pokestop *Pokestop
 				" WHERE id = :id",
 			pokestop,
 		)
+		statsCollector.IncDbQuery("update pokestop", err)
 		if err != nil {
 			log.Errorf("update pokestop: %s", err)
 			return

--- a/decoder/routes.go
+++ b/decoder/routes.go
@@ -4,11 +4,12 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/jellydator/ttlcache/v3"
 	"golbat/db"
 	"golbat/pogo"
-	"gopkg.in/guregu/null.v4"
 	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+	"gopkg.in/guregu/null.v4"
 )
 
 type Route struct {
@@ -51,6 +52,7 @@ func getRouteRecord(db db.DbDetails, id string) (*Route, error) {
 		`,
 		id,
 	)
+	statsCollector.IncDbQuery("select route", err)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	} else if err != nil {
@@ -117,6 +119,7 @@ func saveRouteRecord(db db.DbDetails, route *Route) error {
 			route,
 		)
 
+		statsCollector.IncDbQuery("insert route", err)
 		if err != nil {
 			return fmt.Errorf("insert route error: %w", err)
 		}
@@ -148,6 +151,7 @@ func saveRouteRecord(db db.DbDetails, route *Route) error {
 			route,
 		)
 
+		statsCollector.IncDbQuery("update route", err)
 		if err != nil {
 			return fmt.Errorf("update route error %w", err)
 		}

--- a/decoder/s2cell.go
+++ b/decoder/s2cell.go
@@ -2,12 +2,13 @@ package decoder
 
 import (
 	"context"
+	"golbat/db"
+	"time"
+
 	"github.com/golang/geo/s2"
 	"github.com/jellydator/ttlcache/v3"
 	log "github.com/sirupsen/logrus"
-	"golbat/db"
 	"gopkg.in/guregu/null.v4"
-	"time"
 )
 
 type S2Cell struct {
@@ -64,6 +65,7 @@ func saveS2CellRecords(ctx context.Context, db db.DbDetails, cellIds []uint64) {
 		ON DUPLICATE KEY UPDATE updated=VALUES(updated)
 	`, outputCellIds)
 
+	statsCollector.IncDbQuery("insert s2cell", err)
 	if err != nil {
 		log.Errorf("saveS2CellRecords: %s", err)
 		return

--- a/stats_collector/noop.go
+++ b/stats_collector/noop.go
@@ -40,6 +40,7 @@ func (col *noopCollector) UpdateRaidCount([]geo.AreaName, int64)                
 func (col *noopCollector) UpdateFortCount([]geo.AreaName, string, string)        {}
 func (col *noopCollector) UpdateIncidentCount([]geo.AreaName)                    {}
 func (col *noopCollector) IncDuplicateEncounters(sameAccount bool)               {}
+func (col *noopCollector) IncDbQuery(query string, err error)                    {}
 
 func NewNoopStatsCollector() StatsCollector {
 	return &noopCollector{}

--- a/stats_collector/stats_collector.go
+++ b/stats_collector/stats_collector.go
@@ -40,6 +40,7 @@ type StatsCollector interface {
 	UpdateFortCount(areas []geo.AreaName, fortType string, changeType string)
 	UpdateIncidentCount(areas []geo.AreaName)
 	IncDuplicateEncounters(sameAccount bool)
+	IncDbQuery(query string, err error)
 }
 
 type Config interface {


### PR DESCRIPTION
I was trying to track down some IO spikes to my DB filesystem. Strangely nothing really turned up in slow query log. So I thought maybe there was a spam of requests happening for some strange reason. So, to check or eliminate golbat, I added these stats. (It turns out this eliminated Golbat and made me look elsewhere for the stupid thing I was doing.)

This might be interesting for others, also, so here it is. And timings might also be useful to add at some point to catch degradation.