### PR TITLE
feat: missing quest api endpoint

### DIFF
--- a/decoder/pokestop.go
+++ b/decoder/pokestop.go
@@ -946,6 +946,15 @@ func GetQuestStatusWithGeofence(dbDetails db.DbDetails, geofence *geojson.Featur
 	return res
 }
 
+func GetPokestopsWithMissingQuests(dbDetails db.DbDetails, geofence *geojson.Feature) []db.QuestLocation {
+	res, err := db.GetPokestopsWithMissingQuests(dbDetails, geofence)
+	if err != nil {
+		log.Errorf("QuestStatus: Error retrieving missing quests: %s", err)
+		return []db.QuestLocation{}
+	}
+	return res
+}
+
 func UpdatePokestopRecordWithGetMapFortsOutProto(ctx context.Context, db db.DbDetails, mapFort *pogo.GetMapFortsOutProto_FortProto) (bool, string) {
 	pokestopMutex, _ := pokestopStripedMutex.GetLock(mapFort.Id)
 	pokestopMutex.Lock()

--- a/main.go
+++ b/main.go
@@ -261,6 +261,7 @@ func main() {
 	apiGroup.GET("/health", GetHealth)
 	apiGroup.POST("/clear-quests", ClearQuests)
 	apiGroup.POST("/quest-status", GetQuestStatus)
+	apiGroup.POST("missing-quests", GetPokestopsWithMissingQuests)
 	apiGroup.POST("/pokestop-positions", GetPokestopPositions)
 	apiGroup.GET("/pokestop/id/:fort_id", GetPokestop)
 	apiGroup.POST("/reload-geojson", ReloadGeojson)

--- a/main.go
+++ b/main.go
@@ -261,7 +261,7 @@ func main() {
 	apiGroup.GET("/health", GetHealth)
 	apiGroup.POST("/clear-quests", ClearQuests)
 	apiGroup.POST("/quest-status", GetQuestStatus)
-	apiGroup.POST("missing-quests", GetPokestopsWithMissingQuests)
+	apiGroup.POST("/missing-quests", GetPokestopsWithMissingQuests)
 	apiGroup.POST("/pokestop-positions", GetPokestopPositions)
 	apiGroup.GET("/pokestop/id/:fort_id", GetPokestop)
 	apiGroup.POST("/reload-geojson", ReloadGeojson)

--- a/routes.go
+++ b/routes.go
@@ -431,10 +431,23 @@ func GetQuestStatus(c *gin.Context) {
 		c.Status(http.StatusInternalServerError)
 		return
 	}
-
 	questStatus := decoder.GetQuestStatusWithGeofence(dbDetails, fence)
 
 	c.JSON(http.StatusOK, &questStatus)
+}
+
+func GetPokestopsWithMissingQuests(c *gin.Context) {
+	fence, err := geo.NormaliseFenceRequest(c)
+
+	if err != nil {
+		log.Warnf("POST /api/pokestops-with-missing-quests/ Error during post area %v", err)
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+	pokestops := decoder.GetPokestopsWithMissingQuests(dbDetails, fence)
+
+	c.JSON(http.StatusOK, &pokestops)
+
 }
 
 // GetHealth provides unrestricted health status for monitoring tools


### PR DESCRIPTION
This adds `/api/missing-quests` that accepts a geofence to look up in the Golbat DB which stops are missing either quest set.