### PR TITLE
fix: rework RemoveQuests to run in bulks

### DIFF
--- a/db/pokestop.go
+++ b/db/pokestop.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	log "github.com/sirupsen/logrus"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/paulmach/orb/geojson"
@@ -50,6 +52,7 @@ func GetPokestopPositions(db DbDetails, fence *geojson.Feature) ([]QuestLocation
 }
 
 func RemoveQuests(ctx context.Context, db DbDetails, fence *geojson.Feature) (int64, error) {
+	started := time.Now()
 	const updateChunkSize = 500
 
 	//goland:noinspection GoPreferNilSlice
@@ -130,6 +133,10 @@ func RemoveQuests(ctx context.Context, db DbDetails, fence *geojson.Feature) (in
 		removedQuestsCount += rowsAffected
 	}
 
+	log.Infof(
+		"RemoveQuests for fence inside %f,%f,%f,%f bbox took %s",
+		bbox.Min.Lat(), bbox.Min.Lon(), bbox.Max.Lat(), bbox.Max.Lon(), time.Since(started),
+	)
 	statsCollector.IncDbQuery("remove quests", err)
 	return removedQuestsCount, err
 }

--- a/db/pokestop.go
+++ b/db/pokestop.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/paulmach/orb/geojson"
@@ -48,38 +49,89 @@ func GetPokestopPositions(db DbDetails, fence *geojson.Feature) ([]QuestLocation
 	return areas, nil
 }
 
-func RemoveQuests(ctx context.Context, db DbDetails, fence *geojson.Feature) (sql.Result, error) {
+func RemoveQuests(ctx context.Context, db DbDetails, fence *geojson.Feature) (int64, error) {
+	const updateChunkSize = 500
+
+	//goland:noinspection GoPreferNilSlice
+	allIdsToUpdate := []string{}
+	var removedQuestsCount int64
+
 	bbox := fence.Geometry.Bound()
 	bytes, err := fence.MarshalJSON()
 	if err != nil {
-		return nil, err
+		statsCollector.IncDbQuery("remove quests", err)
+		return removedQuestsCount, err
 	}
 
-	query := "UPDATE pokestop " +
-		"SET " +
-		"quest_type = NULL," +
-		"quest_timestamp = NULL," +
-		"quest_target = NULL," +
-		"quest_conditions = NULL," +
-		"quest_rewards = NULL," +
-		"quest_template = NULL," +
-		"quest_title = NULL, " +
-		"quest_expiry = NULL, " +
-		"alternative_quest_type = NULL," +
-		"alternative_quest_timestamp = NULL," +
-		"alternative_quest_target = NULL," +
-		"alternative_quest_conditions = NULL," +
-		"alternative_quest_rewards = NULL," +
-		"alternative_quest_template = NULL," +
-		"alternative_quest_title = NULL, " +
-		"alternative_quest_expiry = NULL " +
-		"WHERE lat > ? and lon > ? and lat < ? and lon < ? and enabled = 1 " +
-		"and ST_CONTAINS(ST_GeomFromGeoJSON('" + string(bytes) + "', 2, 0), POINT(lon, lat))"
-	res, err := db.GeneralDb.ExecContext(ctx, query,
-		bbox.Min.Lat(), bbox.Min.Lon(), bbox.Max.Lat(), bbox.Max.Lon())
+	// collect allIdsToUpdate
+	err = db.GeneralDb.Select(&allIdsToUpdate,
+		"SELECT `id` FROM `pokestop` "+
+			"WHERE lat >= ? and lon >= ? and lat <= ? and lon <= ? and enabled = 1 "+
+			"AND ST_CONTAINS(ST_GeomFromGeoJSON('"+string(bytes)+"', 2, 0), POINT(lon, lat))",
+		bbox.Min.Lat(), bbox.Min.Lon(), bbox.Max.Lat(), bbox.Max.Lon(),
+	)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		statsCollector.IncDbQuery("remove quests", err)
+		return removedQuestsCount, nil
+	}
+
+	if err != nil {
+		statsCollector.IncDbQuery("remove quests", err)
+		return removedQuestsCount, err
+	}
+
+	for {
+		// take at most updateChunkSize elements from allIdsToUpdate
+		updateIdsCount := len(allIdsToUpdate)
+
+		if updateIdsCount == 0 {
+			break
+		}
+
+		if updateIdsCount > updateChunkSize {
+			updateIdsCount = updateChunkSize
+		}
+
+		updateIds := allIdsToUpdate[:updateIdsCount]
+
+		// remove processed elements from allIdsToUpdate
+		allIdsToUpdate = allIdsToUpdate[updateIdsCount:]
+
+		query, args, _ := sqlx.In("UPDATE pokestop "+
+			"SET "+
+			"quest_type = NULL,"+
+			"quest_timestamp = NULL,"+
+			"quest_target = NULL,"+
+			"quest_conditions = NULL,"+
+			"quest_rewards = NULL,"+
+			"quest_template = NULL,"+
+			"quest_title = NULL, "+
+			"quest_expiry = NULL, "+
+			"alternative_quest_type = NULL,"+
+			"alternative_quest_timestamp = NULL,"+
+			"alternative_quest_target = NULL,"+
+			"alternative_quest_conditions = NULL,"+
+			"alternative_quest_rewards = NULL,"+
+			"alternative_quest_template = NULL,"+
+			"alternative_quest_title = NULL, "+
+			"alternative_quest_expiry = NULL "+
+			"WHERE id IN (?)", updateIds)
+
+		query = db.GeneralDb.Rebind(query)
+		res, err := db.GeneralDb.ExecContext(ctx, query, args...)
+
+		if err != nil {
+			statsCollector.IncDbQuery("remove quests", err)
+			return removedQuestsCount, err
+		}
+
+		rowsAffected, _ := res.RowsAffected()
+		removedQuestsCount += rowsAffected
+	}
 
 	statsCollector.IncDbQuery("remove quests", err)
-	return res, err
+	return removedQuestsCount, err
 }
 
 func FindOldPokestops(ctx context.Context, db DbDetails, cellId int64) ([]string, error) {

--- a/db/pokestop.go
+++ b/db/pokestop.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	log "github.com/sirupsen/logrus"
-	"time"
-
 	"github.com/jmoiron/sqlx"
 	"github.com/paulmach/orb/geojson"
 )
