### PR TITLE
Extend Gyms API

### DIFF
--- a/decoder/gym.go
+++ b/decoder/gym.go
@@ -152,7 +152,7 @@ func SearchGymsSQL(ctx context.Context, db db.DbDetails, query string, limit, of
 
 	const querySQL = `
 		SELECT id FROM gym
-		WHERE (name LIKE ? ESCAPE '\\')
+		WHERE name LIKE ? ESCAPE '\\' AND enabled = 1
 		ORDER BY name ASC
 		LIMIT ? OFFSET ?
 	`

--- a/decoder/gym.go
+++ b/decoder/gym.go
@@ -13,7 +13,6 @@ import (
 	"golbat/geo"
 
 	"github.com/jellydator/ttlcache/v3"
-	"github.com/jmoiron/sqlx"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/guregu/null.v4"
 
@@ -141,84 +140,6 @@ func GetGymRecord(ctx context.Context, db db.DbDetails, fortId string) (*Gym, er
 	return &gym, nil
 }
 
-func GetGymRecords(ctx context.Context, db db.DbDetails, fortIds []string) ([]Gym, error) {
-	if len(fortIds) == 0 {
-		return []Gym{}, nil
-	}
-
-	type item struct {
-		idx int
-		gym Gym
-	}
-	cached := make(map[string]item, len(fortIds))
-	missing := make([]string, 0, len(fortIds))
-
-	for i, fortId := range fortIds {
-		if inMemoryGym := gymCache.Get(fortId); inMemoryGym != nil {
-			g := inMemoryGym.Value()
-			cached[fortId] = item{idx: i, gym: g}
-		} else {
-			missing = append(missing, fortId)
-		}
-	}
-
-	if len(missing) == 0 {
-		out := make([]Gym, 0, len(fortIds))
-		for _, id := range fortIds {
-			out = append(out, cached[id].gym)
-		}
-		return out, nil
-	}
-
-	queryBase := `
-		SELECT id, lat, lon, name, url, last_modified_timestamp, raid_end_timestamp, raid_spawn_timestamp,
-			raid_battle_timestamp, updated, raid_pokemon_id, guarding_pokemon_id, guarding_pokemon_display,
-			available_slots, team_id, raid_level, enabled, ex_raid_eligible, in_battle, raid_pokemon_move_1,
-			raid_pokemon_move_2, raid_pokemon_form, raid_pokemon_alignment, raid_pokemon_cp, raid_is_exclusive,
-			cell_id, deleted, total_cp, first_seen_timestamp, raid_pokemon_gender, sponsor_id, partner_id,
-			raid_pokemon_costume, raid_pokemon_evolution, ar_scan_eligible, power_up_level, power_up_points,
-			power_up_end_timestamp, description, defenders, rsvps
-		FROM gym
-		WHERE id IN (?)
-	`
-
-	q, args, err := sqlx.In(queryBase, missing)
-	if err != nil {
-		return nil, err
-	}
-	q = db.GeneralDb.Rebind(q)
-
-	var fetched []Gym
-	err = db.GeneralDb.SelectContext(ctx, &fetched, q, args...)
-	statsCollector.IncDbQuery("select gyms", err)
-
-	if err != nil && err != sql.ErrNoRows {
-		return nil, err
-	}
-
-	fetchedByID := make(map[string]Gym, len(fetched))
-	for _, g := range fetched {
-		fetchedByID[g.Id] = g
-		gymCache.Set(g.Id, g, ttlcache.DefaultTTL)
-		if config.Config.TestFortInMemory {
-			fortRtreeUpdateGymOnGet(&g)
-		}
-	}
-
-	out := make([]Gym, 0, len(fortIds))
-	for _, id := range fortIds {
-		if it, ok := cached[id]; ok {
-			out = append(out, it.gym)
-			continue
-		}
-		if g, ok := fetchedByID[id]; ok {
-			out = append(out, g)
-		}
-	}
-
-	return out, nil
-}
-
 func escapeLike(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `%`, `\%`)
@@ -226,39 +147,29 @@ func escapeLike(s string) string {
 	return s
 }
 
-func SearchGymsSQL(ctx context.Context, db db.DbDetails, query string, limit, offset int) ([]Gym, error) {
+func SearchGymsSQL(ctx context.Context, db db.DbDetails, query string, limit, offset int) ([]string, error) {
 	like := "%" + escapeLike(query) + "%"
 
-	const selectColumns = `
-		SELECT id, lat, lon, name, url, last_modified_timestamp, raid_end_timestamp, raid_spawn_timestamp,
-			raid_battle_timestamp, updated, raid_pokemon_id, guarding_pokemon_id, guarding_pokemon_display,
-			available_slots, team_id, raid_level, enabled, ex_raid_eligible, in_battle, raid_pokemon_move_1,
-			raid_pokemon_move_2, raid_pokemon_form, raid_pokemon_alignment, raid_pokemon_cp, raid_is_exclusive,
-			cell_id, deleted, total_cp, first_seen_timestamp, raid_pokemon_gender, sponsor_id, partner_id,
-			raid_pokemon_costume, raid_pokemon_evolution, ar_scan_eligible, power_up_level, power_up_points,
-			power_up_end_timestamp, description, defenders, rsvps
-		FROM gym
-	`
-
-	querySQL := selectColumns + `
-		WHERE (name LIKE ? ESCAPE '\' OR url LIKE ? ESCAPE '\' OR description LIKE ? ESCAPE '\' OR id LIKE ? ESCAPE '\')
-		ORDER BY updated DESC, name ASC
+	const querySQL = `
+		SELECT id FROM gym
+		WHERE (name LIKE ? ESCAPE '\\')
+		ORDER BY name ASC
 		LIMIT ? OFFSET ?
 	`
 
 	q := db.GeneralDb.Rebind(querySQL)
 
-	var gyms []Gym
-	err := db.GeneralDb.SelectContext(ctx, &gyms, q, like, like, like, like, limit, offset)
+	var ids []string
+	err := db.GeneralDb.SelectContext(ctx, &ids, q, like, limit, offset)
 	statsCollector.IncDbQuery("search gyms", err)
 
 	if err == sql.ErrNoRows {
-		return []Gym{}, nil
+		return []string{}, nil
 	}
 	if err != nil {
 		return nil, err
 	}
-	return gyms, nil
+	return ids, nil
 }
 
 func calculatePowerUpPoints(fortData *pogo.PokemonFortProto) (null.Int, null.Int) {

--- a/main.go
+++ b/main.go
@@ -268,7 +268,7 @@ func main() {
 	apiGroup.POST("/pokestop-positions", GetPokestopPositions)
 	apiGroup.GET("/pokestop/id/:fort_id", GetPokestop)
 	apiGroup.GET("/gym/id/:gym_id", GetGym)
-	apiGroup.POST("/gym", GetGyms)
+	apiGroup.POST("/gym/query", GetGyms)
 	apiGroup.POST("/gym/search", SearchGyms)
 	apiGroup.POST("/reload-geojson", ReloadGeojson)
 	apiGroup.GET("/reload-geojson", ReloadGeojson)

--- a/main.go
+++ b/main.go
@@ -268,6 +268,8 @@ func main() {
 	apiGroup.POST("/pokestop-positions", GetPokestopPositions)
 	apiGroup.GET("/pokestop/id/:fort_id", GetPokestop)
 	apiGroup.GET("/gym/id/:gym_id", GetGym)
+	apiGroup.POST("/gym", GetGyms)
+	apiGroup.POST("/gym/search", SearchGyms)
 	apiGroup.POST("/reload-geojson", ReloadGeojson)
 	apiGroup.GET("/reload-geojson", ReloadGeojson)
 

--- a/routes.go
+++ b/routes.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -499,6 +500,127 @@ func GetGym(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusAccepted, gym)
+}
+
+// POST /api/gym
+// Body:
+//	{ "ids": ["gymid1", "gymid2", ...] }
+// Also supported:
+//	["gymid1", "gymid2", ...]
+func GetGyms(c *gin.Context) {
+	type idsPayload struct {
+		IDs []string `json:"ids"`
+	}
+
+	var payload idsPayload
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		var arr []string
+		if err2 := c.ShouldBindJSON(&arr); err2 != nil {
+			log.Warnf("POST /api/gyms invalid JSON: %v / %v", err, err2)
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON body; expected {\"ids\":[...] } or [ ... ]"})
+			return
+		}
+		payload.IDs = arr
+	}
+
+	seen := make(map[string]struct{}, len(payload.IDs))
+	ids := make([]string, 0, len(payload.IDs))
+	for _, id := range payload.IDs {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+
+	const maxIDs = 500
+	if len(ids) > maxIDs {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{
+			"error":         "too many ids",
+			"max_supported": maxIDs,
+		})
+		return
+	}
+
+	if len(ids) == 0 {
+		c.JSON(http.StatusOK, []decoder.Gym{})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	gyms, err := decoder.GetGymRecords(ctx, dbDetails, ids)
+	if err != nil {
+		log.Warnf("POST /api/gyms error retrieving gyms: %v", err)
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusOK, gyms)
+}
+
+// Handler: POST /api/gyms/search
+//	{
+//	  "query": "central park",
+//	  "limit": 100,    // optional, default 100, max 500
+//	  "offset": 0,     // optional
+//	  "page": 1        // optional; if provided and offset not provided, offset = (page-1)*limit
+//	}
+func SearchGyms(c *gin.Context) {
+	type payload struct {
+		Query  string `json:"query"`
+		Limit  *int   `json:"limit"`
+		Offset *int   `json:"offset"`
+		Page   *int   `json:"page"`
+	}
+
+	var p payload
+	if err := c.ShouldBindJSON(&p); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON body"})
+		return
+	}
+	q := strings.TrimSpace(p.Query)
+	if q == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "query is required"})
+		return
+	}
+
+	limit := 100
+	if p.Limit != nil {
+		limit = *p.Limit
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 500 {
+		limit = 500
+	}
+
+	offset := 0
+	if p.Offset != nil {
+		offset = *p.Offset
+	} else if p.Page != nil && *p.Page > 0 {
+		offset = (*p.Page - 1) * limit
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	gyms, err := decoder.SearchGymsSQL(ctx, dbDetails, q, limit, offset)
+	if err != nil {
+		log.Warnf("POST /api/gyms/search error: %v", err)
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusOK, gyms)
 }
 
 func GetTappable(c *gin.Context) {

--- a/routes.go
+++ b/routes.go
@@ -503,7 +503,7 @@ func GetGym(c *gin.Context) {
 	c.JSON(http.StatusAccepted, gym)
 }
 
-// POST /api/gym/batch
+// POST /api/gym/query
 //
 //	{ "ids": ["gymid1", "gymid2", ...] }
 func GetGyms(c *gin.Context) {

--- a/routes.go
+++ b/routes.go
@@ -503,7 +503,7 @@ func GetGym(c *gin.Context) {
 	c.JSON(http.StatusAccepted, gym)
 }
 
-// POST /api/gym
+// POST /api/gym/batch
 //
 //	{ "ids": ["gymid1", "gymid2", ...] }
 func GetGyms(c *gin.Context) {
@@ -516,7 +516,7 @@ func GetGyms(c *gin.Context) {
 		var arr []string
 		if err2 := c.ShouldBindJSON(&arr); err2 != nil {
 			log.Warnf("POST /api/gyms invalid JSON: %v / %v", err, err2)
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON body; expected {\"ids\":[...] } or [ ... ]"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON body; expected {\"ids\":[...] }"})
 			return
 		}
 		payload.IDs = arr
@@ -552,7 +552,7 @@ func GetGyms(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	out := make([]decoder.Gym, 0, len(ids))
+	out := make([]*decoder.Gym, 0, len(ids))
 	for _, id := range ids {
 		g, err := decoder.GetGymRecord(ctx, dbDetails, id)
 		if err != nil {
@@ -561,7 +561,7 @@ func GetGyms(c *gin.Context) {
 			return
 		}
 		if g != nil {
-			out = append(out, *g)
+			out = append(out, g)
 		}
 		if ctx.Err() != nil {
 			c.Status(http.StatusInternalServerError)
@@ -635,7 +635,7 @@ func SearchGyms(c *gin.Context) {
 		return
 	}
 
-	out := make([]decoder.Gym, 0, len(ids))
+	out := make([]*decoder.Gym, 0, len(ids))
 	for _, id := range ids {
 		if id == "" {
 			continue
@@ -652,7 +652,7 @@ func SearchGyms(c *gin.Context) {
 			return
 		}
 		if g != nil {
-			out = append(out, *g)
+			out = append(out, g)
 		}
 		if ctx.Err() != nil {
 			c.Status(http.StatusInternalServerError)


### PR DESCRIPTION
Extend gyms API with 2 calls. Tested.

Additions:
- `POST /api/gym` taking JSON body, returns a `[]Gym`
```
{ 
  "ids": ["gymid1", "gymid2", ...]
}
```
- `POST /api/gym/search` taking JSON body, returns a `[]Gym`
```
{
  "query": "central park",
  "limit": 100,    // optional, default 100, max 500
  "offset": 0,     // optional
  "page": 1        // optional; if provided and offset not provided, offset = (page-1)*limit
}
```