### PR TITLE
Bump go requiremment to 1.22

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version: '1.22.x'
       - name: Install dependencies
         run: go get .
       - name: Test with the Go CLI

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.21-alpine as build
+FROM golang:1.22-alpine as build
 
 WORKDIR /go/src/app
 COPY go.mod go.sum ./

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ At this time this is likely to be mostly development discussion.
 
 # Requirements
 
-[go 1.21](https://go.dev/doc/install)
+[go 1.22](https://go.dev/doc/install)
 
 # Instructions
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module golbat
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Depado/ginprom v1.8.0


### PR DESCRIPTION
This bumps golang requirement to 1.22.

1.22.1 is out now and while it doesn't appear that we have any workaround for 'for loop variable scope' in Golbat (unless my search failed me)...it would be nice to not have to worry about it going forward.

There's also a new sql.Null generic. And also 'for i := range <integer>' to range from 0 to <integer>-1.

Supposedly memory performance is improved, also.