### PR TITLE
perf: use runtime maphash for sharded-cache key hashing

### DIFF
--- a/decoder/sharded_cache.go
+++ b/decoder/sharded_cache.go
@@ -2,7 +2,7 @@ package decoder
 
 import (
 	"context"
-	"hash/fnv"
+	"hash/maphash"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -117,9 +117,13 @@ func Int64KeyToShard(key int64) uint64 {
 	return uint64(key)
 }
 
-// StringKeyToShard hashes string keys to uint64 for sharding using FNV-1a
+// stringShardSeed is set once at package init. The hash is used for
+// in-memory shard selection only, never persisted, so a random per-process
+// seed is fine.
+var stringShardSeed = maphash.MakeSeed()
+
+// StringKeyToShard hashes string keys to uint64 for shard selection. Uses
+// runtime maphash, which is ~5× faster than hash/fnv on the cache hot-path.
 func StringKeyToShard(key string) uint64 {
-	h := fnv.New64a()
-	_, _ = h.Write([]byte(key))
-	return h.Sum64()
+	return maphash.String(stringShardSeed, key)
 }


### PR DESCRIPTION
## Summary

`StringKeyToShard` is on every `Get` / `Set` / `Delete` / `GetOrSetFunc` call against `pokestopCache`, `gymCache`, and `stationCache` — easily tens of thousands of calls per second under typical GMO ingest load.

Switch from `hash/fnv` to `hash/maphash`, which is **~5× faster** on the hot path.

## Benchmark

Single-key and many-distinct-keys variants, 5 runs each, Go 1.26 on Apple M3 Pro, 35-char fort IDs (typical):

| Implementation | Time | Allocs |
|---|---|---|
| `fnv.New64a()` + `Write([]byte(key))` | **~17.5 ns/op** | **0 alloc/op** |
| `maphash.String(seed, key)` | **~3.4 ns/op** | **0 alloc/op** |

Both are alloc-free under Go 1.26 — escape analysis keeps the `fnv` hash struct and the `[]byte(key)` cast on the stack. The win is purely CPU.

## Safety notes

- `maphash.MakeSeed()` is captured once at package init. Shard assignments are in-memory only and never persisted, so a random per-process seed is fine.
- After this change, items hash to different shards across restarts. Not visible externally — sharding is purely about lock-contention distribution inside the cache layer.
- Distribution properties are at least as good as FNV-1a (maphash is the same hash the Go runtime uses for `map`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./decoder/`
- [x] `go test ./decoder/ -race -count=1`
- [x] Benchmark above

🤖 Generated with [Claude Code](https://claude.com/claude-code)