### PR TITLE
Embed and expose build/VCS info

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 .idea
 Dockerfile
 config.toml

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func main() {
 		cfg.Logging.Compress,
 	)
 
-	log.Infof("Golbat starting")
+	log.Infof("Golbat starting: revision=%s modified=%v built=%s", gitRevision, gitModified, buildTime)
 
 	// Both Sentry & Pyroscope are optional and off by default. Read more:
 	// https://docs.sentry.io/platforms/go
@@ -327,6 +327,7 @@ func main() {
 
 	r.POST("/raw", Raw)
 	r.GET("/health", GetHealth)
+	r.GET("/version", GetVersion)
 
 	apiGroup := r.Group("/api", AuthRequired())
 	apiGroup.GET("/health", GetHealth)

--- a/version.go
+++ b/version.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"net/http"
+	"runtime/debug"
+
+	"github.com/gin-gonic/gin"
+)
+
+var (
+	gitRevision string
+	gitModified bool
+	buildTime   string
+	goVersion   string
+)
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	goVersion = info.GoVersion
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			gitRevision = s.Value
+		case "vcs.modified":
+			gitModified = s.Value == "true"
+		case "vcs.time":
+			buildTime = s.Value
+		}
+	}
+}
+
+func GetVersion(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"revision":   gitRevision,
+		"modified":   gitModified,
+		"build_time": buildTime,
+		"go_version": goVersion,
+	})
+}


### PR DESCRIPTION
## Summary
- Remove `.git` from `.dockerignore` so Go's automatic VCS embedding works inside container builds
- Read `vcs.revision` / `vcs.modified` / `vcs.time` via `runtime/debug.ReadBuildInfo()` at startup
- Log version on startup: `Golbat starting: revision=<sha> modified=<bool> built=<rfc3339>`
- Add unauthenticated `GET /version` returning JSON with revision, modified flag, build time, and Go version

No build flags or `-ldflags` are needed — Go embeds this automatically when building inside a git checkout (which the Dockerfile now is).

## Test plan
- [x] `go build -tags go_json ./...` succeeds
- [x] `go vet -tags go_json ./...` clean
- [x] Local binary logs `revision=… modified=… built=…` at startup
- [ ] In CI/Docker, confirm the same line appears in container logs and `GET /version` returns populated fields
- [ ] Verify `modified=false` on a clean tagged build

🤖 Generated with [Claude Code](https://claude.com/claude-code)