### PR TITLE
feat: use `min` & `max` in pokemon search api

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -59,6 +59,6 @@ url = "http://localhost:4201"
 #areas = ["London/*", "*/Harrow", "Harrow"]
 
 [tuning]
-max_pokemon_distance = 500  # Maximum distance in kilometers for searching pokemon
+max_pokemon_distance = 100  # Maximum distance in kilometers for searching pokemon
 max_pokemon_results = 3000  # Maximum number of pokemon to return
 extended_timeout = false

--- a/config.toml.example
+++ b/config.toml.example
@@ -31,7 +31,6 @@ password = ""
 address = "127.0.0.1:3306"
 db = ""
 
-
 [pvp]
 enabled = true
 include_hundos_under_cap = false
@@ -58,3 +57,8 @@ url = "http://localhost:4201"
 #url = "http://localhost:4202"
 #types = ["raid"]
 #areas = ["London/*", "*/Harrow", "Harrow"]
+
+[tuning]
+max_distance = 500          # Maximum distance in meters for nearby pokemon
+max_pokemon_results = 3000  # Maximum number of pokemon to return
+extended_timeout = false

--- a/config.toml.example
+++ b/config.toml.example
@@ -59,6 +59,6 @@ url = "http://localhost:4201"
 #areas = ["London/*", "*/Harrow", "Harrow"]
 
 [tuning]
-max_distance = 500          # Maximum distance in meters for nearby pokemon
+max_pokemon_distance = 500  # Maximum distance in kilometers for searching pokemon
 max_pokemon_results = 3000  # Maximum number of pokemon to return
 extended_timeout = false

