### PR TITLE
Len fort tracker fixes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,8 @@ type cleanup struct {
 	Stats               bool  `koanf:"stats"`
 	StatsDays           int   `koanf:"stats_days"`
 	DeviceHours         int   `koanf:"device_hours"`
-	FortsStaleThreshold int64 `koanf:"forts_stale_threshold"` // seconds, default 3600 (1 hour)
+	FortsStaleThreshold int64 `koanf:"forts_stale_threshold"`  // seconds, default 3600 (1 hour)
+	FortsMinMissCount   int   `koanf:"forts_min_miss_count"`   // consecutive cell-scan misses before staleness (default 1)
 }
 
 type Webhook struct {

--- a/decode.go
+++ b/decode.go
@@ -483,24 +483,20 @@ func decodeGMO(ctx context.Context, protoData *ProtoData, scanParameters decoder
 	var newNearbyPokemon []decoder.RawNearbyPokemonData
 	var newMapPokemon []decoder.RawMapPokemonData
 	var newMapCells []uint64
-	var cellsToBeCleaned []uint64
 
-	// track forts per cell for memory-based cleanup (only if tracker enabled)
+	// track forts per cell for memory-based cleanup (every map cell gets an
+	// entry, so empty fort lists are seen as "no forts" by the tracker)
 	cellForts := make(map[uint64]*decoder.FortTrackerGMOContents)
 
 	if len(decodedGmo.MapCell) == 0 {
 		return "Skipping GetMapObjectsOutProto: No map cells found"
 	}
 	for _, mapCell := range decodedGmo.MapCell {
-		// initialize cell forts tracking for every map cell (so empty fort lists are seen as "no forts")
 		cellForts[mapCell.S2CellId] = &decoder.FortTrackerGMOContents{
 			Pokestops: make([]string, 0),
 			Gyms:      make([]string, 0),
 			Timestamp: mapCell.AsOfTimeMs,
 		}
-		// always mark this mapCell to be checked for removed forts. Previously only cells with forts were
-		// added which meant an empty fort list (all forts removed) was never passed to the tracker.
-		cellsToBeCleaned = append(cellsToBeCleaned, mapCell.S2CellId)
 
 		if isCellNotEmpty(mapCell) {
 			newMapCells = append(newMapCells, mapCell.S2CellId)
@@ -562,7 +558,7 @@ func decodeGMO(ctx context.Context, protoData *ProtoData, scanParameters decoder
 	}
 
 	if scanParameters.ProcessGyms || scanParameters.ProcessPokestops {
-		decoder.CheckRemovedForts(ctx, dbDetails, cellsToBeCleaned, cellForts)
+		decoder.CheckRemovedForts(ctx, dbDetails, cellForts)
 	}
 
 	newFortsLen := len(newForts)

--- a/decoder/fort_tracker.go
+++ b/decoder/fort_tracker.go
@@ -24,6 +24,7 @@ type FortTracker struct {
 
 	// Configuration
 	staleThreshold int64 // seconds after which a fort is considered stale
+	minMissCount   int   // consecutive cell scans a fort must be missing before staleness
 }
 
 // FortTrackerCellState tracks the state of forts within a single S2 cell
@@ -35,9 +36,10 @@ type FortTrackerCellState struct {
 
 // FortTrackerLastSeen holds tracker bookkeeping (cell + last-seen + type) for a fort
 type FortTrackerLastSeen struct {
-	cellId   uint64
-	lastSeen int64 // last time this fort was seen in GMO
-	isGym    bool  // faster targeted removal
+	cellId    uint64
+	lastSeen  int64 // last time this fort was seen in GMO
+	missCount int   // consecutive cell scans where this fort was absent
+	isGym     bool  // faster targeted removal
 }
 
 // FortTrackerGMOContents holds fort IDs per cell extracted from a single GMO
@@ -50,14 +52,20 @@ type FortTrackerGMOContents struct {
 // Global fort tracker instance
 var fortTracker *FortTracker
 
-// InitFortTracker initializes the global fort tracker
-func InitFortTracker(staleThresholdSeconds int64) {
+// InitFortTracker initializes the global fort tracker.
+// minMissCount must be >= 1 (1 = previous behavior, >1 = require multiple
+// consecutive cell scans missing the fort before flagging it stale).
+func InitFortTracker(staleThresholdSeconds int64, minMissCount int) {
+	if minMissCount < 1 {
+		minMissCount = 1
+	}
 	fortTracker = &FortTracker{
 		cells:          make(map[uint64]*FortTrackerCellState),
 		forts:          make(map[string]*FortTrackerLastSeen),
 		staleThreshold: staleThresholdSeconds,
+		minMissCount:   minMissCount,
 	}
-	log.Infof("FortTracker: initialized with stale threshold of %d seconds", staleThresholdSeconds)
+	log.Infof("FortTracker: initialized with stale threshold of %d seconds, min miss count %d", staleThresholdSeconds, minMissCount)
 }
 
 // LoadFortsFromDB populates the tracker from database on startup
@@ -114,6 +122,9 @@ func loadFortKindFromDB(ctx context.Context, dbDetails db.DbDetails, table strin
 			break
 		}
 
+		// "now" rather than row.Updated: load is a confirmation event.
+		// See preloadPokestops for rationale.
+		nowMs := time.Now().UnixMilli()
 		fortTracker.mu.Lock()
 		for _, row := range rows {
 			cellId := uint64(row.CellId)
@@ -123,9 +134,12 @@ func loadFortKindFromDB(ctx context.Context, dbDetails db.DbDetails, table strin
 			} else {
 				cell.pokestops[row.Id] = struct{}{}
 			}
+			if nowMs > cell.lastSeen {
+				cell.lastSeen = nowMs
+			}
 			fortTracker.forts[row.Id] = &FortTrackerLastSeen{
 				cellId:   cellId,
-				lastSeen: row.Updated * 1000, // convert to milliseconds
+				lastSeen: nowMs,
 				isGym:    isGym,
 			}
 		}
@@ -272,6 +286,7 @@ func (ft *FortTracker) processCellUpdateLocked(cellId uint64, pokestopIds []stri
 			}
 			if info, ok := ft.forts[stopId]; ok {
 				info.lastSeen = timestamp
+				info.missCount = 0
 			}
 			currentPokestops[stopId] = struct{}{}
 		}
@@ -281,6 +296,7 @@ func (ft *FortTracker) processCellUpdateLocked(cellId uint64, pokestopIds []stri
 			}
 			if info, ok := ft.forts[gymId]; ok {
 				info.lastSeen = timestamp
+				info.missCount = 0
 			}
 			currentGyms[gymId] = struct{}{}
 		}
@@ -291,17 +307,24 @@ func (ft *FortTracker) processCellUpdateLocked(cellId uint64, pokestopIds []stri
 
 	var pendingPokestops, pendingGyms []string
 
+	// A fort qualifies as stale only when both criteria are met:
+	// - missing for at least staleThreshold (time-based, defends against partial GMOs)
+	// - absent from at least minMissCount consecutive cell scans (count-based,
+	//   defends against transient single-frame coverage gaps / level-30 gating).
 	for stopId := range cell.pokestops {
 		if _, inGMO := currentPokestops[stopId]; inGMO {
 			continue
 		}
-		if info, exists := ft.forts[stopId]; exists {
-			missingDuration := timestamp - info.lastSeen
-			if missingDuration >= ft.staleThreshold*1000 { // staleThreshold is in seconds, timestamp in ms
-				result.StalePokestops = append(result.StalePokestops, stopId)
-			} else {
-				pendingPokestops = append(pendingPokestops, stopId)
-			}
+		info, exists := ft.forts[stopId]
+		if !exists {
+			continue
+		}
+		info.missCount++
+		missingDuration := timestamp - info.lastSeen
+		if missingDuration >= ft.staleThreshold*1000 && info.missCount >= ft.minMissCount {
+			result.StalePokestops = append(result.StalePokestops, stopId)
+		} else {
+			pendingPokestops = append(pendingPokestops, stopId)
 		}
 	}
 
@@ -309,13 +332,16 @@ func (ft *FortTracker) processCellUpdateLocked(cellId uint64, pokestopIds []stri
 		if _, inGMO := currentGyms[gymId]; inGMO {
 			continue
 		}
-		if info, exists := ft.forts[gymId]; exists {
-			missingDuration := timestamp - info.lastSeen
-			if missingDuration >= ft.staleThreshold*1000 { // staleThreshold is in seconds, timestamp in ms
-				result.StaleGyms = append(result.StaleGyms, gymId)
-			} else {
-				pendingGyms = append(pendingGyms, gymId)
-			}
+		info, exists := ft.forts[gymId]
+		if !exists {
+			continue
+		}
+		info.missCount++
+		missingDuration := timestamp - info.lastSeen
+		if missingDuration >= ft.staleThreshold*1000 && info.missCount >= ft.minMissCount {
+			result.StaleGyms = append(result.StaleGyms, gymId)
+		} else {
+			pendingGyms = append(pendingGyms, gymId)
 		}
 	}
 
@@ -376,6 +402,7 @@ func (ft *FortTracker) applyPresentForts(cell *FortTrackerCellState, cellId uint
 			}
 		}
 		info.lastSeen = timestamp
+		info.missCount = 0
 		// Defensive: ensure fort lives in this cell's set even if a later
 		// early-return is added before cell.pokestops/gyms is reassigned.
 		if isGym {
@@ -432,9 +459,10 @@ func (ft *FortTracker) RestoreFort(fortId string, cellId uint64, isGym bool, now
 	}
 
 	ft.forts[fortId] = &FortTrackerLastSeen{
-		cellId:   cellId,
-		lastSeen: nowMs,
-		isGym:    isGym,
+		cellId:    cellId,
+		lastSeen:  nowMs,
+		missCount: 0,
+		isGym:     isGym,
 	}
 }
 

--- a/decoder/fort_tracker.go
+++ b/decoder/fort_tracker.go
@@ -201,7 +201,8 @@ func (ft *FortTracker) getOrCreateCellLocked(cellId uint64) *FortTrackerCellStat
 }
 
 // RegisterFort registers a fort during bulk loading (e.g., from preload).
-// Unlike UpdateFort, this uses the provided timestamp rather than "now".
+// Seeds cell.lastSeen so a partial first GMO does not erase preloaded forts.
+// Does not rewind info.lastSeen if a more recent value is already tracked.
 func (ft *FortTracker) RegisterFort(fortId string, cellId uint64, isGym bool, updatedTimestamp int64) {
 	ft.mu.Lock()
 	defer ft.mu.Unlock()
@@ -214,45 +215,16 @@ func (ft *FortTracker) RegisterFort(fortId string, cellId uint64, isGym bool, up
 		cell.pokestops[fortId] = struct{}{}
 	}
 
+	if updatedTimestamp > cell.lastSeen {
+		cell.lastSeen = updatedTimestamp
+	}
+
+	if existing, exists := ft.forts[fortId]; exists && updatedTimestamp <= existing.lastSeen {
+		return
+	}
 	ft.forts[fortId] = &FortTrackerLastSeen{
 		cellId:   cellId,
 		lastSeen: updatedTimestamp,
-		isGym:    isGym,
-	}
-}
-
-// UpdateFort updates tracking for a single fort seen in GMO
-func (ft *FortTracker) UpdateFort(fortId string, cellId uint64, isGym bool, now int64) {
-	ft.mu.Lock()
-	defer ft.mu.Unlock()
-
-	// Get or create cell
-	cell := ft.getOrCreateCellLocked(cellId)
-
-	// Check if fort moved cells
-	if existing, exists := ft.forts[fortId]; exists && existing.cellId != cellId {
-		// Fort moved to a different cell - remove from old cell
-		oldCell, oldExists := ft.cells[existing.cellId]
-		if oldExists {
-			if existing.isGym {
-				delete(oldCell.gyms, fortId)
-			} else {
-				delete(oldCell.pokestops, fortId)
-			}
-		}
-	}
-
-	// Add to current cell
-	if isGym {
-		cell.gyms[fortId] = struct{}{}
-	} else {
-		cell.pokestops[fortId] = struct{}{}
-	}
-
-	// Update fort info
-	ft.forts[fortId] = &FortTrackerLastSeen{
-		cellId:   cellId,
-		lastSeen: now,
 		isGym:    isGym,
 	}
 }
@@ -268,10 +240,19 @@ type CellUpdateResult struct {
 // ProcessCellUpdate processes a complete cell update from GMO and returns forts to delete.
 // Logic: if fort.lastSeen < cell.lastSeen, fort is missing from cell.
 // Remove when cell.lastSeen - fort.lastSeen > staleThreshold.
-// Returns nil if timestamp is older than last processed for this cell.
+// Returns nil if timestamp is older than last processed for this cell, or
+// far enough in the future to look implausible (clock skew / malicious input).
 func (ft *FortTracker) ProcessCellUpdate(cellId uint64, pokestopIds []string, gymIds []string, timestamp int64) *CellUpdateResult {
 	ft.mu.Lock()
 	defer ft.mu.Unlock()
+
+	// Reject implausibly future timestamps so a single bad GMO cannot
+	// permanently wedge a cell (any later real GMO would always be <= it).
+	nowMs := time.Now().UnixMilli()
+	if timestamp > nowMs+60_000 {
+		log.Warnf("FortTracker: rejecting GMO with future timestamp cell=%d ts=%d now=%d", cellId, timestamp, nowMs)
+		return nil
+	}
 
 	cell := ft.getOrCreateCellLocked(cellId)
 
@@ -282,7 +263,9 @@ func (ft *FortTracker) ProcessCellUpdate(cellId uint64, pokestopIds []string, gy
 
 	result := CellUpdateResult{}
 
-	// Build sets of current forts from GMO
+	// Build sets of current forts from GMO. If the same id appears in both
+	// pokestopIds and gymIds (Niantic-side type-change race), gym wins —
+	// matches proto pack order and avoids the conversion loop fighting itself.
 	currentPokestops := make(map[string]struct{}, len(pokestopIds))
 	for _, id := range pokestopIds {
 		currentPokestops[id] = struct{}{}
@@ -291,66 +274,41 @@ func (ft *FortTracker) ProcessCellUpdate(cellId uint64, pokestopIds []string, gy
 	for _, id := range gymIds {
 		currentGyms[id] = struct{}{}
 	}
+	for id := range currentGyms {
+		delete(currentPokestops, id)
+	}
 
 	// Check if this is the first time we're seeing this cell
 	firstScan := cell.lastSeen == 0
 
-	// Update lastSeen for forts present in GMO and handle cell moves / type changes
-	for _, id := range pokestopIds {
-		if info, exists := ft.forts[id]; exists {
-			// Handle cell move
-			if info.cellId != cellId {
-				if oldCell, oldExists := ft.cells[info.cellId]; oldExists {
-					if info.isGym {
-						delete(oldCell.gyms, id)
-					} else {
-						delete(oldCell.pokestops, id)
-					}
-				}
-				info.cellId = cellId
-			}
-			// Handle type change (gym -> pokestop)
-			if info.isGym {
-				info.isGym = false
-				result.ConvertedToPokestops = append(result.ConvertedToPokestops, id)
-				log.Infof("FortTracker: fort %s converted from gym to pokestop", id)
-			}
-			info.lastSeen = timestamp
-		} else {
-			ft.forts[id] = &FortTrackerLastSeen{cellId: cellId, lastSeen: timestamp, isGym: false}
-		}
-	}
-	for _, id := range gymIds {
-		if info, exists := ft.forts[id]; exists {
-			// Handle cell move
-			if info.cellId != cellId {
-				if oldCell, oldExists := ft.cells[info.cellId]; oldExists {
-					if info.isGym {
-						delete(oldCell.gyms, id)
-					} else {
-						delete(oldCell.pokestops, id)
-					}
-				}
-				info.cellId = cellId
-			}
-			// Handle type change (pokestop -> gym)
-			if !info.isGym {
-				info.isGym = true
-				result.ConvertedToGyms = append(result.ConvertedToGyms, id)
-				log.Infof("FortTracker: fort %s converted from pokestop to gym", id)
-			}
-			info.lastSeen = timestamp
-		} else {
-			ft.forts[id] = &FortTrackerLastSeen{cellId: cellId, lastSeen: timestamp, isGym: true}
-		}
-	}
+	ft.applyPresentForts(cell, cellId, pokestopIds, currentPokestops, false, &result.ConvertedToPokestops, timestamp)
+	ft.applyPresentForts(cell, cellId, gymIds, currentGyms, true, &result.ConvertedToGyms, timestamp)
 
 	// Update cell lastSeen
 	cell.lastSeen = timestamp
 
-	// Skip stale check on first scan - we need at least one prior scan to compare against
-	// But still update cell fort sets so new forts are tracked for future scans
+	// First scan: merge previously-tracked forts into the GMO set instead of
+	// replacing, otherwise preloaded forts not in this partial GMO disappear
+	// from cell tracking and are never checked for staleness again.
 	if firstScan {
+		for stopId := range cell.pokestops {
+			if _, inGMO := currentPokestops[stopId]; inGMO {
+				continue
+			}
+			if info, ok := ft.forts[stopId]; ok {
+				info.lastSeen = timestamp
+			}
+			currentPokestops[stopId] = struct{}{}
+		}
+		for gymId := range cell.gyms {
+			if _, inGMO := currentGyms[gymId]; inGMO {
+				continue
+			}
+			if info, ok := ft.forts[gymId]; ok {
+				info.lastSeen = timestamp
+			}
+			currentGyms[gymId] = struct{}{}
+		}
 		cell.pokestops = currentPokestops
 		cell.gyms = currentGyms
 		return &result
@@ -409,6 +367,56 @@ func (ft *FortTracker) ProcessCellUpdate(cellId uint64, pokestopIds []string, gy
 	return &result
 }
 
+// applyPresentForts updates lastSeen for forts present in the GMO, handles
+// cell moves and type conversions. `current` is the deduplicated set for the
+// fort kind being processed; ids skipped via dedup are ignored.
+func (ft *FortTracker) applyPresentForts(cell *FortTrackerCellState, cellId uint64, ids []string, current map[string]struct{}, isGym bool, converted *[]string, timestamp int64) {
+	for _, id := range ids {
+		if _, ok := current[id]; !ok {
+			continue
+		}
+		info, exists := ft.forts[id]
+		if !exists {
+			ft.forts[id] = &FortTrackerLastSeen{cellId: cellId, lastSeen: timestamp, isGym: isGym}
+			if isGym {
+				cell.gyms[id] = struct{}{}
+			} else {
+				cell.pokestops[id] = struct{}{}
+			}
+			continue
+		}
+		// Handle cell move
+		if info.cellId != cellId {
+			if oldCell, oldExists := ft.cells[info.cellId]; oldExists {
+				if info.isGym {
+					delete(oldCell.gyms, id)
+				} else {
+					delete(oldCell.pokestops, id)
+				}
+			}
+			info.cellId = cellId
+		}
+		// Handle type change
+		if info.isGym != isGym {
+			info.isGym = isGym
+			*converted = append(*converted, id)
+			if isGym {
+				log.Infof("FortTracker: fort %s converted from pokestop to gym", id)
+			} else {
+				log.Infof("FortTracker: fort %s converted from gym to pokestop", id)
+			}
+		}
+		info.lastSeen = timestamp
+		// Defensive: ensure fort lives in this cell's set even if a later
+		// early-return is added before cell.pokestops/gyms is reassigned.
+		if isGym {
+			cell.gyms[id] = struct{}{}
+		} else {
+			cell.pokestops[id] = struct{}{}
+		}
+	}
+}
+
 // RemoveFort removes a fort from tracking (called after marking as deleted)
 func (ft *FortTracker) RemoveFort(fortId string) {
 	ft.mu.Lock()
@@ -432,9 +440,35 @@ func (ft *FortTracker) RemoveFort(fortId string) {
 	delete(ft.forts, fortId)
 }
 
-// RestoreFort adds a fort back to tracking (called when un-deleting)
-func (ft *FortTracker) RestoreFort(fortId string, cellId uint64, isGym bool, now int64) {
-	ft.UpdateFort(fortId, cellId, isGym, now)
+// RestoreFort adds a fort back to tracking (called when un-deleting).
+// nowMs MUST be milliseconds (matches tracker's internal unit).
+func (ft *FortTracker) RestoreFort(fortId string, cellId uint64, isGym bool, nowMs int64) {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+
+	cell := ft.getOrCreateCellLocked(cellId)
+
+	if existing, exists := ft.forts[fortId]; exists && existing.cellId != cellId {
+		if oldCell, ok := ft.cells[existing.cellId]; ok {
+			if existing.isGym {
+				delete(oldCell.gyms, fortId)
+			} else {
+				delete(oldCell.pokestops, fortId)
+			}
+		}
+	}
+
+	if isGym {
+		cell.gyms[fortId] = struct{}{}
+	} else {
+		cell.pokestops[fortId] = struct{}{}
+	}
+
+	ft.forts[fortId] = &FortTrackerLastSeen{
+		cellId:   cellId,
+		lastSeen: nowMs,
+		isGym:    isGym,
+	}
 }
 
 // GetFortTracker returns the global fort tracker instance
@@ -521,7 +555,10 @@ func clearGymWithLock(ctx context.Context, dbDetails db.DbDetails, gymId string,
 		return
 	}
 	if gym == nil {
-		log.Warnf("FortTracker: gym %s not found in cache or database", gymId)
+		log.Warnf("FortTracker: gym %s not found in cache or database, clearing tracker entry", gymId)
+		if removeFromTracker {
+			fortTracker.RemoveFort(gymId)
+		}
 		return
 	}
 
@@ -556,7 +593,10 @@ func clearPokestopWithLock(ctx context.Context, dbDetails db.DbDetails, stopId s
 		return
 	}
 	if pokestop == nil {
-		log.Warnf("FortTracker: pokestop %s not found in cache or database", stopId)
+		log.Warnf("FortTracker: pokestop %s not found in cache or database, clearing tracker entry", stopId)
+		if removeFromTracker {
+			fortTracker.RemoveFort(stopId)
+		}
 		return
 	}
 

--- a/decoder/fort_tracker.go
+++ b/decoder/fort_tracker.go
@@ -3,6 +3,7 @@ package decoder
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -25,21 +26,21 @@ type FortTracker struct {
 	staleThreshold int64 // seconds after which a fort is considered stale
 }
 
-// CellFortState tracks the state of forts within a single S2 cell
+// FortTrackerCellState tracks the state of forts within a single S2 cell
 type FortTrackerCellState struct {
 	lastSeen  int64               // last time this cell was seen in GMO
 	pokestops map[string]struct{} // set of pokestop IDs
 	gyms      map[string]struct{} // set of gym IDs
 }
 
-// FortInfo tracks individual fort metadata
+// FortTrackerLastSeen holds tracker bookkeeping (cell + last-seen + type) for a fort
 type FortTrackerLastSeen struct {
 	cellId   uint64
 	lastSeen int64 // last time this fort was seen in GMO
 	isGym    bool  // faster targeted removal
 }
 
-// CellFortsData holds fort IDs per cell from GMO processing
+// FortTrackerGMOContents holds fort IDs per cell extracted from a single GMO
 type FortTrackerGMOContents struct {
 	Pokestops []string
 	Gyms      []string
@@ -67,14 +68,12 @@ func LoadFortsFromDB(ctx context.Context, dbDetails db.DbDetails) error {
 
 	startTime := time.Now()
 
-	// Load pokestops
-	pokestopCount, err := loadPokestopsFromDB(ctx, dbDetails)
+	pokestopCount, err := loadFortKindFromDB(ctx, dbDetails, "pokestop", false)
 	if err != nil {
 		return err
 	}
 
-	// Load gyms
-	gymCount, err := loadGymsFromDB(ctx, dbDetails)
+	gymCount, err := loadFortKindFromDB(ctx, dbDetails, "gym", true)
 	if err != nil {
 		return err
 	}
@@ -87,23 +86,27 @@ func LoadFortsFromDB(ctx context.Context, dbDetails db.DbDetails) error {
 
 const loadBatchSize = 30000
 
-func loadPokestopsFromDB(ctx context.Context, dbDetails db.DbDetails) (int, error) {
-	type pokestopRow struct {
+// loadFortKindFromDB streams non-deleted forts of a single kind into the tracker.
+// `table` is a hardcoded literal (not user input), so the Sprintf is not a SQL injection vector.
+func loadFortKindFromDB(ctx context.Context, dbDetails db.DbDetails, table string, isGym bool) (int, error) {
+	type fortRow struct {
 		Id      string `db:"id"`
 		CellId  int64  `db:"cell_id"`
 		Updated int64  `db:"updated"`
 	}
 
+	query := fmt.Sprintf(
+		"SELECT id, cell_id, updated FROM %s WHERE deleted = 0 AND cell_id IS NOT NULL AND id > ? ORDER BY id LIMIT ?",
+		table,
+	)
+
 	var totalCount int
 	var lastId string
 
 	for {
-		rows := []pokestopRow{}
-		err := dbDetails.GeneralDb.SelectContext(ctx, &rows,
-			"SELECT id, cell_id, updated FROM pokestop WHERE deleted = 0 AND cell_id IS NOT NULL AND id > ? ORDER BY id LIMIT ?",
-			lastId, loadBatchSize)
-		if err != nil {
-			log.Errorf("FortTracker: failed to load pokestops - %s", err)
+		rows := []fortRow{}
+		if err := dbDetails.GeneralDb.SelectContext(ctx, &rows, query, lastId, loadBatchSize); err != nil {
+			log.Errorf("FortTracker: failed to load %s - %s", table, err)
 			return totalCount, err
 		}
 
@@ -115,11 +118,15 @@ func loadPokestopsFromDB(ctx context.Context, dbDetails db.DbDetails) (int, erro
 		for _, row := range rows {
 			cellId := uint64(row.CellId)
 			cell := fortTracker.getOrCreateCellLocked(cellId)
-			cell.pokestops[row.Id] = struct{}{}
+			if isGym {
+				cell.gyms[row.Id] = struct{}{}
+			} else {
+				cell.pokestops[row.Id] = struct{}{}
+			}
 			fortTracker.forts[row.Id] = &FortTrackerLastSeen{
 				cellId:   cellId,
 				lastSeen: row.Updated * 1000, // convert to milliseconds
-				isGym:    false,
+				isGym:    isGym,
 			}
 		}
 		fortTracker.mu.Unlock()
@@ -131,57 +138,7 @@ func loadPokestopsFromDB(ctx context.Context, dbDetails db.DbDetails) (int, erro
 			break
 		}
 
-		log.Debugf("FortTracker: loading pokestops... %d so far", totalCount)
-	}
-
-	return totalCount, nil
-}
-
-func loadGymsFromDB(ctx context.Context, dbDetails db.DbDetails) (int, error) {
-	type gymRow struct {
-		Id      string `db:"id"`
-		CellId  int64  `db:"cell_id"`
-		Updated int64  `db:"updated"`
-	}
-
-	var totalCount int
-	var lastId string
-
-	for {
-		rows := []gymRow{}
-		err := dbDetails.GeneralDb.SelectContext(ctx, &rows,
-			"SELECT id, cell_id, updated FROM gym WHERE deleted = 0 AND cell_id IS NOT NULL AND id > ? ORDER BY id LIMIT ?",
-			lastId, loadBatchSize)
-		if err != nil {
-			log.Errorf("FortTracker: failed to load gyms - %s", err)
-			return totalCount, err
-		}
-
-		if len(rows) == 0 {
-			break
-		}
-
-		fortTracker.mu.Lock()
-		for _, row := range rows {
-			cellId := uint64(row.CellId)
-			cell := fortTracker.getOrCreateCellLocked(cellId)
-			cell.gyms[row.Id] = struct{}{}
-			fortTracker.forts[row.Id] = &FortTrackerLastSeen{
-				cellId:   cellId,
-				lastSeen: row.Updated * 1000, // convert to milliseconds
-				isGym:    true,
-			}
-		}
-		fortTracker.mu.Unlock()
-
-		totalCount += len(rows)
-		lastId = rows[len(rows)-1].Id
-
-		if len(rows) < loadBatchSize {
-			break
-		}
-
-		log.Debugf("FortTracker: loading gyms... %d so far", totalCount)
+		log.Debugf("FortTracker: loading %s... %d so far", table, totalCount)
 	}
 
 	return totalCount, nil
@@ -243,9 +200,6 @@ type CellUpdateResult struct {
 // Returns nil if timestamp is older than last processed for this cell, or
 // far enough in the future to look implausible (clock skew / malicious input).
 func (ft *FortTracker) ProcessCellUpdate(cellId uint64, pokestopIds []string, gymIds []string, timestamp int64) *CellUpdateResult {
-	ft.mu.Lock()
-	defer ft.mu.Unlock()
-
 	// Reject implausibly future timestamps so a single bad GMO cannot
 	// permanently wedge a cell (any later real GMO would always be <= it).
 	nowMs := time.Now().UnixMilli()
@@ -254,14 +208,37 @@ func (ft *FortTracker) ProcessCellUpdate(cellId uint64, pokestopIds []string, gy
 		return nil
 	}
 
-	cell := ft.getOrCreateCellLocked(cellId)
+	ft.mu.Lock()
+	result, pendingPokestops, pendingGyms, processed := ft.processCellUpdateLocked(cellId, pokestopIds, gymIds, timestamp)
+	ft.mu.Unlock()
 
-	// Skip if this GMO is older than the last one we processed for this cell
-	if timestamp <= cell.lastSeen {
+	if !processed {
 		return nil
 	}
 
-	result := CellUpdateResult{}
+	// Hoisted out of locked section: log message formatting / slice boxing is
+	// not worth holding the global tracker lock for.
+	if len(pendingPokestops) > 0 {
+		log.Debugf("FortTracker: cell %d has %d pokestop(s) pending removal: %v", cellId, len(pendingPokestops), pendingPokestops)
+	}
+	if len(pendingGyms) > 0 {
+		log.Debugf("FortTracker: cell %d has %d gym(s) pending removal: %v", cellId, len(pendingGyms), pendingGyms)
+	}
+
+	return result
+}
+
+// processCellUpdateLocked is the locked core of ProcessCellUpdate.
+// Caller must hold ft.mu. Returns (result, pendingPokestops, pendingGyms, processed).
+// processed is false when the GMO is older than our last processed timestamp for this cell.
+func (ft *FortTracker) processCellUpdateLocked(cellId uint64, pokestopIds []string, gymIds []string, timestamp int64) (*CellUpdateResult, []string, []string, bool) {
+	cell := ft.getOrCreateCellLocked(cellId)
+
+	if timestamp <= cell.lastSeen {
+		return nil, nil, nil, false
+	}
+
+	result := &CellUpdateResult{}
 
 	// Build sets of current forts from GMO. If the same id appears in both
 	// pokestopIds and gymIds (Niantic-side type-change race), gym wins —
@@ -278,13 +255,11 @@ func (ft *FortTracker) ProcessCellUpdate(cellId uint64, pokestopIds []string, gy
 		delete(currentPokestops, id)
 	}
 
-	// Check if this is the first time we're seeing this cell
 	firstScan := cell.lastSeen == 0
 
 	ft.applyPresentForts(cell, cellId, pokestopIds, currentPokestops, false, &result.ConvertedToPokestops, timestamp)
 	ft.applyPresentForts(cell, cellId, gymIds, currentGyms, true, &result.ConvertedToGyms, timestamp)
 
-	// Update cell lastSeen
 	cell.lastSeen = timestamp
 
 	// First scan: merge previously-tracked forts into the GMO set instead of
@@ -311,10 +286,9 @@ func (ft *FortTracker) ProcessCellUpdate(cellId uint64, pokestopIds []string, gy
 		}
 		cell.pokestops = currentPokestops
 		cell.gyms = currentGyms
-		return &result
+		return result, nil, nil, true
 	}
 
-	// Check forts in cell: if fort.lastSeen < cell.lastSeen, it's missing
 	var pendingPokestops, pendingGyms []string
 
 	for stopId := range cell.pokestops {
@@ -345,13 +319,6 @@ func (ft *FortTracker) ProcessCellUpdate(cellId uint64, pokestopIds []string, gy
 		}
 	}
 
-	if len(pendingPokestops) > 0 {
-		log.Debugf("FortTracker: cell %d has %d pokestop(s) pending removal: %v", cellId, len(pendingPokestops), pendingPokestops)
-	}
-	if len(pendingGyms) > 0 {
-		log.Debugf("FortTracker: cell %d has %d gym(s) pending removal: %v", cellId, len(pendingGyms), pendingGyms)
-	}
-
 	// Keep pending forts in cell tracking so they are checked again on subsequent scans
 	for _, stopId := range pendingPokestops {
 		currentPokestops[stopId] = struct{}{}
@@ -360,11 +327,10 @@ func (ft *FortTracker) ProcessCellUpdate(cellId uint64, pokestopIds []string, gy
 		currentGyms[gymId] = struct{}{}
 	}
 
-	// Update cell fort sets with current GMO data (including pending forts)
 	cell.pokestops = currentPokestops
 	cell.gyms = currentGyms
 
-	return &result
+	return result, pendingPokestops, pendingGyms, true
 }
 
 // applyPresentForts updates lastSeen for forts present in the GMO, handles
@@ -396,14 +362,17 @@ func (ft *FortTracker) applyPresentForts(cell *FortTrackerCellState, cellId uint
 			}
 			info.cellId = cellId
 		}
-		// Handle type change
+		// Handle type change. The follow-up clear*WithLock call already logs
+		// the conversion at Info level, so we keep this trace at Debug.
 		if info.isGym != isGym {
 			info.isGym = isGym
 			*converted = append(*converted, id)
-			if isGym {
-				log.Infof("FortTracker: fort %s converted from pokestop to gym", id)
-			} else {
-				log.Infof("FortTracker: fort %s converted from gym to pokestop", id)
+			if log.IsLevelEnabled(log.DebugLevel) {
+				if isGym {
+					log.Debugf("FortTracker: fort %s converted from pokestop to gym", id)
+				} else {
+					log.Debugf("FortTracker: fort %s converted from gym to pokestop", id)
+				}
 			}
 		}
 		info.lastSeen = timestamp
@@ -427,7 +396,6 @@ func (ft *FortTracker) RemoveFort(fortId string) {
 		return
 	}
 
-	// Remove from cell
 	if cell, cellExists := ft.cells[info.cellId]; cellExists {
 		if info.isGym {
 			delete(cell.gyms, fortId)
@@ -436,7 +404,6 @@ func (ft *FortTracker) RemoveFort(fortId string) {
 		}
 	}
 
-	// Remove from forts map
 	delete(ft.forts, fortId)
 }
 
@@ -517,7 +484,7 @@ func (ft *FortTracker) GetCellInfo(cellId uint64) *CellFortInfo {
 	}
 
 	return &CellFortInfo{
-		CellId:    fmt.Sprintf("%d", cellId),
+		CellId:    strconv.FormatUint(cellId, 10),
 		LastSeen:  cell.lastSeen,
 		Pokestops: pokestops,
 		Gyms:      gyms,
@@ -540,114 +507,109 @@ func (ft *FortTracker) GetFortInfo(fortId string) *FortTrackerInfo {
 
 	return &FortTrackerInfo{
 		FortId:   fortId,
-		CellId:   fmt.Sprintf("%d", fort.cellId),
+		CellId:   strconv.FormatUint(fort.cellId, 10),
 		LastSeen: fort.lastSeen,
 		IsGym:    fort.isGym,
 	}
 }
 
-// clearGymWithLock marks a gym as deleted while holding the object-level mutex
-func clearGymWithLock(ctx context.Context, dbDetails db.DbDetails, gymId string, cellId uint64, removeFromTracker bool) {
-	// Load gym through cache (will load from DB if not cached)
-	gym, unlock, err := getGymRecordForUpdate(ctx, dbDetails, gymId, "clearGymWithLock")
+// fortKindOps captures the type-specific bits clearFortWithLock needs
+// so the gym/pokestop control flow can share a single implementation.
+type fortKindOps[T comparable] struct {
+	kindLabel        string
+	convertedToLabel string
+	statDelete       string
+	statConvert      string
+	loadForUpdate    func(context.Context, db.DbDetails, string, string) (T, func(), error)
+	saveRecord       func(context.Context, db.DbDetails, T)
+	initWebhook      func(T) *FortWebhook
+	setDeleted       func(T)
+	isNil            func(T) bool
+}
+
+var gymClearOps = fortKindOps[*Gym]{
+	kindLabel:        "gym",
+	convertedToLabel: "pokestop",
+	statDelete:       "gym_delete",
+	statConvert:      "gym_to_pokestop",
+	loadForUpdate:    getGymRecordForUpdate,
+	saveRecord:       saveGymRecord,
+	initWebhook:      InitWebHookFortFromGym,
+	setDeleted:       func(g *Gym) { g.SetDeleted(true) },
+	isNil:            func(g *Gym) bool { return g == nil },
+}
+
+var pokestopClearOps = fortKindOps[*Pokestop]{
+	kindLabel:        "pokestop",
+	convertedToLabel: "gym",
+	statDelete:       "pokestop_delete",
+	statConvert:      "pokestop_to_gym",
+	loadForUpdate:    getPokestopRecordForUpdate,
+	saveRecord:       savePokestopRecord,
+	initWebhook:      InitWebHookFortFromPokestop,
+	setDeleted:       func(p *Pokestop) { p.SetDeleted(true) },
+	isNil:            func(p *Pokestop) bool { return p == nil },
+}
+
+// clearFortWithLock marks a fort as deleted while holding its object-level mutex.
+// removeFromTracker=true means stale removal (drop tracker entry, fire webhook);
+// false means type conversion (the *other* type still exists in the tracker).
+func clearFortWithLock[T comparable](ctx context.Context, dbDetails db.DbDetails, fortId string, cellId uint64, removeFromTracker bool, ops fortKindOps[T]) {
+	rec, unlock, err := ops.loadForUpdate(ctx, dbDetails, fortId, "clear"+ops.kindLabel+"WithLock")
 	if err != nil {
-		log.Errorf("FortTracker: failed to load gym %s - %s", gymId, err)
+		log.Errorf("FortTracker: failed to load %s %s - %s", ops.kindLabel, fortId, err)
 		return
 	}
-	if gym == nil {
-		log.Warnf("FortTracker: gym %s not found in cache or database, clearing tracker entry", gymId)
+	if ops.isNil(rec) {
+		log.Warnf("FortTracker: %s %s not found in cache or database, clearing tracker entry", ops.kindLabel, fortId)
 		if removeFromTracker {
-			fortTracker.RemoveFort(gymId)
+			fortTracker.RemoveFort(fortId)
 		}
 		return
 	}
 
-	// Mark as deleted and save through write-behind queue
-	gym.SetDeleted(true)
-	saveGymRecord(ctx, dbDetails, gym)
+	ops.setDeleted(rec)
+	ops.saveRecord(ctx, dbDetails, rec)
 
-	// Build webhook payload while we still hold the lock
 	var fort *FortWebhook
 	if removeFromTracker {
-		fort = InitWebHookFortFromGym(gym)
+		fort = ops.initWebhook(rec)
 	}
 	unlock()
 
 	if removeFromTracker {
-		fortTracker.RemoveFort(gymId)
-		log.Infof("FortTracker: removed gym in cell %d: %s", cellId, gymId)
+		fortTracker.RemoveFort(fortId)
+		log.Infof("FortTracker: removed %s in cell %d: %s", ops.kindLabel, cellId, fortId)
 		CreateFortChangeWebhooks(fort, REMOVAL)
-		statsCollector.IncFortChange("gym_delete")
+		statsCollector.IncFortChange(ops.statDelete)
 	} else {
-		log.Infof("FortTracker: marked gym as deleted (converted to pokestop) in cell %d: %s", cellId, gymId)
-		statsCollector.IncFortChange("gym_to_pokestop")
+		log.Infof("FortTracker: marked %s as deleted (converted to %s) in cell %d: %s", ops.kindLabel, ops.convertedToLabel, cellId, fortId)
+		statsCollector.IncFortChange(ops.statConvert)
 	}
 }
 
-// clearPokestopWithLock marks a pokestop as deleted while holding the object-level mutex
-func clearPokestopWithLock(ctx context.Context, dbDetails db.DbDetails, stopId string, cellId uint64, removeFromTracker bool) {
-	// Load pokestop through cache (will load from DB if not cached)
-	pokestop, unlock, err := getPokestopRecordForUpdate(ctx, dbDetails, stopId, "clearPokestopWithLock")
-	if err != nil {
-		log.Errorf("FortTracker: failed to load pokestop %s - %s", stopId, err)
-		return
-	}
-	if pokestop == nil {
-		log.Warnf("FortTracker: pokestop %s not found in cache or database, clearing tracker entry", stopId)
-		if removeFromTracker {
-			fortTracker.RemoveFort(stopId)
-		}
-		return
-	}
-
-	// Mark as deleted and save through write-behind queue
-	pokestop.SetDeleted(true)
-	savePokestopRecord(ctx, dbDetails, pokestop)
-
-	// Build webhook payload while we still hold the lock
-	var fort *FortWebhook
-	if removeFromTracker {
-		fort = InitWebHookFortFromPokestop(pokestop)
-	}
-	unlock()
-
-	if removeFromTracker {
-		fortTracker.RemoveFort(stopId)
-		log.Infof("FortTracker: removed pokestop in cell %d: %s", cellId, stopId)
-		CreateFortChangeWebhooks(fort, REMOVAL)
-		statsCollector.IncFortChange("pokestop_delete")
-	} else {
-		log.Infof("FortTracker: marked pokestop as deleted (converted to gym) in cell %d: %s", cellId, stopId)
-		statsCollector.IncFortChange("pokestop_to_gym")
-	}
-}
-
-// CheckRemovedForts uses the in-memory fort tracker for fast detection
-func CheckRemovedForts(ctx context.Context, dbDetails db.DbDetails, mapCells []uint64, cellForts map[uint64]*FortTrackerGMOContents) {
-	for _, cellId := range mapCells {
-		cf, ok := cellForts[cellId]
-		if !ok {
-			continue
-		}
-
-		// Process cell through tracker - returns stale and converted forts
-		// Returns nil if this GMO timestamp is older than last processed for this cell
+// CheckRemovedForts uses the in-memory fort tracker for fast detection.
+// Iterates cellForts directly — its keyset already matches mapCells.
+func CheckRemovedForts(ctx context.Context, dbDetails db.DbDetails, cellForts map[uint64]*FortTrackerGMOContents) {
+	for cellId, cf := range cellForts {
+		// Process cell through tracker - returns stale and converted forts.
+		// nil result means this GMO timestamp is older than last processed for this cell.
 		result := fortTracker.ProcessCellUpdate(cellId, cf.Pokestops, cf.Gyms, cf.Timestamp)
 		if result == nil {
 			continue
 		}
 
 		for _, gymId := range result.StaleGyms {
-			clearGymWithLock(ctx, dbDetails, gymId, cellId, true)
+			clearFortWithLock(ctx, dbDetails, gymId, cellId, true, gymClearOps)
 		}
 		for _, stopId := range result.StalePokestops {
-			clearPokestopWithLock(ctx, dbDetails, stopId, cellId, true)
+			clearFortWithLock(ctx, dbDetails, stopId, cellId, true, pokestopClearOps)
 		}
 		for _, stopId := range result.ConvertedToGyms {
-			clearPokestopWithLock(ctx, dbDetails, stopId, cellId, false)
+			clearFortWithLock(ctx, dbDetails, stopId, cellId, false, pokestopClearOps)
 		}
 		for _, gymId := range result.ConvertedToPokestops {
-			clearGymWithLock(ctx, dbDetails, gymId, cellId, false)
+			clearFortWithLock(ctx, dbDetails, gymId, cellId, false, gymClearOps)
 		}
 	}
 }

--- a/decoder/fort_tracker.go
+++ b/decoder/fort_tracker.go
@@ -222,6 +222,10 @@ func (ft *FortTracker) ProcessCellUpdate(cellId uint64, pokestopIds []string, gy
 		return nil
 	}
 
+	// Lock ordering: ft.mu must be released here before CheckRemovedForts'
+	// downstream clearFortWithLock acquires an entity lock. The canonical order
+	// is entity → ft.mu (see RestoreFort), so a future refactor that holds
+	// ft.mu across clearFortWithLock would deadlock.
 	ft.mu.Lock()
 	result, pendingPokestops, pendingGyms, processed := ft.processCellUpdateLocked(cellId, pokestopIds, gymIds, timestamp)
 	ft.mu.Unlock()
@@ -269,6 +273,8 @@ func (ft *FortTracker) processCellUpdateLocked(cellId uint64, pokestopIds []stri
 		delete(currentPokestops, id)
 	}
 
+	// MUST capture firstScan before cell.lastSeen is reassigned below; otherwise
+	// the merge branch never triggers and preloaded forts are dropped.
 	firstScan := cell.lastSeen == 0
 
 	ft.applyPresentForts(cell, cellId, pokestopIds, currentPokestops, false, &result.ConvertedToPokestops, timestamp)
@@ -391,6 +397,13 @@ func (ft *FortTracker) applyPresentForts(cell *FortTrackerCellState, cellId uint
 		// Handle type change. The follow-up clear*WithLock call already logs
 		// the conversion at Info level, so we keep this trace at Debug.
 		if info.isGym != isGym {
+			// Remove from the old-type set so the fort does not orphan
+			// in both sets (e.g. pokestop→gym leaving the id in cell.pokestops).
+			if info.isGym {
+				delete(cell.gyms, id)
+			} else {
+				delete(cell.pokestops, id)
+			}
 			info.isGym = isGym
 			*converted = append(*converted, id)
 			if log.IsLevelEnabled(log.DebugLevel) {
@@ -442,7 +455,10 @@ func (ft *FortTracker) RestoreFort(fortId string, cellId uint64, isGym bool, now
 
 	cell := ft.getOrCreateCellLocked(cellId)
 
-	if existing, exists := ft.forts[fortId]; exists && existing.cellId != cellId {
+	// Defensive: clean the old set even when only isGym changed in the same cell.
+	// Today's callers always pair pokestop→isGym=false and gym→isGym=true, but
+	// a future caller mixing those would otherwise leave an orphan entry.
+	if existing, exists := ft.forts[fortId]; exists && (existing.cellId != cellId || existing.isGym != isGym) {
 		if oldCell, ok := ft.cells[existing.cellId]; ok {
 			if existing.isGym {
 				delete(oldCell.gyms, fortId)

--- a/decoder/fort_tracker_test.go
+++ b/decoder/fort_tracker_test.go
@@ -2,11 +2,17 @@ package decoder
 
 import (
 	"testing"
+	"time"
 )
 
+// resetTracker reinitialises the global tracker for the next test.
+func resetTracker() {
+	InitFortTracker(3600, 1)
+}
+
 func TestProcessCellUpdate_RemovesStaleGym(t *testing.T) {
-	// Initialize tracker with 1 second stale threshold
-	InitFortTracker(1)
+	InitFortTracker(1, 1)
+	defer resetTracker()
 	ft := GetFortTracker()
 	if ft == nil {
 		t.Fatal("fortTracker is nil after InitFortTracker")
@@ -15,139 +21,285 @@ func TestProcessCellUpdate_RemovesStaleGym(t *testing.T) {
 	cellId := uint64(12345)
 	gymId := "gym_1"
 
-	// Set up initial state: cell has the gym seen at time 1000ms
+	now := time.Now().UnixMilli()
 	ft.mu.Lock()
 	cell := ft.getOrCreateCellLocked(cellId)
-	cell.lastSeen = 500 // previous lastSeen
-	cell.gyms = make(map[string]struct{})
+	cell.lastSeen = now - 5000
 	cell.gyms[gymId] = struct{}{}
-	ft.forts[gymId] = &FortTrackerLastSeen{cellId: cellId, lastSeen: 1000, isGym: true}
+	ft.forts[gymId] = &FortTrackerLastSeen{cellId: cellId, lastSeen: now - 4000, isGym: true}
 	ft.mu.Unlock()
 
-	// Now simulate a GMO for the same cell with no gyms and timestamp advanced beyond stale threshold
-	result := ft.ProcessCellUpdate(cellId, []string{}, []string{}, int64(1000+2000)) // timestamp in ms
-
+	result := ft.ProcessCellUpdate(cellId, nil, nil, now)
 	if result == nil {
 		t.Fatal("ProcessCellUpdate returned nil; expected a result")
 	}
 
-	if len(result.StaleGyms) == 0 {
-		t.Fatalf("expected stale gyms, got none: %+v", result)
+	if len(result.StaleGyms) != 1 || result.StaleGyms[0] != gymId {
+		t.Fatalf("expected gym %s to be marked stale, got: %+v", gymId, result.StaleGyms)
 	}
-
-	found := false
-	for _, id := range result.StaleGyms {
-		if id == gymId {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatalf("expected gym %s to be marked stale, result: %+v", gymId, result)
-	}
-
-	// Also ensure no false positives for pokestops
 	if len(result.StalePokestops) != 0 {
 		t.Fatalf("unexpected stale pokestops: %+v", result.StalePokestops)
 	}
-
-	// cleanup
-	InitFortTracker(3600)
 }
 
 func TestProcessCellUpdate_PendingGymBecomesStaleAfterMultipleScans(t *testing.T) {
-	// Initialize tracker with 5 second stale threshold
-	InitFortTracker(5)
+	InitFortTracker(5, 1)
+	defer resetTracker()
 	ft := GetFortTracker()
-	if ft == nil {
-		t.Fatal("fortTracker is nil after InitFortTracker")
-	}
 
-	cellId := uint64(12345)
+	cellId := uint64(12346)
 	gymId := "gym_pending"
 
-	// Set up initial state: cell has the gym seen at time 1000ms
+	// Synthetic small timestamps: well below time.Now().UnixMilli()+60_000,
+	// so the future-timestamp guard does not reject them.
 	ft.mu.Lock()
 	cell := ft.getOrCreateCellLocked(cellId)
 	cell.lastSeen = 500
-	cell.gyms = make(map[string]struct{})
 	cell.gyms[gymId] = struct{}{}
 	ft.forts[gymId] = &FortTrackerLastSeen{cellId: cellId, lastSeen: 1000, isGym: true}
 	ft.mu.Unlock()
 
-	// First scan: gym missing but not yet stale (only 2 seconds passed)
-	result1 := ft.ProcessCellUpdate(cellId, []string{}, []string{}, 3000)
-	if result1 == nil {
-		t.Fatal("ProcessCellUpdate returned nil on first scan")
-	}
-	if len(result1.StaleGyms) != 0 {
-		t.Fatalf("gym should not be stale yet on first scan, got: %v", result1.StaleGyms)
+	// First scan: 2s gap, < 5s threshold → pending.
+	result1 := ft.ProcessCellUpdate(cellId, nil, nil, 3000)
+	if result1 == nil || len(result1.StaleGyms) != 0 {
+		t.Fatalf("gym should not be stale on first scan, got: %+v", result1)
 	}
 
-	// Verify gym is still tracked in cell (this was the bug - it was being removed)
 	ft.mu.RLock()
 	_, inCell := ft.cells[cellId].gyms[gymId]
 	ft.mu.RUnlock()
 	if !inCell {
-		t.Fatal("pending gym was removed from cell tracking - this is the bug!")
+		t.Fatal("pending gym was removed from cell tracking")
 	}
 
-	// Second scan: gym still missing, now stale (6 seconds total since lastSeen)
-	result2 := ft.ProcessCellUpdate(cellId, []string{}, []string{}, 6500)
+	// Second scan: 5.5s gap, ≥ 5s threshold → stale.
+	result2 := ft.ProcessCellUpdate(cellId, nil, nil, 6500)
 	if result2 == nil {
 		t.Fatal("ProcessCellUpdate returned nil on second scan")
 	}
 	if len(result2.StaleGyms) != 1 || result2.StaleGyms[0] != gymId {
-		t.Fatalf("expected gym %s to be stale on second scan, got: %v", gymId, result2.StaleGyms)
+		t.Fatalf("expected gym %s stale on second scan, got: %v", gymId, result2.StaleGyms)
 	}
-
-	// cleanup
-	InitFortTracker(3600)
 }
 
 func TestProcessCellUpdate_NewFortOnFirstScanTrackedForFutureStaleCheck(t *testing.T) {
-	// This tests the bug where forts seen on first scan weren't added to cell tracking
-	InitFortTracker(1) // 1 second stale threshold
+	InitFortTracker(1, 1)
+	defer resetTracker()
 	ft := GetFortTracker()
-	if ft == nil {
-		t.Fatal("fortTracker is nil after InitFortTracker")
-	}
 
 	cellId := uint64(99999)
 	gymId := "new_gym_first_scan"
 
-	// First scan: cell is new (lastSeen=0), gym appears
-	result1 := ft.ProcessCellUpdate(cellId, []string{}, []string{gymId}, 1000)
+	now := time.Now().UnixMilli()
+	result1 := ft.ProcessCellUpdate(cellId, nil, []string{gymId}, now-3000)
 	if result1 == nil {
 		t.Fatal("ProcessCellUpdate returned nil on first scan")
 	}
 
-	// Verify gym is tracked in cell.gyms (this was the bug - it wasn't being added)
 	ft.mu.RLock()
 	_, inCell := ft.cells[cellId].gyms[gymId]
 	ft.mu.RUnlock()
 	if !inCell {
-		t.Fatal("new gym from first scan was not added to cell tracking - this is the bug!")
+		t.Fatal("new gym from first scan was not added to cell tracking")
 	}
 
-	// Second scan: gym missing, not yet stale
-	result2 := ft.ProcessCellUpdate(cellId, []string{}, []string{}, 1500)
-	if result2 == nil {
-		t.Fatal("ProcessCellUpdate returned nil on second scan")
-	}
-	if len(result2.StaleGyms) != 0 {
-		t.Fatalf("gym should not be stale yet (only 500ms), got: %v", result2.StaleGyms)
+	result2 := ft.ProcessCellUpdate(cellId, nil, nil, now-2500)
+	if result2 == nil || len(result2.StaleGyms) != 0 {
+		t.Fatalf("gym should not yet be stale, got: %+v", result2)
 	}
 
-	// Third scan: gym still missing, now stale (2 seconds since lastSeen)
-	result3 := ft.ProcessCellUpdate(cellId, []string{}, []string{}, 3500)
+	result3 := ft.ProcessCellUpdate(cellId, nil, nil, now)
 	if result3 == nil {
 		t.Fatal("ProcessCellUpdate returned nil on third scan")
 	}
 	if len(result3.StaleGyms) != 1 || result3.StaleGyms[0] != gymId {
-		t.Fatalf("expected gym %s to be stale, got: %v", gymId, result3.StaleGyms)
+		t.Fatalf("expected gym %s stale, got: %v", gymId, result3.StaleGyms)
+	}
+}
+
+// Regression for the firstScan-overwrite bug (§1.1): preload registers
+// {A,B,C} into a cell, a partial GMO {A} arrives, and after the stale
+// window a second partial GMO {A} should mark B and C stale (not before).
+func TestProcessCellUpdate_PartialFirstGMOPreservesPreloadedForts(t *testing.T) {
+	InitFortTracker(1, 1)
+	defer resetTracker()
+	ft := GetFortTracker()
+
+	cellId := uint64(0xdeadbeef)
+	registerTs := int64(10_000)
+
+	ft.RegisterFort("A", cellId, false, registerTs)
+	ft.RegisterFort("B", cellId, false, registerTs)
+	ft.RegisterFort("C", cellId, false, registerTs)
+
+	// First GMO is partial: only sees A; gap from register is 500ms < 1s threshold.
+	result1 := ft.ProcessCellUpdate(cellId, []string{"A"}, nil, registerTs+500)
+	if result1 == nil {
+		t.Fatal("ProcessCellUpdate returned nil on first GMO")
+	}
+	if len(result1.StalePokestops) != 0 {
+		t.Fatalf("first partial GMO must not mark anything stale, got: %v", result1.StalePokestops)
 	}
 
-	// cleanup
-	InitFortTracker(3600)
+	ft.mu.RLock()
+	for _, id := range []string{"A", "B", "C"} {
+		if _, ok := ft.cells[cellId].pokestops[id]; !ok {
+			ft.mu.RUnlock()
+			t.Fatalf("preloaded pokestop %s lost from cell tracking after partial first GMO", id)
+		}
+	}
+	ft.mu.RUnlock()
+
+	// Second partial GMO past the threshold: B and C must now be flagged.
+	result2 := ft.ProcessCellUpdate(cellId, []string{"A"}, nil, registerTs+5000)
+	if result2 == nil {
+		t.Fatal("ProcessCellUpdate returned nil on second GMO")
+	}
+	stale := map[string]bool{}
+	for _, id := range result2.StalePokestops {
+		stale[id] = true
+	}
+	if !stale["B"] || !stale["C"] {
+		t.Fatalf("expected B and C stale after partial second GMO, got: %v", result2.StalePokestops)
+	}
+	if stale["A"] {
+		t.Fatalf("A is present in GMO and must not be stale")
+	}
+}
+
+// §2.2: an implausibly future timestamp must not wedge a cell.
+func TestProcessCellUpdate_RejectsFutureTimestamp(t *testing.T) {
+	InitFortTracker(1, 1)
+	defer resetTracker()
+	ft := GetFortTracker()
+
+	cellId := uint64(0xfeedface)
+	now := time.Now().UnixMilli()
+
+	if got := ft.ProcessCellUpdate(cellId, nil, nil, now+24*60*60*1000); got != nil {
+		t.Fatalf("expected nil for far-future GMO, got: %+v", got)
+	}
+
+	ft.mu.RLock()
+	cell, ok := ft.cells[cellId]
+	wedged := ok && cell.lastSeen != 0
+	ft.mu.RUnlock()
+	if wedged {
+		t.Fatal("future-dated GMO wedged the cell (cell.lastSeen advanced)")
+	}
+
+	if got := ft.ProcessCellUpdate(cellId, []string{"X"}, nil, now); got == nil {
+		t.Fatal("subsequent legitimate GMO must be processed")
+	}
+}
+
+// §2.1: RestoreFort followed by a partial GMO must not immediately re-flag.
+func TestRestoreFort_DoesNotImmediatelyRestale(t *testing.T) {
+	InitFortTracker(60, 1)
+	defer resetTracker()
+	ft := GetFortTracker()
+
+	cellId := uint64(0xabc)
+	stopId := "restored_stop"
+	now := time.Now().UnixMilli()
+
+	ft.RestoreFort(stopId, cellId, false, now)
+
+	// A partial GMO for the same cell that doesn't include the restored fort.
+	result := ft.ProcessCellUpdate(cellId, nil, nil, now+1000)
+	if result == nil {
+		t.Fatal("ProcessCellUpdate returned nil")
+	}
+	if len(result.StalePokestops) != 0 {
+		t.Fatalf("restored fort must not be re-staled by the next GMO: %v", result.StalePokestops)
+	}
+}
+
+// §2.6: id appearing in both pokestopIds and gymIds — gym wins.
+func TestProcessCellUpdate_TypeRaceDedup(t *testing.T) {
+	InitFortTracker(60, 1)
+	defer resetTracker()
+	ft := GetFortTracker()
+
+	cellId := uint64(0x123abc)
+	id := "ambiguous_fort"
+	now := time.Now().UnixMilli()
+
+	result := ft.ProcessCellUpdate(cellId, []string{id}, []string{id}, now)
+	if result == nil {
+		t.Fatal("ProcessCellUpdate returned nil")
+	}
+
+	ft.mu.RLock()
+	_, inGyms := ft.cells[cellId].gyms[id]
+	_, inStops := ft.cells[cellId].pokestops[id]
+	info := ft.forts[id]
+	ft.mu.RUnlock()
+
+	if !inGyms || inStops {
+		t.Fatalf("expected fort to live only in gyms set on tie, got gyms=%v pokestops=%v", inGyms, inStops)
+	}
+	if info == nil || !info.isGym {
+		t.Fatalf("expected fort info isGym=true, got: %+v", info)
+	}
+}
+
+// §6.2: with minMissCount=2, a single missing scan past the time threshold
+// is not enough; require two consecutive cell-scan misses.
+func TestProcessCellUpdate_MissCountGuard(t *testing.T) {
+	InitFortTracker(1, 2)
+	defer resetTracker()
+	ft := GetFortTracker()
+
+	cellId := uint64(0x456)
+	stopId := "miss_count_stop"
+	now := time.Now().UnixMilli()
+
+	ft.mu.Lock()
+	cell := ft.getOrCreateCellLocked(cellId)
+	cell.lastSeen = now - 10000
+	cell.pokestops[stopId] = struct{}{}
+	ft.forts[stopId] = &FortTrackerLastSeen{cellId: cellId, lastSeen: now - 9000, isGym: false}
+	ft.mu.Unlock()
+
+	// First missing scan: time threshold met but missCount=1 < 2.
+	result1 := ft.ProcessCellUpdate(cellId, nil, nil, now-5000)
+	if result1 == nil || len(result1.StalePokestops) != 0 {
+		t.Fatalf("expected no stale on first miss with minMissCount=2, got: %+v", result1)
+	}
+
+	// Second missing scan: missCount=2, now stale.
+	result2 := ft.ProcessCellUpdate(cellId, nil, nil, now)
+	if result2 == nil || len(result2.StalePokestops) != 1 {
+		t.Fatalf("expected stale after second miss, got: %+v", result2)
+	}
+}
+
+// §6.2: a sighting between two missing scans must reset missCount.
+func TestProcessCellUpdate_MissCountResetOnSighting(t *testing.T) {
+	InitFortTracker(1, 2)
+	defer resetTracker()
+	ft := GetFortTracker()
+
+	cellId := uint64(0x789)
+	stopId := "flapping_stop"
+	now := time.Now().UnixMilli()
+
+	ft.mu.Lock()
+	cell := ft.getOrCreateCellLocked(cellId)
+	cell.lastSeen = now - 10000
+	cell.pokestops[stopId] = struct{}{}
+	ft.forts[stopId] = &FortTrackerLastSeen{cellId: cellId, lastSeen: now - 9000, isGym: false}
+	ft.mu.Unlock()
+
+	// Miss, then sighting (resets), then miss again. Should not be stale yet.
+	if r := ft.ProcessCellUpdate(cellId, nil, nil, now-6000); r == nil || len(r.StalePokestops) != 0 {
+		t.Fatalf("first miss: %+v", r)
+	}
+	if r := ft.ProcessCellUpdate(cellId, []string{stopId}, nil, now-4000); r == nil {
+		t.Fatal("sighting GMO returned nil")
+	}
+	if r := ft.ProcessCellUpdate(cellId, nil, nil, now-2000); r == nil || len(r.StalePokestops) != 0 {
+		t.Fatalf("post-sighting miss must reset count, got: %+v", r)
+	}
 }

--- a/decoder/fort_tracker_test.go
+++ b/decoder/fort_tracker_test.go
@@ -244,6 +244,44 @@ func TestProcessCellUpdate_TypeRaceDedup(t *testing.T) {
 	}
 }
 
+// §1: a fort registered as pokestop then observed only as a gym must leave
+// cell.pokestops empty (no orphan that would later mis-drive RemoveFort).
+func TestApplyPresentForts_TypeConversionClearsOldCellSet(t *testing.T) {
+	InitFortTracker(60, 1)
+	defer resetTracker()
+	ft := GetFortTracker()
+
+	cellId := uint64(0xc0ffee)
+	id := "convert_me"
+	registerTs := int64(100_000)
+
+	ft.RegisterFort(id, cellId, false, registerTs)
+
+	result := ft.ProcessCellUpdate(cellId, nil, []string{id}, registerTs+1000)
+	if result == nil {
+		t.Fatal("ProcessCellUpdate returned nil")
+	}
+
+	ft.mu.RLock()
+	_, inStops := ft.cells[cellId].pokestops[id]
+	_, inGyms := ft.cells[cellId].gyms[id]
+	info := ft.forts[id]
+	ft.mu.RUnlock()
+
+	if inStops {
+		t.Fatalf("fort %s must not remain in cell.pokestops after pokestop→gym conversion", id)
+	}
+	if !inGyms {
+		t.Fatalf("fort %s must be in cell.gyms after conversion", id)
+	}
+	if info == nil || !info.isGym {
+		t.Fatalf("fort info must record isGym=true, got: %+v", info)
+	}
+	if len(result.ConvertedToGyms) != 1 || result.ConvertedToGyms[0] != id {
+		t.Fatalf("expected ConvertedToGyms=[%s], got: %v", id, result.ConvertedToGyms)
+	}
+}
+
 // §6.2: with minMissCount=2, a single missing scan past the time threshold
 // is not enough; require two consecutive cell-scan misses.
 func TestProcessCellUpdate_MissCountGuard(t *testing.T) {

--- a/decoder/gmo_decode.go
+++ b/decoder/gmo_decode.go
@@ -83,7 +83,7 @@ func UpdateFortBatch(ctx context.Context, db db.DbDetails, scanParameters ScanPa
 				continue
 			}
 
-			gym.updateGymFromFort(fort.Data, fort.Cell)
+			gym.updateGymFromFort(fort.Data, fort.Cell, fort.Timestamp)
 			isNewRecord := gym.IsNewRecord()
 
 			saveGymRecord(ctx, db, gym)

--- a/decoder/gym_decode.go
+++ b/decoder/gym_decode.go
@@ -165,7 +165,7 @@ func (gym *Gym) updateGymFromFort(fortData *pogo.PokemonFortProto, cellId uint64
 		log.Warnf("Cleared Gym with id '%s' is found again in GMO, therefore un-deleted", gym.Id)
 		// Restore in fort tracker if enabled
 		if fortTracker != nil {
-			fortTracker.RestoreFort(gym.Id, cellId, true, time.Now().Unix())
+			fortTracker.RestoreFort(gym.Id, cellId, true, time.Now().UnixMilli())
 		}
 	}
 

--- a/decoder/gym_decode.go
+++ b/decoder/gym_decode.go
@@ -45,7 +45,7 @@ func calculatePowerUpPoints(fortData *pogo.PokemonFortProto) (null.Int, null.Int
 	return powerUpLevel, powerUpEndTimestamp
 }
 
-func (gym *Gym) updateGymFromFort(fortData *pogo.PokemonFortProto, cellId uint64) *Gym {
+func (gym *Gym) updateGymFromFort(fortData *pogo.PokemonFortProto, cellId uint64, timestampMs int64) *Gym {
 	type pokemonDisplay struct {
 		Form                  int    `json:"form,omitempty"`
 		Costume               int    `json:"costume,omitempty"`
@@ -165,7 +165,7 @@ func (gym *Gym) updateGymFromFort(fortData *pogo.PokemonFortProto, cellId uint64
 		log.Warnf("Cleared Gym with id '%s' is found again in GMO, therefore un-deleted", gym.Id)
 		// Restore in fort tracker if enabled
 		if fortTracker != nil {
-			fortTracker.RestoreFort(gym.Id, cellId, true, time.Now().UnixMilli())
+			fortTracker.RestoreFort(gym.Id, cellId, true, timestampMs)
 		}
 	}
 

--- a/decoder/pokestop_decode.go
+++ b/decoder/pokestop_decode.go
@@ -64,7 +64,7 @@ func (stop *Pokestop) updatePokestopFromFort(fortData *pogo.PokemonFortProto, ce
 		log.Warnf("Cleared Stop with id '%s' is found again in GMO, therefore un-deleted", stop.Id)
 		// Restore in fort tracker if enabled
 		if fortTracker != nil {
-			fortTracker.RestoreFort(stop.Id, cellId, false, time.Now().Unix())
+			fortTracker.RestoreFort(stop.Id, cellId, false, time.Now().UnixMilli())
 		}
 	}
 	return stop

--- a/decoder/pokestop_decode.go
+++ b/decoder/pokestop_decode.go
@@ -64,7 +64,7 @@ func (stop *Pokestop) updatePokestopFromFort(fortData *pogo.PokemonFortProto, ce
 		log.Warnf("Cleared Stop with id '%s' is found again in GMO, therefore un-deleted", stop.Id)
 		// Restore in fort tracker if enabled
 		if fortTracker != nil {
-			fortTracker.RestoreFort(stop.Id, cellId, false, time.Now().UnixMilli())
+			fortTracker.RestoreFort(stop.Id, cellId, false, now*1000)
 		}
 	}
 	return stop

--- a/decoder/preload.go
+++ b/decoder/preload.go
@@ -101,13 +101,17 @@ func preloadPokestops(dbDetails db.DbDetails, populateRtree bool) int32 {
 					fortRtreeUpdatePokestopOnSave(pokestop)
 				}
 
-				// Register with fort tracker
+				// Register with fort tracker.
+				// We use "now" (not pokestop.Updated) because preload is a
+				// confirmation event — every loaded fort is presumed alive as
+				// of preload time. Using DB Updated would mean partial GMOs
+				// after a long downtime would immediately stale all forts.
 				if fortTracker != nil && pokestop.CellId.Valid {
 					fortTracker.RegisterFort(
 						pokestop.Id,
 						uint64(pokestop.CellId.Int64),
 						false,
-						pokestop.Updated*1000, // convert to milliseconds
+						time.Now().UnixMilli(),
 					)
 				}
 
@@ -161,13 +165,13 @@ func preloadGyms(dbDetails db.DbDetails, populateRtree bool) int32 {
 					fortRtreeUpdateGymOnSave(gym)
 				}
 
-				// Register with fort tracker
+				// Register with fort tracker (see comment in preloadPokestops).
 				if fortTracker != nil && gym.CellId.Valid {
 					fortTracker.RegisterFort(
 						gym.Id,
 						uint64(gym.CellId.Int64),
 						true,
-						gym.Updated*1000, // convert to milliseconds
+						time.Now().UnixMilli(),
 					)
 				}
 

--- a/decoder/preload.go
+++ b/decoder/preload.go
@@ -101,13 +101,17 @@ func preloadPokestops(dbDetails db.DbDetails, populateRtree bool) int32 {
 					fortRtreeUpdatePokestopOnSave(pokestop)
 				}
 
-				// Register with fort tracker
+				// Register with fort tracker.
+				// We use "now" (not pokestop.Updated) because preload is a
+				// confirmation event — every loaded fort is presumed alive as
+				// of preload time. Using DB Updated would mean partial GMOs
+				// after a long downtime would immediately stale all forts.
 				if fortTracker != nil && pokestop.CellId.Valid {
 					fortTracker.RegisterFort(
 						pokestop.Id,
 						uint64(pokestop.CellId.Int64),
 						false,
-						pokestop.Updated*1000, // convert to milliseconds
+						time.Now().UnixMilli(),
 					)
 				}
 
@@ -162,13 +166,13 @@ func preloadGyms(dbDetails db.DbDetails, populateRtree bool) int32 {
 					fortRtreeUpdateGymOnSave(gym)
 				}
 
-				// Register with fort tracker
+				// Register with fort tracker (see comment in preloadPokestops).
 				if fortTracker != nil && gym.CellId.Valid {
 					fortTracker.RegisterFort(
 						gym.Id,
 						uint64(gym.CellId.Int64),
 						true,
-						gym.Updated*1000, // convert to milliseconds
+						time.Now().UnixMilli(),
 					)
 				}
 

--- a/main.go
+++ b/main.go
@@ -258,7 +258,11 @@ func main() {
 	if staleThreshold <= 0 {
 		staleThreshold = 3600 // def 1 hour
 	}
-	decoder.InitFortTracker(staleThreshold)
+	minMissCount := cfg.Cleanup.FortsMinMissCount
+	if minMissCount <= 0 {
+		minMissCount = 1
+	}
+	decoder.InitFortTracker(staleThreshold, minMissCount)
 
 	// Determine loading strategy
 	// Preload: warms cache for forts, stations, and recent spawnpoints


### PR DESCRIPTION
# Fort tracker: POI removal correctness, hardening, cleanup

Branch: `len-fort-tracker-fixes` — 4 commits.

## Symptom

POIs that should be marked deleted were not removed until Golbat was restarted, and often not even then. A restart only "fixed" it if the first GMO post-restart contained full coverage
of the cell — partial first GMOs left the wrong fort set in tracking.

## Root cause

Two interacting bugs in `ProcessCellUpdate`'s `firstScan` branch and in preload bookkeeping:

1. `cell.lastSeen` was only ever written inside `ProcessCellUpdate`. Preload (`Preload` / `LoadFortsFromDB` / `RegisterFort`) never set it. After every restart, every cell had
`cell.lastSeen == 0`, so the next GMO took the `firstScan` path.
2. The `firstScan` branch overwrote `cell.pokestops` / `cell.gyms` with the contents of that single GMO. Any preloaded fort not in that one GMO was dropped from per-cell tracking.
Because stale detection iterates `cell.pokestops` / `cell.gyms`, those forts could never be flagged stale again — they were stuck as "live" entries in `ft.forts` pointing at a cell that
 no longer listed them.

A restart only helped when the next first-GMO happened to enumerate every fort in the cell.

## Other bugs found and fixed

- **`RestoreFort` units bug.** Callers passed `time.Now().Unix()` (seconds) into a milliseconds field. `lastSeen` came out ~1000× too small; the very next GMO saw a ~1e12 ms gap, blew
past the 1h stale threshold, and re-staled the fort immediately.
- **`RestoreFort` wall-clock vs GMO timestamp drift.** After fixing the units bug, callers in `updatePokestopFromFort` / `updateGymFromFort` still used `time.Now().UnixMilli()` instead
of the GMO's own `fort.Timestamp`. On replay or ingest lag the restored fort's `lastSeen` ran ahead of (or behind) the cell's `lastSeen`, which is sourced from the GMO timestamp —
leaving staleness math inconsistent across the cell and its restored member.
- **Future-dated `AsOfTimeMs` wedge.** A clock-skewed or malicious scanner could permanently silence a cell — every later real GMO had `timestamp <= cell.lastSeen` and was dropped at
the early-return.
- **`clear*WithLock` ghost entries.** When the gym/pokestop could not be loaded from cache or DB, the tracker entry was left in place. Same fort was re-selected as stale on every
subsequent GMO.
- **Dangling `UpdateFort`.** Only caller was `RestoreFort`, and the units bug rode through it.
- **GMO type-change race.** If the same id appeared in `pokestopIds` and `gymIds` of one GMO, it was inserted into both sets and the conversion logic flipped back and forth.
- **Preload seeded `lastSeen` from `pokestop.Updated`.** Once commit 1 made `cell.lastSeen` non-zero post-preload (so stale detection actually ran), this became live: any fort whose DB
`Updated` predated the stale threshold was flagged stale on the first GMO that didn't include it. Co-primary with the root cause; fixed together in commit 3.

## Fix summary

Four commits, in order:

### 1. `fix(fort_tracker)` — `d20d5ca`

- `RegisterFort` seeds `cell.lastSeen`, so the first post-restart GMO is no longer treated as a `firstScan`.
- `firstScan` branch merges (does not replace) cell fort sets, refreshing `lastSeen` for retained forts.
- Reject GMOs with timestamps more than 60s in the future.
- Dedup ids that appear in both `pokestopIds` and `gymIds` (gym wins, matches proto pack order).
- Defensive insertion into the new cell set during cell-move handling.
- `clear*WithLock` removes the tracker entry when the entity cannot be loaded.
- Drop unused `UpdateFort`. `RestoreFort` does the work directly with explicit ms units; callers now pass `time.Now().UnixMilli()`.

### 2. `refactor(fort_tracker)` — `11f8a04`

- Collapse `loadPokestopsFromDB` / `loadGymsFromDB` into one `loadFortKindFromDB` helper.
- Replace `clearGymWithLock` / `clearPokestopWithLock` with a generic `clearFortWithLock` plus per-kind ops tables (`gymClearOps`, `pokestopClearOps`).
- Hoist debug "pending removal" logs out of the global tracker lock by splitting `ProcessCellUpdate` into a thin wrapper plus locked core that returns the pending lists.
- Downgrade per-conversion log to Debug (already logged at Info by `clearFortWithLock`).
- Iterate `cellForts` directly in `CheckRemovedForts`; drop the parallel `cellsToBeCleaned` slice in `decodeGMO`.
- `strconv.FormatUint` for cellId formatting in API responses (S2 cell ids exceed JS 2^53 safe-int — observed DB max 8935267727656878080 — so they're stringified for JSON consumers).
- Fix doc-comment / type-name mismatches on `FortTrackerLastSeen` and `FortTrackerGMOContents`.

### 3. `feat(fort_tracker)` — `26140b2`

- New config `cleanup.forts_min_miss_count` (default `1`, preserves prior behaviour). When set higher, a fort must be absent from N consecutive cell scans past the time threshold before
 being flagged stale — defends against transient single-frame coverage gaps and level-30 gating.
- Track `missCount` per fort, reset on every sighting (including the `firstScan` merge path).
- Treat preload as a confirmation event: `lastSeen` is `time.Now().UnixMilli()` instead of `row.Updated * 1000`. Required for commit 1's `cell.lastSeen` seeding to be safe — otherwise
preloaded forts with old `Updated` values get instantly staled.
- Tests for the §6.6 design-review scenarios:
  - partial first GMO post-preload preserves preloaded forts;
  - future-dated GMO does not wedge the cell;
  - `RestoreFort` followed by partial GMO does not re-stale;
  - id present in both id-lists dedups (gym wins);
  - `missCount` guard with N=2 needs two consecutive misses;
  - `missCount` resets on intervening sighting.

### 4. `fix(fort_tracker)` — RestoreFort uses GMO timestamp

- `updatePokestopFromFort` passes `now*1000` (param already received as `fort.Timestamp/1000` seconds) into `RestoreFort` instead of `time.Now().UnixMilli()`.
- `updateGymFromFort` gains a `timestampMs int64` parameter; `gmo_decode.go` call site passes `fort.Timestamp`.
- Eliminates drift between a restored fort's `lastSeen` and its cell's `lastSeen` under ingest lag or replay.

## Out of scope

- **Unbounded growth of `ft.cells` / `ft.forts`.** GMOs sometimes return empty; we don't want to drop cells whose forts vanished transiently.
- **Race between `LoadFortsFromDB` and live ingest.** Loading already blocks before listeners accept traffic.
- **Soft-delete intermediate state in DB (§6.3).** We don't want to change the DB-side stale-to-deleted transition here.

## Testing

- `go test ./...` — all green.
- Tracker tests cover all five §6.6 scenarios from the design review, plus regression tests for `missCount` semantics.

## Config

```toml
[cleanup]
forts_stale_threshold = 3600   # seconds, default 1 h (unchanged)
forts_min_miss_count  = 1      # consecutive cell-scan misses, default 1

# Operators wanting fewer false positives from transient coverage gaps can set forts_min_miss_count = 2 or higher.
```