@@ -52,7 +49,6 @@ func GetPokestopPositions(db DbDetails, fence *geojson.Feature) ([]QuestLocation
 }
 
 func RemoveQuests(ctx context.Context, db DbDetails, fence *geojson.Feature) (int64, error) {
-	started := time.Now()
 	const updateChunkSize = 500
 
 	//goland:noinspection GoPreferNilSlice
@@ -133,10 +129,6 @@ func RemoveQuests(ctx context.Context, db DbDetails, fence *geojson.Feature) (in
 		removedQuestsCount += rowsAffected
 	}
 
-	log.Infof(
-		"RemoveQuests for fence inside %f,%f,%f,%f bbox took %s",
-		bbox.Min.Lat(), bbox.Min.Lon(), bbox.Max.Lat(), bbox.Max.Lon(), time.Since(started),
-	)
 	statsCollector.IncDbQuery("remove quests", err)
 	return removedQuestsCount, err
 }

--- a/decoder/pokestop.go
+++ b/decoder/pokestop.go
@@ -896,13 +896,12 @@ func UpdatePokestopWithQuest(ctx context.Context, db db.DbDetails, quest *pogo.F
 }
 
 func ClearQuestsWithinGeofence(ctx context.Context, dbDetails db.DbDetails, geofence *geojson.Feature) {
-	res, err := db.RemoveQuests(ctx, dbDetails, geofence)
+	rows, err := db.RemoveQuests(ctx, dbDetails, geofence)
 	if err != nil {
 		log.Errorf("ClearQuest: Error removing quests: %s", err)
 		return
 	}
 	ClearPokestopCache()
-	rows, _ := res.RowsAffected()
 	log.Infof("ClearQuest: Removed quests from %d pokestops", rows)
 }
 

--- a/decoder/pokestop.go
+++ b/decoder/pokestop.go
@@ -896,13 +896,14 @@ func UpdatePokestopWithQuest(ctx context.Context, db db.DbDetails, quest *pogo.F
 }
 
 func ClearQuestsWithinGeofence(ctx context.Context, dbDetails db.DbDetails, geofence *geojson.Feature) {
+	started := time.Now()
 	rows, err := db.RemoveQuests(ctx, dbDetails, geofence)
 	if err != nil {
 		log.Errorf("ClearQuest: Error removing quests: %s", err)
 		return
 	}
 	ClearPokestopCache()
-	log.Infof("ClearQuest: Removed quests from %d pokestops", rows)
+	log.Infof("ClearQuest: Removed quests from %d pokestops in %s", rows, time.Since(started))
 }
 
 func GetQuestStatusWithGeofence(dbDetails db.DbDetails, geofence *geojson.Feature) db.QuestStatus {


### PR DESCRIPTION
Rework `RemoveQuests` to run in bulks of 500.

Working

> INFO 2023-12-27 22:37:49 RemoveQuests for fence inside ... bbox took 47.302689ms
INFO 2023-12-27 22:37:49 ClearQuest: Removed quests from 530 pokestops