### PR TITLE
Truncate route description

### DIFF
--- a/util/truncate.go
+++ b/util/truncate.go
@@ -1,0 +1,20 @@
+package util
+
+import "unicode/utf8"
+
+// TruncateUTF8 truncates a string to contain a
+// maximum number of runes, truncating on rune boundary.
+// Returns true if the returned string is possibly different
+// than the passed-in string.
+func TruncateUTF8(s string, maxRunes int) (string, bool) {
+	if utf8.RuneCountInString(s) > maxRunes {
+		runes := []rune(s)
+		// making double sure
+		if len(runes) > maxRunes {
+			runes = runes[:maxRunes]
+		}
+		s = string(runes)
+		return s, true
+	}
+	return s, false
+}


### PR DESCRIPTION
I'm seeing a number of these:

```
ERRO 2024-01-13 14:26:18 Failed to decode route insert route error: Error 1406 (22001): Data too long for column 'description' at row 1
```

Rather than increase the VARCHAR(255) at this time, I've chosen to just truncate the description and log info about it. Truncating unicode correctly is a bit of fun.

Fixes #204