### PR TITLE
Stats: Include Pokemon form (draft)

### DIFF
--- a/decoder/stats.go
+++ b/decoder/stats.go
@@ -822,8 +822,8 @@ func logPokemonCount(statsDb *sqlx.DB) {
 					rowsToWrite := rows[i:end]
 
 					_, err := statsDb.NamedExec(
-						fmt.Sprintf("INSERT INTO %s (date, area, fence, form_id, pokemon_id, `count`)"+
-							" VALUES (:date, :area, :fence, :form_id, :pokemon_id, :count)"+
+						fmt.Sprintf("INSERT INTO %s (date, area, fence, pokemon_id, form_id, `count`)"+
+							" VALUES (:date, :area, :fence, :pokemon_id, :form_id, :count)"+
 							" ON DUPLICATE KEY UPDATE `count` = `count` + VALUES(`count`);", table),
 						rowsToWrite,
 					)
@@ -854,8 +854,8 @@ func logPokemonCount(statsDb *sqlx.DB) {
 				rowsToWrite := rows[i:end]
 
 				_, err := statsDb.NamedExec(
-					"INSERT INTO pokemon_shiny_stats (date, area, fence, form_id, pokemon_id, `count`, total)"+
-						" VALUES (:date, :area, :fence, :form_id, :pokemon_id, :count, :total)"+
+					"INSERT INTO pokemon_shiny_stats (date, area, fence, pokemon_id, form_id, `count`, total)"+
+						" VALUES (:date, :area, :fence, :pokemon_id, :form_id, :count, :total)"+
 						" ON DUPLICATE KEY UPDATE `count` = `count` + VALUES(`count`), total = total + VALUES(total);",
 					rowsToWrite,
 				)

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/puzpuzpuz/xsync/v3 v3.5.1
 	github.com/ringsaturn/tzf v0.17.0
 	github.com/ringsaturn/tzf-rel v0.0.2025-a
-	github.com/ringsaturn/tzf-rel-lite v0.0.2025-a
 	github.com/sirupsen/logrus v1.9.3
 	github.com/tidwall/rtree v1.10.0
 	github.com/toorop/gin-logrus v0.0.0-20210225092905-2c785434f26f
@@ -71,9 +70,9 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/ringsaturn/tzf-rel-lite v0.0.2025-a // indirect
 	github.com/tidwall/geoindex v1.7.0 // indirect
 	github.com/tidwall/geojson v1.4.5 // indirect
-	github.com/tidwall/lotsa v1.0.3 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/twpayne/go-polyline v1.1.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/loov/hrtime v1.0.3 h1:LiWKU3B9skJwRPUf0Urs9+0+OE3TxdMuiRPOTwR0gcU=
+github.com/loov/hrtime v1.0.3/go.mod h1:yDY3Pwv2izeY4sq7YcPX/dtLwzg5NU1AxWuWxKwd0p0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
@@ -188,6 +190,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/puzpuzpuz/xsync/v3 v3.5.1 h1:GJYJZwO6IdxN/IKbneznS6yPkVC+c3zyY/j19c++5Fg=
 github.com/puzpuzpuz/xsync/v3 v3.5.1/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPKP9jpmh0nnA=
+github.com/ringsaturn/go-cities.json v0.6.6 h1:zXEsYeQBjgJwKdGHMrq1j8d9uVNxmnbVvi2fAQAyfNM=
+github.com/ringsaturn/go-cities.json v0.6.6/go.mod h1:RWApnQPG6nU558XXbY1try5mi9u9Hd667J6vr948VBo=
 github.com/ringsaturn/tzf v0.17.0 h1:hGHBPBzJfSLmCAKg0khA7yxx9kqPPNYkggdodpKNaKI=
 github.com/ringsaturn/tzf v0.17.0/go.mod h1:4Z139lkC4Btg5tse9qdQ78gWmj7X0VwJjDxxO4ydAiU=
 github.com/ringsaturn/tzf-rel v0.0.2025-a h1:OLJe11vif6JMDtECkS71hAOdIzDHV+uBVgWUW3V/dZQ=

--- a/sql/37_stats_form.down.sql
+++ b/sql/37_stats_form.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `pokemon_stats` DROP COLUMN `form_id`;
+ALTER TABLE `pokemon_iv_stats` DROP COLUMN `form_id`;
+ALTER TABLE `pokemon_hundo_stats` DROP COLUMN `form_id`;
+ALTER TABLE `pokemon_nundo_stats` DROP COLUMN `form_id`;
+ALTER TABLE `pokemon_shiny_stats` DROP COLUMN `form_id`;

--- a/sql/37_stats_form.up.sql
+++ b/sql/37_stats_form.up.sql
@@ -1,0 +1,43 @@
+ALTER TABLE `raid_stats`
+    ADD COLUMN fence varchar(255) NOT NULL DEFAULT '' AFTER `date`,
+    ADD COLUMN area varchar(255) NOT NULL DEFAULT '' AFTER `date`,
+    DROP PRIMARY KEY,
+    ADD PRIMARY KEY (`date`, area, fence, pokemon_id),
+    CHANGE `level` `level` SMALLINT UNSIGNED NULL DEFAULT NULL AFTER `fence`;
+
+ALTER TABLE `invasion_stats`
+    ADD COLUMN fence varchar(255) NOT NULL DEFAULT '' AFTER `date`,
+    ADD COLUMN area varchar(255) NOT NULL DEFAULT '' AFTER `date`,
+    CHANGE `grunt_type` `character` SMALLINT UNSIGNED NOT NULL,
+    DROP PRIMARY KEY,
+    ADD PRIMARY KEY (`date`, area, fence, `character`);
+
+ALTER TABLE `quest_stats`
+    ADD COLUMN fence varchar(255) NOT NULL DEFAULT '' AFTER `date`,
+    ADD COLUMN area varchar(255) NOT NULL DEFAULT '' AFTER `date`,
+    DROP PRIMARY KEY,
+    ADD PRIMARY KEY (`date`, area, fence, reward_type, pokemon_id, item_id);
+
+ALTER TABLE pokemon_iv_stats
+    MODIFY area varchar(255) NOT NULL DEFAULT '' AFTER `date`,
+    MODIFY fence varchar(255) NOT NULL DEFAULT '' AFTER area;
+
+ALTER TABLE pokemon_hundo_stats
+    MODIFY area varchar(255) NOT NULL DEFAULT '' AFTER `date`,
+    MODIFY fence varchar(255) NOT NULL DEFAULT '' AFTER area;
+
+ALTER TABLE pokemon_shiny_stats
+    MODIFY area varchar(255) NOT NULL DEFAULT '' AFTER `date`,
+    MODIFY fence varchar(255) NOT NULL DEFAULT '' AFTER area;
+
+ALTER TABLE pokemon_stats
+    MODIFY area varchar(255) NOT NULL DEFAULT '' AFTER `date`,
+    MODIFY fence varchar(255) NOT NULL DEFAULT '' AFTER area;
+
+ALTER TABLE pokemon_area_stats
+    MODIFY area varchar(255),
+    MODIFY fence varchar(255);
+
+ALTER TABLE pokemon_nundo_stats
+    MODIFY area varchar(255),
+    MODIFY fence varchar(255);

--- a/sql/37_stats_form.up.sql
+++ b/sql/37_stats_form.up.sql
@@ -1,5 +1,5 @@
-ALTER TABLE `pokemon_stats` ADD `form_id` SMALLINT(5) UNSIGNED NOT NULL AFTER `fence`;
-ALTER TABLE `pokemon_iv_stats` ADD `form_id` SMALLINT(5) UNSIGNED NOT NULL AFTER `fence`;
-ALTER TABLE `pokemon_hundo_stats` ADD `form_id` SMALLINT(5) UNSIGNED NOT NULL AFTER `fence`;
-ALTER TABLE `pokemon_nundo_stats` ADD `form_id` SMALLINT(5) UNSIGNED NOT NULL AFTER `fence`;
-ALTER TABLE `pokemon_shiny_stats` ADD `form_id` SMALLINT(5) UNSIGNED NOT NULL AFTER `fence`;
+ALTER TABLE `pokemon_stats` ADD `form_id` SMALLINT(5) UNSIGNED NOT NULL AFTER `pokemon_id`;
+ALTER TABLE `pokemon_iv_stats` ADD `form_id` SMALLINT(5) UNSIGNED NOT NULL AFTER `pokemon_id`;
+ALTER TABLE `pokemon_hundo_stats` ADD `form_id` SMALLINT(5) UNSIGNED NOT NULL AFTER `pokemon_id`;
+ALTER TABLE `pokemon_nundo_stats` ADD `form_id` SMALLINT(5) UNSIGNED NOT NULL AFTER `pokemon_id`;
+ALTER TABLE `pokemon_shiny_stats` ADD `form_id` SMALLINT(5) UNSIGNED NOT NULL AFTER `pokemon_id`;

--- a/sql/37_stats_form.up.sql
+++ b/sql/37_stats_form.up.sql
@@ -1,43 +1,5 @@
-ALTER TABLE `raid_stats`
-    ADD COLUMN fence varchar(255) NOT NULL DEFAULT '' AFTER `date`,
-    ADD COLUMN area varchar(255) NOT NULL DEFAULT '' AFTER `date`,
-    DROP PRIMARY KEY,
-    ADD PRIMARY KEY (`date`, area, fence, pokemon_id),
-    CHANGE `level` `level` SMALLINT UNSIGNED NULL DEFAULT NULL AFTER `fence`;
-
-ALTER TABLE `invasion_stats`
-    ADD COLUMN fence varchar(255) NOT NULL DEFAULT '' AFTER `date`,
-    ADD COLUMN area varchar(255) NOT NULL DEFAULT '' AFTER `date`,
-    CHANGE `grunt_type` `character` SMALLINT UNSIGNED NOT NULL,
-    DROP PRIMARY KEY,
-    ADD PRIMARY KEY (`date`, area, fence, `character`);
-
-ALTER TABLE `quest_stats`
-    ADD COLUMN fence varchar(255) NOT NULL DEFAULT '' AFTER `date`,
-    ADD COLUMN area varchar(255) NOT NULL DEFAULT '' AFTER `date`,
-    DROP PRIMARY KEY,
-    ADD PRIMARY KEY (`date`, area, fence, reward_type, pokemon_id, item_id);
-
-ALTER TABLE pokemon_iv_stats
-    MODIFY area varchar(255) NOT NULL DEFAULT '' AFTER `date`,
-    MODIFY fence varchar(255) NOT NULL DEFAULT '' AFTER area;
-
-ALTER TABLE pokemon_hundo_stats
-    MODIFY area varchar(255) NOT NULL DEFAULT '' AFTER `date`,
-    MODIFY fence varchar(255) NOT NULL DEFAULT '' AFTER area;
-
-ALTER TABLE pokemon_shiny_stats
-    MODIFY area varchar(255) NOT NULL DEFAULT '' AFTER `date`,
-    MODIFY fence varchar(255) NOT NULL DEFAULT '' AFTER area;
-
-ALTER TABLE pokemon_stats
-    MODIFY area varchar(255) NOT NULL DEFAULT '' AFTER `date`,
-    MODIFY fence varchar(255) NOT NULL DEFAULT '' AFTER area;
-
-ALTER TABLE pokemon_area_stats
-    MODIFY area varchar(255),
-    MODIFY fence varchar(255);
-
-ALTER TABLE pokemon_nundo_stats
-    MODIFY area varchar(255),
-    MODIFY fence varchar(255);
+ALTER TABLE `pokemon_stats` ADD `form_id` SMALLINT(5) UNSIGNED NOT NULL AFTER `fence`;
+ALTER TABLE `pokemon_iv_stats` ADD `form_id` SMALLINT(5) UNSIGNED NOT NULL AFTER `fence`;
+ALTER TABLE `pokemon_hundo_stats` ADD `form_id` SMALLINT(5) UNSIGNED NOT NULL AFTER `fence`;
+ALTER TABLE `pokemon_nundo_stats` ADD `form_id` SMALLINT(5) UNSIGNED NOT NULL AFTER `fence`;
+ALTER TABLE `pokemon_shiny_stats` ADD `form_id` SMALLINT(5) UNSIGNED NOT NULL AFTER `fence`;


### PR DESCRIPTION
**DRAFT** https://github.com/UnownHash/Golbat/issues/237

Bugged as I get only single Pokémon & form entry when there's a lot of different Pikachu in there... I will revisit it again someday, unless someone is bored and will find a bug.

```sql
SELECT pokemon_id, form_id, sum(count) FROM `pokemon_stats` group by pokemon_id, form_id ORDER BY pokemon_id, form_id; 
```
```
pokemon_id | form_id | sum(count)
7          | 181     | 6
8          | 184     | 2
10         | 0       | 44
16         | 0       | 48
19         | 45      | 40
20         | 47      | 6
21         | 0       | 28
22         | 0       | 2
25         | 2857    | 228
26         | 49      | 2
27         | 51      | 12
```
