### PR TITLE
fix: pyroscope auth integration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -80,10 +80,14 @@ type sentry struct {
 type pyroscope struct {
 	ApplicationName      string `koanf:"application_name"`
 	ServerAddress        string `koanf:"server_address"`
-	ApiKey               string `koanf:"api_key"`
+	BasicAuthUser        string `koanf:"basic_auth_user"`
+	BasicAuthPassword    string `koanf:"basic_auth_password"`
 	Logger               bool   `koanf:"logger"`
 	MutexProfileFraction int    `koanf:"mutex_profile_fraction"`
 	BlockProfileRate     int    `koanf:"block_profile_rate"`
+
+	// Deprecated
+	ApiKey string `koanf:"api_key"`
 }
 
 type Prometheus struct {

--- a/external/pyroscope.go
+++ b/external/pyroscope.go
@@ -41,8 +41,13 @@ func InitPyroscope() {
 			pyroscopeConfig.Logger = nil
 		}
 
-		if config.Config.Pyroscope.ApiKey != "" {
-			pyroscopeConfig.AuthToken = config.Config.Pyroscope.ApiKey
+		if apiKey := config.Config.Pyroscope.ApiKey; apiKey != "" {
+			pyroscopeConfig.HTTPHeaders = map[string]string{
+				"Authorization": "Bearer " + apiKey,
+			}
+		} else if basicAuthUser := config.Config.Pyroscope.BasicAuthUser; basicAuthUser != "" {
+			pyroscopeConfig.BasicAuthUser = basicAuthUser
+			pyroscopeConfig.BasicAuthPassword = config.Config.Pyroscope.BasicAuthPassword
 		}
 
 		_, err := pyroscope.Start(pyroscopeConfig)


### PR DESCRIPTION
fixes #256 

* `github.com/grafana/pyroscope-go v1.2.0` broke apiToken usage
* Seems that pyroscope lib removed ApiKey auth completely when they deprecated it
* For fixing we need to change to BasicAuth