### PR TITLE
Remove pokemonInternalToDb

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,24 +7,23 @@ import (
 )
 
 type configDefinition struct {
-	Port                int        `koanf:"port"`
-	GrpcPort            int        `koanf:"grpc_port"`
-	Webhooks            []Webhook  `koanf:"webhooks"`
-	Database            database   `koanf:"database"`
-	Logging             logging    `koanf:"logging"`
-	Sentry              sentry     `koanf:"sentry"`
-	Pyroscope           pyroscope  `koanf:"pyroscope"`
-	Prometheus          Prometheus `koanf:"prometheus"`
-	PokemonMemoryOnly   bool       `koanf:"pokemon_memory_only"`
-	PokemonInternalToDb bool       `koanf:"pokemon_internal_to_db"`
-	TestFortInMemory    bool       `koanf:"test_fort_in_memory"`
-	Cleanup             cleanup    `koanf:"cleanup"`
-	RawBearer           string     `koanf:"raw_bearer"`
-	ApiSecret           string     `koanf:"api_secret"`
-	Pvp                 pvp        `koanf:"pvp"`
-	Koji                koji       `koanf:"koji"`
-	Tuning              tuning     `koanf:"tuning"`
-	ScanRules           []scanRule `koanf:"scan_rules"`
+	Port              int        `koanf:"port"`
+	GrpcPort          int        `koanf:"grpc_port"`
+	Webhooks          []Webhook  `koanf:"webhooks"`
+	Database          database   `koanf:"database"`
+	Logging           logging    `koanf:"logging"`
+	Sentry            sentry     `koanf:"sentry"`
+	Pyroscope         pyroscope  `koanf:"pyroscope"`
+	Prometheus        Prometheus `koanf:"prometheus"`
+	PokemonMemoryOnly bool       `koanf:"pokemon_memory_only"`
+	TestFortInMemory  bool       `koanf:"test_fort_in_memory"`
+	Cleanup           cleanup    `koanf:"cleanup"`
+	RawBearer         string     `koanf:"raw_bearer"`
+	ApiSecret         string     `koanf:"api_secret"`
+	Pvp               pvp        `koanf:"pvp"`
+	Koji              koji       `koanf:"koji"`
+	Tuning            tuning     `koanf:"tuning"`
+	ScanRules         []scanRule `koanf:"scan_rules"`
 }
 
 func (configDefinition configDefinition) GetWebhookInterval() time.Duration {

--- a/decoder/pokemon.go
+++ b/decoder/pokemon.go
@@ -289,7 +289,7 @@ func savePokemonRecordAsAtTime(ctx context.Context, db db.DbDetails, pokemon *Po
 	//log.Println(cmp.Diff(oldPokemon, pokemon))
 
 	if !config.Config.PokemonMemoryOnly {
-		if isEncounter && config.Config.PokemonInternalToDb {
+		if isEncounter {
 			unboosted, boosted, strong := pokemon.locateAllScans()
 			if unboosted != nil && boosted != nil {
 				unboosted.RemoveDittoAuxInfo()


### PR DESCRIPTION
Improper configuration of this switch causes Pokemon data to be consistent causing Golbat to sometimes crash. This switch is now always on except for PokemonMemoryOnly mode.