### PR TITLE
Bandaid for tainted accounts for cherry picking

### DIFF
--- a/decoder/pokemon.go
+++ b/decoder/pokemon.go
@@ -699,6 +699,9 @@ func (pokemon *Pokemon) setUnknownTimestamp() {
 }
 
 func (pokemon *Pokemon) addEncounterPokemon(ctx context.Context, db db.DbDetails, proto *pogo.PokemonProto, username string) {
+	if proto.IndividualAttack <= 10 && proto.IndividualDefense <= 10 && proto.IndividualStamina <= 10 {
+		return // suspect tainted account. skip parsing encounter
+	}
 	pokemon.Username = null.StringFrom(username)
 	pokemon.Shiny = null.BoolFrom(proto.PokemonDisplay.Shiny)
 	pokemon.Cp = null.IntFrom(int64(proto.Cp))


### PR DESCRIPTION
This can be `git cherry-pick`ed before a more permanent solution is found.

This would prevent you from scanning:

* Nundos (0% IV pokemon)
* Little rank 1 Kingler, Galarian Mr Mime, Vaporeon, Ampharos, Heracross, Octillery, Houndoom, Miltank, Blissey, Blaziken, Gardevoir, Flygon, Armaldo, Relicanth, Rampardos, Rhyperior, Electivire, Gallade, Darmanitan-Zen, Archeops, Vanilluxe, Bisharp, Hisuian Braviary, Volcarona, Aromatisse, Orbeetles, Drednaw, Hatterene, Obstagoon, Dracovish, Cetitan, Flutter Mane, Iron Treads, Iron Bundle
* Little rank 1 Lugia, Regirock, Regice, Kyogre, Groudon, Dialga, Dialga-Origin, Palkia-Origin, Giratina-Origin, Terrakion, Reshiram, Zekrom, Kyurem-Black, Kyurem-White, Keldeo, Genesect, Zygarde, Volcanion, Tapu Fini, Kartana, Guzzlord, Necrozma-Dusk Mane, Necrozma-Dawn Wings, Zamazenta-Crowned Shield, Enamorus-Therian
* Ultra rank 1 Eternamax Eternatus