### PR TITLE
rework showcase to support buddy focus requirements

### DIFF
--- a/decoder/pokestop.go
+++ b/decoder/pokestop.go
@@ -61,6 +61,7 @@ type Pokestop struct {
 	AlternativeQuestTitle      null.String `db:"alternative_quest_title" json:"alternative_quest_title"`
 	AlternativeQuestExpiry     null.Int    `db:"alternative_quest_expiry" json:"alternative_quest_expiry"`
 	Description                null.String `db:"description" json:"description"`
+	ShowcaseFocus              null.String `db:"showcase_focus" json:"showcase_focus"`
 	ShowcasePokemon            null.Int    `db:"showcase_pokemon_id" json:"showcase_pokemon_id"`
 	ShowcasePokemonForm        null.Int    `db:"showcase_pokemon_form_id" json:"showcase_pokemon_form_id"`
 	ShowcasePokemonType        null.Int    `db:"showcase_pokemon_type_id" json:"showcase_pokemon_type_id"`
@@ -184,9 +185,7 @@ func hasChangesPokestop(old *Pokestop, new *Pokestop) bool {
 		!floatAlmostEqual(old.Lat, new.Lat, floatTolerance) ||
 		!floatAlmostEqual(old.Lon, new.Lon, floatTolerance) ||
 		old.ShowcaseRankingStandard != new.ShowcaseRankingStandard ||
-		old.ShowcasePokemon != new.ShowcasePokemon ||
-		old.ShowcasePokemonForm != new.ShowcasePokemonForm ||
-		old.ShowcasePokemonType != new.ShowcasePokemonType ||
+		old.ShowcaseFocus != new.ShowcaseFocus ||
 		old.ShowcaseRankings != new.ShowcaseRankings ||
 		old.ShowcaseExpiry != new.ShowcaseExpiry
 }
@@ -566,54 +565,21 @@ func (stop *Pokestop) updatePokestopFromGetContestDataOutProto(contest *pogo.Con
 	stop.ShowcaseRankingStandard = null.IntFrom(int64(contest.GetMetric().GetRankingStandard()))
 	stop.ShowcaseExpiry = null.IntFrom(contest.GetSchedule().GetContestCycle().GetEndTimeMs() / 1000)
 
-	// Focuses is used now and populates the new 'RequireFormToMatch' field, which
-	// Focus does not populate. We can only store 1 atm, so this just grabs the first
-	// if there is one and falls back to Focus if Focuses is empty, just in case.
-	var focussedPokemon *pogo.ContestPokemonFocusProto
-	var focussedPokemonType *pogo.ContestFocusProto
+	focusStore := createFocusStoreFromContestProto(contest)
 
-	if focuses := contest.GetFocuses(); len(focuses) > 0 {
-		var numPokemon int
-
-		for _, focus := range focuses {
-			if pok := focus.GetPokemon(); pok != nil {
-				if focussedPokemon == nil {
-					focussedPokemon = pok
-				}
-				numPokemon++
-			}
-
-			if pokType := focus.GetType(); pokType != nil {
-				if focussedPokemonType == nil {
-					focussedPokemonType = focus
-				}
-			}
-		}
-		if l := len(focuses); l > 1 {
-			log.Warnf("pokestop '%s' contains %d focus entries (%d pokemon): using the first pokemon found",
-				stop.Id, l, numPokemon,
-			)
-		}
-	} else {
-		focussedPokemon = contest.GetFocus().GetPokemon()
+	if len(focusStore) > 1 {
+		log.Warnf("SHOWCASE: we got more than one showcase focus: %v", focusStore)
 	}
 
-	if focussedPokemon == nil {
-		stop.ShowcasePokemon = null.IntFromPtr(nil)
-		stop.ShowcasePokemonForm = null.IntFromPtr(nil)
-	} else {
-		stop.ShowcasePokemon = null.IntFrom(int64(focussedPokemon.GetPokedexId()))
-		if focussedPokemon.RequireFormToMatch {
-			stop.ShowcasePokemonForm = null.IntFrom(int64(focussedPokemon.GetPokemonDisplay().GetForm()))
-		} else {
-			stop.ShowcasePokemonForm = null.IntFromPtr(nil)
+	for key, focus := range focusStore {
+		focus["type"] = key
+		jsonBytes, err := json.Marshal(focus)
+		if err != nil {
+			log.Errorf("SHOWCASE: Stop '%s' - Focus '%v' marshalling failed: %s", stop.Id, focus, err)
 		}
-	}
-
-	if focussedPokemonType == nil {
-		stop.ShowcasePokemonType = null.IntFromPtr(nil)
-	} else {
-		stop.ShowcasePokemonType = null.IntFrom(int64(focussedPokemonType.GetType().GetPokemonType1()))
+		stop.ShowcaseFocus = null.StringFrom(string(jsonBytes))
+		// still support old format - probably still required to filter in external tools
+		stop.extractShowcasePokemonInfoDeprecated(key, focus)
 	}
 }
 
@@ -753,6 +719,7 @@ func createPokestopWebhooks(oldStop *Pokestop, stop *Pokestop) {
 			"power_up_points":           stop.PowerUpPoints.ValueOrZero(),
 			"power_up_end_timestamp":    stop.PowerUpPoints.ValueOrZero(),
 			"updated":                   stop.Updated,
+			"showcase_focus":            stop.ShowcaseFocus,
 			"showcase_pokemon_id":       stop.ShowcasePokemon,
 			"showcase_pokemon_form_id":  stop.ShowcasePokemonForm,
 			"showcase_pokemon_type_id":  stop.ShowcasePokemonType,
@@ -785,27 +752,27 @@ func savePokestopRecord(ctx context.Context, db db.DbDetails, pokestop *Pokestop
 	//log.Traceln(cmp.Diff(oldPokestop, pokestop))
 
 	if oldPokestop == nil {
-		res, err := db.GeneralDb.NamedExecContext(ctx,
-			"INSERT INTO pokestop ("+
-				"id, lat, lon, name, url, enabled, lure_expire_timestamp, last_modified_timestamp, quest_type,"+
-				"quest_timestamp, quest_target, quest_conditions, quest_rewards, quest_template, quest_title,"+
-				"alternative_quest_type, alternative_quest_timestamp, alternative_quest_target,"+
-				"alternative_quest_conditions, alternative_quest_rewards, alternative_quest_template,"+
-				"alternative_quest_title, cell_id, lure_id, sponsor_id, partner_id, ar_scan_eligible,"+
-				"power_up_points, power_up_level, power_up_end_timestamp, updated, first_seen_timestamp,"+
-				"quest_expiry, alternative_quest_expiry, description, showcase_pokemon_id,"+
-				"showcase_pokemon_form_id, showcase_pokemon_type_id, showcase_ranking_standard, showcase_expiry, showcase_rankings"+
-				")"+
-				"VALUES ("+
-				":id, :lat, :lon, :name, :url, :enabled, :lure_expire_timestamp, :last_modified_timestamp, :quest_type,"+
-				":quest_timestamp, :quest_target, :quest_conditions, :quest_rewards, :quest_template, :quest_title,"+
-				":alternative_quest_type, :alternative_quest_timestamp, :alternative_quest_target,"+
-				":alternative_quest_conditions, :alternative_quest_rewards, :alternative_quest_template,"+
-				":alternative_quest_title, :cell_id, :lure_id, :sponsor_id, :partner_id, :ar_scan_eligible,"+
-				":power_up_points, :power_up_level, :power_up_end_timestamp,"+
-				"UNIX_TIMESTAMP(), UNIX_TIMESTAMP(),"+
-				":quest_expiry, :alternative_quest_expiry, :description, :showcase_pokemon_id,"+
-				":showcase_pokemon_form_id, :showcase_pokemon_type_id, :showcase_ranking_standard, :showcase_expiry, :showcase_rankings)",
+		res, err := db.GeneralDb.NamedExecContext(ctx, `
+			INSERT INTO pokestop (
+				id, lat, lon, name, url, enabled, lure_expire_timestamp, last_modified_timestamp, quest_type,
+				quest_timestamp, quest_target, quest_conditions, quest_rewards, quest_template, quest_title,
+				alternative_quest_type, alternative_quest_timestamp, alternative_quest_target,
+				alternative_quest_conditions, alternative_quest_rewards, alternative_quest_template,
+				alternative_quest_title, cell_id, lure_id, sponsor_id, partner_id, ar_scan_eligible,
+				power_up_points, power_up_level, power_up_end_timestamp, updated, first_seen_timestamp,
+				quest_expiry, alternative_quest_expiry, description, showcase_focus, showcase_pokemon_id,
+				showcase_pokemon_form_id, showcase_pokemon_type_id, showcase_ranking_standard, showcase_expiry, showcase_rankings
+				)
+				VALUES (
+				:id, :lat, :lon, :name, :url, :enabled, :lure_expire_timestamp, :last_modified_timestamp, :quest_type,
+				:quest_timestamp, :quest_target, :quest_conditions, :quest_rewards, :quest_template, :quest_title,
+				:alternative_quest_type, :alternative_quest_timestamp, :alternative_quest_target,
+				:alternative_quest_conditions, :alternative_quest_rewards, :alternative_quest_template,
+				:alternative_quest_title, :cell_id, :lure_id, :sponsor_id, :partner_id, :ar_scan_eligible,
+				:power_up_points, :power_up_level, :power_up_end_timestamp,
+				UNIX_TIMESTAMP(), UNIX_TIMESTAMP(),
+				:quest_expiry, :alternative_quest_expiry, :description, :showcase_focus, :showcase_pokemon_id,
+				:showcase_pokemon_form_id, :showcase_pokemon_type_id, :showcase_ranking_standard, :showcase_expiry, :showcase_rankings)`,
 			pokestop)
 
 		statsCollector.IncDbQuery("insert pokestop", err)
@@ -816,49 +783,50 @@ func savePokestopRecord(ctx context.Context, db db.DbDetails, pokestop *Pokestop
 		}
 		_ = res
 	} else {
-		res, err := db.GeneralDb.NamedExecContext(ctx,
-			"UPDATE pokestop SET "+
-				"lat = :lat,"+
-				"lon = :lon,"+
-				"name = :name,"+
-				"url = :url,"+
-				"enabled = :enabled,"+
-				"lure_expire_timestamp = :lure_expire_timestamp,"+
-				"last_modified_timestamp = :last_modified_timestamp,"+
-				"updated = :updated,"+
-				"quest_type = :quest_type, "+
-				"quest_timestamp = :quest_timestamp, "+
-				"quest_target = :quest_target, "+
-				"quest_conditions = :quest_conditions, "+
-				"quest_rewards = :quest_rewards, "+
-				"quest_template = :quest_template, "+
-				"quest_title = :quest_title,"+
-				"alternative_quest_type = :alternative_quest_type, "+
-				"alternative_quest_timestamp = :alternative_quest_timestamp,"+
-				"alternative_quest_target = :alternative_quest_target, "+
-				"alternative_quest_conditions = :alternative_quest_conditions, "+
-				"alternative_quest_rewards = :alternative_quest_rewards,"+
-				"alternative_quest_template = :alternative_quest_template,"+
-				"alternative_quest_title = :alternative_quest_title,"+
-				"cell_id = :cell_id,"+
-				"lure_id = :lure_id,"+
-				"deleted = :deleted,"+
-				"sponsor_id = :sponsor_id,"+
-				"partner_id = :partner_id,"+
-				"ar_scan_eligible = :ar_scan_eligible,"+
-				"power_up_points = :power_up_points,"+
-				"power_up_level = :power_up_level,"+
-				"power_up_end_timestamp = :power_up_end_timestamp,"+
-				"quest_expiry = :quest_expiry,"+
-				"alternative_quest_expiry = :alternative_quest_expiry,"+
-				"description = :description,"+
-				"showcase_pokemon_id = :showcase_pokemon_id,"+
-				"showcase_pokemon_form_id = :showcase_pokemon_form_id,"+
-				"showcase_pokemon_type_id = :showcase_pokemon_type_id,"+
-				"showcase_ranking_standard = :showcase_ranking_standard,"+
-				"showcase_expiry = :showcase_expiry,"+
-				"showcase_rankings = :showcase_rankings"+
-				" WHERE id = :id",
+		res, err := db.GeneralDb.NamedExecContext(ctx, `
+			UPDATE pokestop SET
+				lat = :lat,
+				lon = :lon,
+				name = :name,
+				url = :url,
+				enabled = :enabled,
+				lure_expire_timestamp = :lure_expire_timestamp,
+				last_modified_timestamp = :last_modified_timestamp,
+				updated = :updated,
+				quest_type = :quest_type, 
+				quest_timestamp = :quest_timestamp, 
+				quest_target = :quest_target, 
+				quest_conditions = :quest_conditions, 
+				quest_rewards = :quest_rewards, 
+				quest_template = :quest_template, 
+				quest_title = :quest_title,
+				alternative_quest_type = :alternative_quest_type, 
+				alternative_quest_timestamp = :alternative_quest_timestamp,
+				alternative_quest_target = :alternative_quest_target, 
+				alternative_quest_conditions = :alternative_quest_conditions, 
+				alternative_quest_rewards = :alternative_quest_rewards,
+				alternative_quest_template = :alternative_quest_template,
+				alternative_quest_title = :alternative_quest_title,
+				cell_id = :cell_id,
+				lure_id = :lure_id,
+				deleted = :deleted,
+				sponsor_id = :sponsor_id,
+				partner_id = :partner_id,
+				ar_scan_eligible = :ar_scan_eligible,
+				power_up_points = :power_up_points,
+				power_up_level = :power_up_level,
+				power_up_end_timestamp = :power_up_end_timestamp,
+				quest_expiry = :quest_expiry,
+				alternative_quest_expiry = :alternative_quest_expiry,
+				description = :description,
+				showcase_focus = :showcase_focus,
+				showcase_pokemon_id = :showcase_pokemon_id,
+				showcase_pokemon_form_id = :showcase_pokemon_form_id,
+				showcase_pokemon_type_id = :showcase_pokemon_type_id,
+				showcase_ranking_standard = :showcase_ranking_standard,
+				showcase_expiry = :showcase_expiry,
+				showcase_rankings = :showcase_rankings
+			WHERE id = :id`,
 			pokestop,
 		)
 		statsCollector.IncDbQuery("update pokestop", err)

--- a/decoder/pokestop_showcase.go
+++ b/decoder/pokestop_showcase.go
@@ -1,0 +1,130 @@
+package decoder
+
+import (
+	"golbat/pogo"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/guregu/null.v4"
+)
+
+type contestFocusType string
+
+const (
+	focusPokemon          contestFocusType = "pokemon"
+	focusPokemonType      contestFocusType = "type"
+	focusPokemonAlignment contestFocusType = "alignment"
+	focusPokemonClass     contestFocusType = "class"
+	focusPokemonFamily    contestFocusType = "family"
+	focusBuddy            contestFocusType = "buddy"
+	focusGeneration       contestFocusType = "generation"
+	focusHatched          contestFocusType = "hatched"
+	focusMega             contestFocusType = "mega"
+	focusShiny            contestFocusType = "shiny"
+)
+
+func createFocusStoreFromContestProto(contest *pogo.ContestProto) map[contestFocusType]map[string]any {
+	focusStore := make(map[contestFocusType]map[string]any)
+
+	for _, focus := range contest.GetFocuses() {
+		if pok := focus.GetPokemon(); pok != nil {
+			result := make(map[string]any)
+			result["pokemon_id"] = int32(pok.PokedexId)
+			if pok.RequireFormToMatch {
+				result["pokemon_form"] = int32(pok.PokemonDisplay.Form)
+			}
+			focusStore[focusPokemon] = result
+		}
+		if pokType := focus.GetType(); pokType != nil {
+			result := make(map[string]any)
+			result["pokemon_type_1"] = int32(pokType.GetPokemonType1())
+			if type2 := pokType.GetPokemonType2(); type2 != pogo.HoloPokemonType_POKEMON_TYPE_NONE {
+				result["pokemon_type_2"] = int32(type2)
+			}
+			focusStore[focusPokemonType] = result
+		}
+		if alignment := focus.GetAlignment(); alignment != nil {
+			// unset, purified, shadow
+			focusStore[focusPokemonAlignment] = map[string]any{
+				"pokemon_alignment": int32(alignment.GetRequiredAlignment()),
+			}
+		}
+		if pokemonClass := focus.GetPokemonClass(); pokemonClass != nil {
+			// normal, legendary, mythic, ultra beast
+			focusStore[focusPokemonClass] = map[string]any{
+				"pokemon_class": int32(pokemonClass.GetRequiredClass()),
+			}
+		}
+		if pokemonFamily := focus.GetPokemonFamily(); pokemonFamily != nil {
+			// family pikachu, zubat e.g.
+			focusStore[focusPokemonFamily] = map[string]any{
+				"pokemon_family": int32(pokemonFamily.GetRequiredFamily()),
+			}
+		}
+		if buddy := focus.GetBuddy(); buddy != nil {
+			focusStore[focusBuddy] = map[string]any{
+				"min_level": int32(buddy.GetMinBuddyLevel()),
+			}
+		}
+		if generation := focus.GetGeneration(); generation != nil {
+			focusStore[focusGeneration] = map[string]any{
+				"generation": int32(generation.GetPokemonGeneration()),
+			}
+		}
+		if hatched := focus.GetHatched(); hatched != nil {
+			focusStore[focusHatched] = map[string]any{
+				"hatched": hatched.GetRequireToBeHatched(),
+			}
+		}
+		if mega := focus.GetMega(); mega != nil {
+			focusStore[focusMega] = map[string]any{
+				"temp_evolution": int32(mega.GetTemporaryEvolutionRequired()),
+				"restriction":    int32(mega.GetRestriction()),
+			}
+		}
+		if shiny := focus.GetShiny(); shiny != nil {
+			focusStore[focusShiny] = map[string]any{
+				"shiny": shiny.GetRequireToBeShiny(),
+			}
+		}
+	}
+	return focusStore
+}
+
+// Deprecated: to support backward compatibility - can be removed if external tools don't reference it anymore
+// this info is now stored in showcase_focus directly
+func (stop *Pokestop) extractShowcasePokemonInfoDeprecated(key contestFocusType, focus map[string]any) {
+	if key == focusPokemon {
+		if pokemonID, ok := focus["pokemon_id"].(int32); ok {
+			stop.ShowcasePokemon = null.IntFrom(int64(pokemonID))
+		} else {
+			log.Warnf("SHOWCASE: Stop '%s' - Missing or invalid 'pokemon_id'", stop.Id)
+			stop.ShowcasePokemon = null.IntFromPtr(nil)
+		}
+
+		if form, ok := focus["pokemon_form"].(int32); ok {
+			stop.ShowcasePokemonForm = null.IntFrom(int64(form))
+		} else {
+			stop.ShowcasePokemonForm = null.IntFromPtr(nil)
+		}
+	} else {
+		stop.ShowcasePokemon = null.IntFromPtr(nil)
+		stop.ShowcasePokemonForm = null.IntFromPtr(nil)
+	}
+
+	if key == focusPokemonType {
+		if type1, ok := focus["pokemon_type1"].(int32); ok {
+			stop.ShowcasePokemonType = null.IntFrom(int64(type1))
+		} else {
+			log.Warnf("SHOWCASE: Stop '%s' - Missing or invalid 'pokemon_type1'", stop.Id)
+			stop.ShowcasePokemonType = null.IntFromPtr(nil)
+		}
+
+		if type2, ok := focus["pokemon_type_2"].(int32); ok {
+			if type2Int64 := int64(type2); type2Int64 != 0 {
+				log.Warnf("SHOWCASE: Stop: '%s' with Focused Pokemon Type 2: %d", stop.Id, type2Int64)
+			}
+		}
+	} else {
+		stop.ShowcasePokemonType = null.IntFromPtr(nil)
+	}
+}

--- a/sql/39_showcase_focus.down.sql
+++ b/sql/39_showcase_focus.down.sql
@@ -1,0 +1,1 @@
+alter table `pokestop` DROP COLUMN `showcase_focus`;

--- a/sql/39_showcase_focus.up.sql
+++ b/sql/39_showcase_focus.up.sql
@@ -1,0 +1,2 @@
+alter table `pokestop`
+    add `showcase_focus` text DEFAULT NULL AFTER `showcase_pokemon_type_id`;


### PR DESCRIPTION
types:

- pokemon
- type
- alignment
- class
- family
- buddy
- generation
- hatched
- mega
- shiny


Changed the way how we process showcases and those different focuses...

Mid of February 2025 they introduced a buddy min level focus requirement.. This PR will support it

![image](https://github.com/user-attachments/assets/9057e81e-8869-43b3-b055-6e7c82093d6f)

![image](https://github.com/user-attachments/assets/8ec12b5f-8f52-47fa-84c5-ea55cb14240d)

