### PR TITLE
Add /debug/pprof routes

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -62,3 +62,4 @@ url = "http://localhost:4201"
 max_pokemon_distance = 100  # Maximum distance in kilometers for searching pokemon
 max_pokemon_results = 3000  # Maximum number of pokemon to return
 extended_timeout = false
+profile_routes = false

--- a/config/config.go
+++ b/config/config.go
@@ -114,6 +114,7 @@ type tuning struct {
 	ExtendedTimeout    bool    `koanf:"extended_timeout"`
 	MaxPokemonResults  int     `koanf:"max_pokemon_results"`
 	MaxPokemonDistance float64 `koanf:"max_pokemon_distance"`
+	ProfileRoutes      bool    `koanf:"profile_routes"`
 }
 
 type scanRule struct {

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"strings"
 	"sync"
 	"time"
@@ -275,6 +276,30 @@ func main() {
 	apiGroup.POST("/pokemon/search", PokemonSearch)
 
 	apiGroup.GET("/devices/all", GetDevices)
+
+	debugGroup := r.Group("/debug")
+	pprofGroup := debugGroup.Group("/pprof")
+	pprofGroup.GET("/cmdline", func(c *gin.Context) {
+		pprof.Cmdline(c.Writer, c.Request)
+	})
+	pprofGroup.GET("/heap", func(c *gin.Context) {
+		pprof.Index(c.Writer, c.Request)
+	})
+	pprofGroup.GET("/block", func(c *gin.Context) {
+		pprof.Index(c.Writer, c.Request)
+	})
+	pprofGroup.GET("/mutex", func(c *gin.Context) {
+		pprof.Index(c.Writer, c.Request)
+	})
+	pprofGroup.GET("/trace", func(c *gin.Context) {
+		pprof.Trace(c.Writer, c.Request)
+	})
+	pprofGroup.GET("/profile", func(c *gin.Context) {
+		pprof.Profile(c.Writer, c.Request)
+	})
+	pprofGroup.GET("/symbol", func(c *gin.Context) {
+		pprof.Symbol(c.Writer, c.Request)
+	})
 
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", cfg.Port),

--- a/main.go
+++ b/main.go
@@ -278,7 +278,7 @@ func main() {
 	apiGroup.GET("/devices/all", GetDevices)
 
 	debugGroup := r.Group("/debug")
-	pprofGroup := debugGroup.Group("/pprof")
+	pprofGroup := debugGroup.Group("/pprof", AuthRequired())
 	pprofGroup.GET("/cmdline", func(c *gin.Context) {
 		pprof.Cmdline(c.Writer, c.Request)
 	})

--- a/main.go
+++ b/main.go
@@ -278,28 +278,31 @@ func main() {
 	apiGroup.GET("/devices/all", GetDevices)
 
 	debugGroup := r.Group("/debug")
-	pprofGroup := debugGroup.Group("/pprof", AuthRequired())
-	pprofGroup.GET("/cmdline", func(c *gin.Context) {
-		pprof.Cmdline(c.Writer, c.Request)
-	})
-	pprofGroup.GET("/heap", func(c *gin.Context) {
-		pprof.Index(c.Writer, c.Request)
-	})
-	pprofGroup.GET("/block", func(c *gin.Context) {
-		pprof.Index(c.Writer, c.Request)
-	})
-	pprofGroup.GET("/mutex", func(c *gin.Context) {
-		pprof.Index(c.Writer, c.Request)
-	})
-	pprofGroup.GET("/trace", func(c *gin.Context) {
-		pprof.Trace(c.Writer, c.Request)
-	})
-	pprofGroup.GET("/profile", func(c *gin.Context) {
-		pprof.Profile(c.Writer, c.Request)
-	})
-	pprofGroup.GET("/symbol", func(c *gin.Context) {
-		pprof.Symbol(c.Writer, c.Request)
-	})
+
+	if cfg.Tuning.ProfileRoutes {
+		pprofGroup := debugGroup.Group("/pprof", AuthRequired())
+		pprofGroup.GET("/cmdline", func(c *gin.Context) {
+			pprof.Cmdline(c.Writer, c.Request)
+		})
+		pprofGroup.GET("/heap", func(c *gin.Context) {
+			pprof.Index(c.Writer, c.Request)
+		})
+		pprofGroup.GET("/block", func(c *gin.Context) {
+			pprof.Index(c.Writer, c.Request)
+		})
+		pprofGroup.GET("/mutex", func(c *gin.Context) {
+			pprof.Index(c.Writer, c.Request)
+		})
+		pprofGroup.GET("/trace", func(c *gin.Context) {
+			pprof.Trace(c.Writer, c.Request)
+		})
+		pprofGroup.GET("/profile", func(c *gin.Context) {
+			pprof.Profile(c.Writer, c.Request)
+		})
+		pprofGroup.GET("/symbol", func(c *gin.Context) {
+			pprof.Symbol(c.Writer, c.Request)
+		})
+	}
 
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", cfg.Port),


### PR DESCRIPTION
This is copy/pasta from Fletchling which adds the /debug/pprof routes to the gin router. These routes can be used by 'go tool pprof' or curling directly to store profile data.

This will allow us to download profile data to use for 'pgo'.

(https://go.dev/blog/pgo) (https://go.dev/doc/pgo)