### PR TITLE
Add exclude_areas option to webhook config

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -66,6 +66,9 @@ url = "http://localhost:4201"
 #url = "http://localhost:4202"
 #types = ["raid"]
 #areas = ["London/*", "*/Harrow", "Harrow"]
+# exclude_areas suppresses messages from the listed geofences/areas. If an
+# area appears in both areas and exclude_areas, the exclusion wins.
+#exclude_areas = ["London/Westminster", "*/Wembley"]
 
 [tuning]
 max_pokemon_distance = 100  # Maximum distance in kilometers for searching pokemon

--- a/config/config.go
+++ b/config/config.go
@@ -61,12 +61,14 @@ type cleanup struct {
 }
 
 type Webhook struct {
-	Url       string            `koanf:"url"`
-	Types     []string          `koanf:"types"`
-	Areas     []string          `koanf:"areas"`
-	Headers   []string          `koanf:"headers"`
-	HeaderMap map[string]string `koanf:"-"`
-	AreaNames []geo.AreaName    `koanf:"-"`
+	Url              string            `koanf:"url"`
+	Types            []string          `koanf:"types"`
+	Areas            []string          `koanf:"areas"`
+	ExcludeAreas     []string          `koanf:"exclude_areas"`
+	Headers          []string          `koanf:"headers"`
+	HeaderMap        map[string]string `koanf:"-"`
+	AreaNames        []geo.AreaName    `koanf:"-"`
+	ExcludeAreaNames []geo.AreaName    `koanf:"-"`
 }
 
 type pvp struct {

--- a/config/reader.go
+++ b/config/reader.go
@@ -113,6 +113,7 @@ func ReadConfig() (configDefinition, error) {
 	for i := 0; i < len(Config.Webhooks); i++ {
 		hook := &Config.Webhooks[i]
 		hook.AreaNames = splitIntoAreaAndFenceName(hook.Areas)
+		hook.ExcludeAreaNames = splitIntoAreaAndFenceName(hook.ExcludeAreas)
 		hook.HeaderMap = splitIntoHeaderMap(hook.Headers)
 	}
 

--- a/webhooks/webhook.go
+++ b/webhooks/webhook.go
@@ -68,17 +68,18 @@ var webhookConfigStringToType = map[string][]WebhookType{
 }
 
 type webhook struct {
-	url         string
-	areaNames   []geo.AreaName
-	typesWanted []WebhookType
-	headerMap   map[string]string
-	httpClient  *http.Client
+	url              string
+	areaNames        []geo.AreaName
+	excludeAreaNames []geo.AreaName
+	typesWanted      []WebhookType
+	headerMap        map[string]string
+	httpClient       *http.Client
 }
 
 func (wh *webhook) getPayload(collection webhookCollection) ([]byte, error) {
 	var totalCollection []webhookMessage
 
-	if len(wh.areaNames) == 0 {
+	if len(wh.areaNames) == 0 && len(wh.excludeAreaNames) == 0 {
 		for _, whType := range wh.typesWanted {
 			totalCollection = append(
 				totalCollection,
@@ -88,9 +89,13 @@ func (wh *webhook) getPayload(collection webhookCollection) ([]byte, error) {
 	} else {
 		for _, whType := range wh.typesWanted {
 			for _, message := range collection[whType].Messages {
-				if geo.AreaMatchWithWildcards(message.Areas, wh.areaNames) {
-					totalCollection = append(totalCollection, message)
+				if len(wh.excludeAreaNames) > 0 && geo.AreaMatchWithWildcards(message.Areas, wh.excludeAreaNames) {
+					continue
 				}
+				if len(wh.areaNames) > 0 && !geo.AreaMatchWithWildcards(message.Areas, wh.areaNames) {
+					continue
+				}
+				totalCollection = append(totalCollection, message)
 			}
 		}
 	}
@@ -174,10 +179,11 @@ func webhookFromConfigWebhook(configWh config.Webhook) (*webhook, error) {
 	}
 
 	return &webhook{
-		url:         urlStr,
-		typesWanted: typesWanted,
-		areaNames:   configWh.AreaNames,
-		httpClient:  &http.Client{},
-		headerMap:   configWh.HeaderMap,
+		url:              urlStr,
+		typesWanted:      typesWanted,
+		areaNames:        configWh.AreaNames,
+		excludeAreaNames: configWh.ExcludeAreaNames,
+		httpClient:       &http.Client{},
+		headerMap:        configWh.HeaderMap,
 	}, nil
 }


### PR DESCRIPTION
Behavior: 
- Allows a webhook to suppress messages from specific geofences/areas. 
- When an area appears in both areas and exclude_areas, exclusion wins.
- With no areas and only exclude_areas, the webhook receives everything except the excluded areas; with both, exclusion takes precedence over inclusion.