--- a/config/config.go
+++ b/config/config.go
@@ -111,8 +111,9 @@ type database struct {
 }
 
 type tuning struct {
-	ExtendedTimeout   bool `koanf:"extended_timeout"`
-	MaxPokemonResults int  `koanf:"max_pokemon_results"`
+	ExtendedTimeout   bool    `koanf:"extended_timeout"`
+	MaxPokemonResults int     `koanf:"max_pokemon_results"`
+	MaxDistance       float64 `koanf:"max_distance"`
 }
 
 type scanRule struct {

--- a/config/config.go
+++ b/config/config.go
@@ -111,9 +111,9 @@ type database struct {
 }
 
 type tuning struct {
-	ExtendedTimeout   bool    `koanf:"extended_timeout"`
-	MaxPokemonResults int     `koanf:"max_pokemon_results"`
-	MaxDistance       float64 `koanf:"max_distance"`
+	ExtendedTimeout    bool    `koanf:"extended_timeout"`
+	MaxPokemonResults  int     `koanf:"max_pokemon_results"`
+	MaxPokemonDistance float64 `koanf:"max_pokemon_distance"`
 }
 
 type scanRule struct {

--- a/config/reader.go
+++ b/config/reader.go
@@ -47,8 +47,8 @@ func ReadConfig() (configDefinition, error) {
 			MaxPool: 100,
 		},
 		Tuning: tuning{
-			MaxPokemonResults: 3000,
-			MaxDistance:       500,
+			MaxPokemonResults:  3000,
+			MaxPokemonDistance: 500,
 		},
 		Pvp: pvp{
 			LevelCaps: []int{50, 51},

--- a/config/reader.go
+++ b/config/reader.go
@@ -48,7 +48,7 @@ func ReadConfig() (configDefinition, error) {
 		},
 		Tuning: tuning{
 			MaxPokemonResults:  3000,
-			MaxPokemonDistance: 500,
+			MaxPokemonDistance: 100,
 		},
 		Pvp: pvp{
 			LevelCaps: []int{50, 51},

--- a/config/reader.go
+++ b/config/reader.go
@@ -48,6 +48,7 @@ func ReadConfig() (configDefinition, error) {
 		},
 		Tuning: tuning{
 			MaxPokemonResults: 3000,
+			MaxDistance:       500,
 		},
 		Pvp: pvp{
 			LevelCaps: []int{50, 51},

--- a/decoder/api_pokemon.go
+++ b/decoder/api_pokemon.go
@@ -49,11 +49,12 @@ func GetAvailablePokemon() []*ApiPokemonAvailableResult {
 // Pokemon search
 
 type ApiPokemonSearch struct {
-	Min       geo.Location `json:"min"`
-	Max       geo.Location `json:"max"`
-	Center    geo.Location `json:"center"`
-	Limit     int          `json:"limit"`
-	SearchIds []int16      `json:"searchIds"`
+	Min         geo.Location `json:"min"`
+	Max         geo.Location `json:"max"`
+	Center      geo.Location `json:"center"`
+	Limit       int          `json:"limit"`
+	SearchIds   []int16      `json:"searchIds"`
+	MaxDistance float64      `json:"maxDistance"`
 }
 
 func SearchPokemon(request ApiPokemonSearch) []*Pokemon {
@@ -75,7 +76,10 @@ func SearchPokemon(request ApiPokemonSearch) []*Pokemon {
 	}
 	pokemonSkipped := 0
 	pokemonScanned := 0
-	maxDistance := float64(1000) // This should come from the request?
+	maxDistance := request.MaxDistance
+	if maxDistance == 0 {
+		maxDistance = float64(1000)
+	}
 
 	pokemonTree2.Nearby(
 		rtree.BoxDist[float64, uint64]([2]float64{request.Center.Longitude, request.Center.Latitude}, [2]float64{request.Center.Longitude, request.Center.Latitude}, nil),

--- a/decoder/api_pokemon.go
+++ b/decoder/api_pokemon.go
@@ -1,6 +1,7 @@
 package decoder
 
 import (
+	"fmt"
 	"golbat/config"
 	"golbat/geo"
 	"math"
@@ -11,6 +12,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/rtree"
 )
+
+const earthRadiusKm = 6371
 
 type ApiPokemonAvailableResult struct {
 	PokemonId int16 `json:"id"`
@@ -63,13 +66,34 @@ func calculateHypotenuse(a, b float64) float64 {
 	return math.Sqrt(a*a + b*b)
 }
 
-func SearchPokemon(request ApiPokemonSearch) []*Pokemon {
+func toRadians(deg float64) float64 {
+	return deg * math.Pi / 180
+}
+
+func haversine(start, end geo.Location) float64 {
+	lat1Rad := toRadians(start.Latitude)
+	lat2Rad := toRadians(end.Latitude)
+	deltaLat := toRadians(end.Latitude - start.Latitude)
+	deltaLon := toRadians(end.Longitude - start.Longitude)
+
+	a := math.Sin(deltaLat/2)*math.Sin(deltaLat/2) +
+		math.Cos(lat1Rad)*math.Cos(lat2Rad)*
+			math.Sin(deltaLon/2)*math.Sin(deltaLon/2)
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+
+	return earthRadiusKm * c
+}
+
+func SearchPokemon(request ApiPokemonSearch) ([]*Pokemon, error) {
 	start := time.Now()
 	results := make([]*Pokemon, 0, request.Limit)
 	pokemonMatched := 0
 
 	if request.SearchIds == nil {
-		return nil
+		return nil, fmt.Errorf("SearchPokemon - no search ids provided")
+	}
+	if haversine(request.Min, request.Max) > config.Config.Tuning.MaxPokemonDistance {
+		return nil, fmt.Errorf("SearchPokemon - the distance between max and min points is greater than the configurable max distance")
 	}
 
 	pokemonTreeMutex.RLock()
@@ -83,11 +107,9 @@ func SearchPokemon(request ApiPokemonSearch) []*Pokemon {
 	pokemonSkipped := 0
 	pokemonScanned := 0
 	maxDistance := calculateHypotenuse(request.Max.Longitude-request.Min.Longitude, request.Max.Latitude-request.Min.Latitude) / 2
-	// request.MaxDistance
-	// if maxDistance == 0 || maxDistance > config.Config.Tuning.MaxPokemonDistance {
-	// 	maxDistance = config.Config.Tuning.MaxPokemonDistance
-	// }
-
+	if maxDistance == 0 {
+		maxDistance = 10
+	}
 	pokemonTree2.Nearby(
 		rtree.BoxDist[float64, uint64]([2]float64{request.Center.Longitude, request.Center.Latitude}, [2]float64{request.Center.Longitude, request.Center.Latitude}, nil),
 		func(min, max [2]float64, pokemonId uint64, dist float64) bool {
@@ -124,7 +146,7 @@ func SearchPokemon(request ApiPokemonSearch) []*Pokemon {
 	)
 
 	log.Infof("SearchPokemon - scanned %d pokemon, total time %s, %d returned", pokemonScanned, time.Since(start), len(results))
-	return results
+	return results, nil
 }
 
 // Get one result

--- a/decoder/api_pokemon.go
+++ b/decoder/api_pokemon.go
@@ -54,12 +54,11 @@ func GetAvailablePokemon() []*ApiPokemonAvailableResult {
 // Pokemon search
 
 type ApiPokemonSearch struct {
-	Min         geo.Location `json:"min"`
-	Max         geo.Location `json:"max"`
-	Center      geo.Location `json:"center"`
-	Limit       int          `json:"limit"`
-	SearchIds   []int16      `json:"searchIds"`
-	MaxDistance float64      `json:"maxDistance"`
+	Min       geo.Location `json:"min"`
+	Max       geo.Location `json:"max"`
+	Center    geo.Location `json:"center"`
+	Limit     int          `json:"limit"`
+	SearchIds []int16      `json:"searchIds"`
 }
 
 func calculateHypotenuse(a, b float64) float64 {

--- a/decoder/api_pokemon.go
+++ b/decoder/api_pokemon.go
@@ -17,8 +17,6 @@ type ApiPokemonAvailableResult struct {
 	Count     int   `json:"count"`
 }
 
-const earthRadiusKm = 6371
-
 func GetAvailablePokemon() []*ApiPokemonAvailableResult {
 	type pokemonFormKey struct {
 		pokemonId int16

--- a/decoder/api_pokemon.go
+++ b/decoder/api_pokemon.go
@@ -77,8 +77,8 @@ func SearchPokemon(request ApiPokemonSearch) []*Pokemon {
 	pokemonSkipped := 0
 	pokemonScanned := 0
 	maxDistance := request.MaxDistance
-	if maxDistance == 0 {
-		maxDistance = float64(1000)
+	if maxDistance == 0 || maxDistance > config.Config.Tuning.MaxDistance {
+		maxDistance = config.Config.Tuning.MaxDistance
 	}
 
 	pokemonTree2.Nearby(

--- a/routes.go
+++ b/routes.go
@@ -422,7 +422,12 @@ func PokemonSearch(c *gin.Context) {
 		return
 	}
 
-	res := decoder.SearchPokemon(requestBody)
+	res, err := decoder.SearchPokemon(requestBody)
+	if err != nil {
+		log.Warnf("POST /api/search/ Error during post search %v", err)
+		c.Status(http.StatusBadRequest)
+		return
+	}
 	c.JSON(http.StatusAccepted, res)
 }
 


### PR DESCRIPTION
This makes use of the previously ignored `min` and `max` location arguments.

It does a one time haversine comparison between the two points sent in the API request to ensure the distance is shorter than the new config value `tuning.max_pokemon_distance`. 

After the check, it uses the Pythagorean theorem to calculate the box-dist between the two points for comparison with the Pokemon's distance from the center point.  