### PR TITLE
feat: api support for geojson geometries

### DIFF
--- a/db/pokestop.go
+++ b/db/pokestop.go
@@ -3,9 +3,9 @@ package db
 import (
 	"context"
 	"database/sql"
-	"golbat/geo"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/paulmach/orb/geojson"
 )
 
 type QuestLocation struct {
@@ -24,14 +24,17 @@ type QuestStatus struct {
 	TotalStops uint32 `db:"total" json:"total"`
 }
 
-func GetPokestopPositions(db DbDetails, fence geo.Geofence) ([]QuestLocation, error) {
-	bbox := fence.GetBoundingBox()
-
+func GetPokestopPositions(db DbDetails, fence *geojson.Feature) ([]QuestLocation, error) {
+	bbox := fence.Geometry.Bound()
+	bytes, err := fence.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
 	areas := []QuestLocation{}
-	err := db.GeneralDb.Select(&areas, "SELECT id, lat, lon FROM pokestop "+
+	err = db.GeneralDb.Select(&areas, "SELECT id, lat, lon FROM pokestop "+
 		"WHERE lat > ? and lon > ? and lat < ? and lon < ? and enabled = 1 "+
-		"and ST_CONTAINS(ST_GEOMFROMTEXT('POLYGON(("+fence.ToPolygonString()+"))'), point(lat,lon))",
-		bbox.MinimumLatitude, bbox.MinimumLongitude, bbox.MaximumLatitude, bbox.MaximumLongitude)
+		"and ST_CONTAINS(ST_GeomFromGeoJSON('"+string(bytes)+"', 2, 0), POINT(lon, lat))",
+		bbox.Min.Lat(), bbox.Min.Lon(), bbox.Max.Lat(), bbox.Max.Lon())
 
 	statsCollector.IncDbQuery("select pokestop-positions", err)
 	if err == sql.ErrNoRows {
@@ -45,8 +48,12 @@ func GetPokestopPositions(db DbDetails, fence geo.Geofence) ([]QuestLocation, er
 	return areas, nil
 }
 
-func RemoveQuests(ctx context.Context, db DbDetails, fence geo.Geofence) (sql.Result, error) {
-	bbox := fence.GetBoundingBox()
+func RemoveQuests(ctx context.Context, db DbDetails, fence *geojson.Feature) (sql.Result, error) {
+	bbox := fence.Geometry.Bound()
+	bytes, err := fence.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
 
 	query := "UPDATE pokestop " +
 		"SET " +
@@ -67,9 +74,10 @@ func RemoveQuests(ctx context.Context, db DbDetails, fence geo.Geofence) (sql.Re
 		"alternative_quest_title = NULL, " +
 		"alternative_quest_expiry = NULL " +
 		"WHERE lat > ? and lon > ? and lat < ? and lon < ? and enabled = 1 " +
-		"and ST_CONTAINS(ST_GEOMFROMTEXT('POLYGON((" + fence.ToPolygonString() + "))'), point(lat,lon))"
+		"and ST_CONTAINS(ST_GeomFromGeoJSON('" + string(bytes) + "', 2, 0), POINT(lon, lat))"
 	res, err := db.GeneralDb.ExecContext(ctx, query,
-		bbox.MinimumLatitude, bbox.MinimumLongitude, bbox.MaximumLatitude, bbox.MaximumLongitude)
+		bbox.Min.Lat(), bbox.Min.Lon(), bbox.Max.Lat(), bbox.Max.Lon())
+
 	statsCollector.IncDbQuery("remove quests", err)
 	return res, err
 }
@@ -106,30 +114,32 @@ func ClearOldPokestops(ctx context.Context, db DbDetails, stopIds []string) erro
 	return nil
 }
 
-func GetQuestStatus(db DbDetails, fence geo.Geofence) (QuestStatus, error) {
-	if len(fence.Fence) == 0 {
-		return QuestStatus{}, nil
-	}
-	bbox := fence.GetBoundingBox()
+func GetQuestStatus(db DbDetails, fence *geojson.Feature) (QuestStatus, error) {
+	bbox := fence.Geometry.Bound()
+	status := QuestStatus{}
 
-	areas := QuestStatus{}
-	err := db.GeneralDb.Get(&areas,
+	bytes, err := fence.MarshalJSON()
+	if err != nil {
+		return status, err
+	}
+
+	err = db.GeneralDb.Get(&status,
 		"SELECT COUNT(*) AS total, "+
 			"COUNT(CASE WHEN quest_type IS NOT NULL THEN 1 END) AS ar_quests, "+
 			"COUNT(CASE WHEN alternative_quest_type IS NOT NULL THEN 1 END) AS no_ar_quests FROM pokestop "+
 			"WHERE lat > ? AND lon > ? AND lat < ? AND lon < ? AND enabled = 1 AND deleted = 0 "+
-			"AND ST_CONTAINS(ST_GEOMFROMTEXT('POLYGON(("+fence.ToPolygonString()+"))'), point(lat,lon)) ",
-		bbox.MinimumLatitude, bbox.MinimumLongitude, bbox.MaximumLatitude, bbox.MaximumLongitude,
+			"AND ST_CONTAINS(ST_GeomFromGeoJSON('"+string(bytes)+"', 2, 0), POINT(lon, lat)) ",
+		bbox.Min.Lat(), bbox.Min.Lon(), bbox.Max.Lat(), bbox.Max.Lon(),
 	)
 
 	statsCollector.IncDbQuery("select quest-status", err)
 	if err == sql.ErrNoRows {
-		return areas, nil
+		return status, nil
 	}
 
 	if err != nil {
-		return areas, err
+		return status, err
 	}
 
-	return areas, nil
+	return status, nil
 }

--- a/decoder/pokestop.go
+++ b/decoder/pokestop.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
+	"github.com/paulmach/orb/geojson"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/guregu/null.v4"
 
 	"golbat/config"
 	"golbat/db"
-	"golbat/geo"
 	"golbat/pogo"
 	"golbat/tz"
 	"golbat/util"
@@ -895,7 +895,7 @@ func UpdatePokestopWithQuest(ctx context.Context, db db.DbDetails, quest *pogo.F
 	return fmt.Sprintf("%s", quest.FortId)
 }
 
-func ClearQuestsWithinGeofence(ctx context.Context, dbDetails db.DbDetails, geofence geo.Geofence) {
+func ClearQuestsWithinGeofence(ctx context.Context, dbDetails db.DbDetails, geofence *geojson.Feature) {
 	res, err := db.RemoveQuests(ctx, dbDetails, geofence)
 	if err != nil {
 		log.Errorf("ClearQuest: Error removing quests: %s", err)
@@ -906,7 +906,7 @@ func ClearQuestsWithinGeofence(ctx context.Context, dbDetails db.DbDetails, geof
 	log.Infof("ClearQuest: Removed quests from %d pokestops", rows)
 }
 
-func GetQuestStatusWithGeofence(dbDetails db.DbDetails, geofence geo.Geofence) db.QuestStatus {
+func GetQuestStatusWithGeofence(dbDetails db.DbDetails, geofence *geojson.Feature) db.QuestStatus {
 	res, err := db.GetQuestStatus(dbDetails, geofence)
 	if err != nil {
 		log.Errorf("QuestStatus: Error retrieving quests: %s", err)
@@ -935,7 +935,7 @@ func UpdatePokestopRecordWithGetMapFortsOutProto(ctx context.Context, db db.DbDe
 	return true, fmt.Sprintf("%s %s", mapFort.Id, mapFort.Name)
 }
 
-func GetPokestopPositions(details db.DbDetails, geofence geo.Geofence) ([]db.QuestLocation, error) {
+func GetPokestopPositions(details db.DbDetails, geofence *geojson.Feature) ([]db.QuestLocation, error) {
 	return db.GetPokestopPositions(details, geofence)
 }
 

--- a/geo/geofence.go
+++ b/geo/geofence.go
@@ -279,19 +279,18 @@ func MatchGeofences(featureCollection *geojson.FeatureCollection, lat, lon float
 }
 
 func (fence *Geofence) toFeature() *geojson.Feature {
-	var ring orb.Ring
-	for _, loc := range fence.Fence {
-		ring = append(ring, orb.Point{loc.Longitude, loc.Latitude})
+	ring := make(orb.Ring, len(fence.Fence))
+	for i, loc := range fence.Fence {
+		ring[i] = orb.Point{loc.Longitude, loc.Latitude}
 	}
-	polygon := orb.Polygon{ring}
 
-	return geojson.NewFeature(polygon)
+	return geojson.NewFeature(orb.Polygon{ring})
 }
 
 func (fence *GeofenceApi) toGeofence() *Geofence {
-	var locations []Location
-	for _, loc := range fence.Fence {
-		locations = append(locations, loc.ToLocation())
+	locations := make([]Location, len(fence.Fence))
+	for i, loc := range fence.Fence {
+		locations[i] = loc.ToLocation()
 	}
 
 	return &Geofence{Fence: locations}

--- a/geo/geofence.go
+++ b/geo/geofence.go
@@ -10,6 +10,7 @@ import (
 	"github.com/paulmach/orb"
 	"github.com/paulmach/orb/geojson"
 	"github.com/paulmach/orb/planar"
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/rtree"
 )
 
@@ -304,17 +305,20 @@ func NormaliseFenceRequest(c *gin.Context) (*geojson.Feature, error) {
 
 	geometry, err := geojson.UnmarshalGeometry(bodyBytes)
 	if err == nil {
+		log.Debugf("%s %s - received a geometry", c.Request.Method, c.FullPath())
 		return geojson.NewFeature(geometry.Geometry()), nil
 	}
 
 	feature, err := geojson.UnmarshalFeature(bodyBytes)
 	if err == nil {
+		log.Debugf("%s %s - received a feature", c.Request.Method, c.FullPath())
 		return feature, nil
 	}
 
 	var golbatFance *GeofenceApi
 	err = json.Unmarshal(bodyBytes, &golbatFance)
 	if err == nil {
+		log.Debugf("%s %s - received a fence", c.Request.Method, c.FullPath())
 		return golbatFance.toGeofence().toFeature(), err
 	}
 

--- a/geo/location.go
+++ b/geo/location.go
@@ -7,6 +7,11 @@ type Location struct {
 	Longitude float64
 }
 
+type ApiLocation struct {
+	Latitude  float64 `json:"lat"`
+	Longitude float64 `json:"lon"`
+}
+
 func (l Location) Tuple() (float64, float64) {
 	return l.Latitude, l.Longitude
 }
@@ -30,4 +35,8 @@ func SplitRoute(route []Location, parts int) [][]Location {
 	routes = append(routes, route[startSplit:])
 
 	return routes
+}
+
+func (l ApiLocation) ToLocation() Location {
+	return Location{l.Latitude, l.Longitude}
 }


### PR DESCRIPTION
This extends the existing API endpoints to also support sending a Feature or a Geometry object in the request body. Should maintain 100% backwards compatibility with the added function that normalizes the request body into a Feature. 

- Moves the ApiLocation / ApiGeofence structs into more appropriate places (why are these even separate structs?)
- Converts all pokestop related SQL to use geojson functions instead