### PR TITLE
Addition of live stats api endpoint

### DIFF
--- a/decoder/api_pokemon.go
+++ b/decoder/api_pokemon.go
@@ -2,12 +2,13 @@ package decoder
 
 import (
 	"fmt"
-	"golbat/config"
-	"golbat/geo"
 	"math"
 	"slices"
 	"strconv"
 	"time"
+
+	"golbat/config"
+	"golbat/geo"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/rtree"
@@ -167,6 +168,7 @@ type ApiPokemonLiveStatsResult struct {
 
 func GetLiveStatsPokemon() *ApiPokemonLiveStatsResult {
 	start := time.Now()
+	now := time.Now().Unix()
 
 	liveStats := &ApiPokemonLiveStatsResult{
 		0,
@@ -176,15 +178,17 @@ func GetLiveStatsPokemon() *ApiPokemonLiveStatsResult {
 	}
 
 	pokemonLookupCache.Range(func(key uint64, pokemon PokemonLookupCacheItem) bool {
-		liveStats.PokemonActive++
-		if pokemon.PokemonLookup.Iv > -1 {
-			liveStats.PokemonActiveIv++
-		}
-		if pokemon.PokemonLookup.Shiny {
-			liveStats.PokemonActiveShiny++
-		}
-		if pokemon.PokemonLookup.Iv == 100 {
-			liveStats.PokemonActive100iv++
+		if pokemon.PokemonLookup.ExpireTimestamp > now {
+			liveStats.PokemonActive++
+			if pokemon.PokemonLookup.Iv > -1 {
+				liveStats.PokemonActiveIv++
+			}
+			if pokemon.PokemonLookup.Shiny {
+				liveStats.PokemonActiveShiny++
+			}
+			if pokemon.PokemonLookup.Iv == 100 {
+				liveStats.PokemonActive100iv++
+			}
 		}
 		return true
 	})

--- a/decoder/api_pokemon.go
+++ b/decoder/api_pokemon.go
@@ -157,3 +157,38 @@ func GetOnePokemon(pokemonId uint64) *Pokemon {
 	}
 	return nil
 }
+
+type ApiPokemonLiveStatsResult struct {
+	PokemonActive      int `json:"pokemon_active"`
+	PokemonActiveIv    int `json:"pokemon_active_iv"`
+	PokemonActive100iv int `json:"pokemon_active_100iv"`
+	PokemonActiveShiny int `json:"pokemon_active_shiny"`
+}
+
+func GetLiveStatsPokemon() *ApiPokemonLiveStatsResult {
+	start := time.Now()
+
+	liveStats := &ApiPokemonLiveStatsResult{
+		0,
+		0,
+		0,
+		0,
+	}
+
+	pokemonLookupCache.Range(func(key uint64, pokemon PokemonLookupCacheItem) bool {
+		liveStats.PokemonActive++
+		if pokemon.PokemonLookup.Iv > -1 {
+			liveStats.PokemonActiveIv++
+		}
+		if pokemon.PokemonLookup.Shiny {
+			liveStats.PokemonActiveShiny++
+		}
+		if pokemon.PokemonLookup.Iv == 100 {
+			liveStats.PokemonActive100iv++
+		}
+		return true
+	})
+
+	log.Infof("apiLiveStats - %d pokemon_active, %d pokemon_active_iv, %d pokemon_active_100iv, %d pokemon_active_shiny, total time %s", liveStats.PokemonActive, liveStats.PokemonActiveIv, liveStats.PokemonActive100iv, liveStats.PokemonActiveShiny, time.Since(start))
+	return liveStats
+}

--- a/decoder/pokemonRtree.go
+++ b/decoder/pokemonRtree.go
@@ -36,6 +36,7 @@ type PokemonLookup struct {
 	Iv                 int8
 	Size               int8
 	Shiny              bool
+	ExpireTimestamp    int64
 }
 
 type PokemonPvpLookup struct {
@@ -44,9 +45,11 @@ type PokemonPvpLookup struct {
 	Ultra  int16
 }
 
-var pokemonLookupCache *xsync.MapOf[uint64, PokemonLookupCacheItem]
-var pokemonTreeMutex sync.RWMutex
-var pokemonTree rtree.RTreeG[uint64]
+var (
+	pokemonLookupCache *xsync.MapOf[uint64, PokemonLookupCacheItem]
+	pokemonTreeMutex   sync.RWMutex
+	pokemonTree        rtree.RTreeG[uint64]
+)
 
 func initPokemonRtree() {
 	pokemonLookupCache = xsync.NewMapOf[uint64, PokemonLookupCacheItem]()
@@ -56,7 +59,6 @@ func initPokemonRtree() {
 		removePokemonFromTree(&r)
 		// Rely on the pokemon pvp lookup caches to remove themselves rather than trying to synchronise
 	})
-
 }
 
 func pokemonRtreeUpdatePokemonOnGet(pokemon *Pokemon) {
@@ -98,8 +100,9 @@ func updatePokemonLookup(pokemon *Pokemon, changePvp bool, pvpResults map[string
 			}
 			return -1
 		}(),
-		Size:               int8(valueOrMinus1(pokemon.Size)),
-		Shiny:              bool(pokemon.Shiny.ValueOrZero()),
+		Size:            int8(valueOrMinus1(pokemon.Size)),
+		Shiny:           bool(pokemon.Shiny.ValueOrZero()),
+		ExpireTimestamp: int64(valueOrMinus1(pokemon.ExpireTimestamp)),
 	}
 	if !pokemon.IsDitto {
 		pokemonLookupCacheItem.PokemonLookup.Form = int16(pokemon.Form.ValueOrZero())

--- a/decoder/pokemonRtree.go
+++ b/decoder/pokemonRtree.go
@@ -35,6 +35,7 @@ type PokemonLookup struct {
 	Xxl                bool
 	Iv                 int8
 	Size               int8
+	Shiny              bool
 }
 
 type PokemonPvpLookup struct {
@@ -97,7 +98,8 @@ func updatePokemonLookup(pokemon *Pokemon, changePvp bool, pvpResults map[string
 			}
 			return -1
 		}(),
-		Size: int8(valueOrMinus1(pokemon.Size)),
+		Size:               int8(valueOrMinus1(pokemon.Size)),
+		Shiny:              bool(pokemon.Shiny.ValueOrZero()),
 	}
 	if !pokemon.IsDitto {
 		pokemonLookupCacheItem.PokemonLookup.Form = int16(pokemon.Form.ValueOrZero())

--- a/decoder/pokemonRtree.go
+++ b/decoder/pokemonRtree.go
@@ -35,8 +35,6 @@ type PokemonLookup struct {
 	Xxl                bool
 	Iv                 int8
 	Size               int8
-	Shiny              bool
-	ExpireTimestamp    int64
 }
 
 type PokemonPvpLookup struct {
@@ -45,11 +43,9 @@ type PokemonPvpLookup struct {
 	Ultra  int16
 }
 
-var (
-	pokemonLookupCache *xsync.MapOf[uint64, PokemonLookupCacheItem]
-	pokemonTreeMutex   sync.RWMutex
-	pokemonTree        rtree.RTreeG[uint64]
-)
+var pokemonLookupCache *xsync.MapOf[uint64, PokemonLookupCacheItem]
+var pokemonTreeMutex sync.RWMutex
+var pokemonTree rtree.RTreeG[uint64]
 
 func initPokemonRtree() {
 	pokemonLookupCache = xsync.NewMapOf[uint64, PokemonLookupCacheItem]()
@@ -59,6 +55,7 @@ func initPokemonRtree() {
 		removePokemonFromTree(&r)
 		// Rely on the pokemon pvp lookup caches to remove themselves rather than trying to synchronise
 	})
+
 }
 
 func pokemonRtreeUpdatePokemonOnGet(pokemon *Pokemon) {
@@ -100,9 +97,7 @@ func updatePokemonLookup(pokemon *Pokemon, changePvp bool, pvpResults map[string
 			}
 			return -1
 		}(),
-		Size:            int8(valueOrMinus1(pokemon.Size)),
-		Shiny:           bool(pokemon.Shiny.ValueOrZero()),
-		ExpireTimestamp: int64(valueOrMinus1(pokemon.ExpireTimestamp)),
+		Size: int8(valueOrMinus1(pokemon.Size)),
 	}
 	if !pokemon.IsDitto {
 		pokemonLookupCacheItem.PokemonLookup.Form = int16(pokemon.Form.ValueOrZero())

--- a/main.go
+++ b/main.go
@@ -271,6 +271,7 @@ func main() {
 	apiGroup.POST("/pokemon/scan", PokemonScan)
 	apiGroup.POST("/pokemon/v2/scan", PokemonScan2)
 	apiGroup.POST("/pokemon/search", PokemonSearch)
+	apiGroup.GET("/pokemon/livestats", PokemonLiveStats)
 
 	apiGroup.GET("/devices/all", GetDevices)
 

--- a/routes.go
+++ b/routes.go
@@ -478,3 +478,8 @@ func GetPokestop(c *gin.Context) {
 func GetDevices(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"devices": GetAllDevices()})
 }
+
+func PokemonLiveStats(c *gin.Context) {
+	res := decoder.GetLiveStatsPokemon()
+	c.JSON(http.StatusAccepted, res)
+}


### PR DESCRIPTION
Adds an api endpoint to get count of active pokemon, active with IV, active 100iv and active shiny.

Call with `/api/pokemon/livestats` and response like `{"pokemon_active":18853,"pokemon_active_iv":13077,"pokemon_active_100iv":5,"pokemon_active_shiny":56}`