### PR TITLE
Add golangci-lint CI and fix lint findings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  GO_VERSION: '1.26.x'
+
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.12.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,6 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.12.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,37 @@
+version: "2"
+
+run:
+  build-tags:
+    - go_json
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+  settings:
+    errcheck:
+      # Close/Copy on read paths is a standard Go idiom; a deferred Close
+      # error after a successful read has nowhere actionable to go.
+      exclude-functions:
+        - (io.Closer).Close
+        - (*database/sql.Rows).Close
+        - (*github.com/jmoiron/sqlx.Rows).Close
+        - io.Copy
+        - (*encoding/json.Decoder).Decode
+
+  exclusions:
+    rules:
+      # Entity access pattern: each entity type provides peek*Record /
+      # get*RecordReadOnly / get*RecordForUpdate even when not currently
+      # called, to keep the access-pattern API symmetric across entities.
+      # See CLAUDE.md "Record Access Patterns".
+      - linters:
+          - unused
+        path: decoder/
+        text: "func (peek|get)[A-Z][A-Za-z]+Record(ReadOnly|ForUpdate)? is unused"

--- a/decode.go
+++ b/decode.go
@@ -122,7 +122,7 @@ func decode(ctx context.Context, method int, protoData *ProtoData) {
 	}
 	if !ignore {
 		elapsed := time.Since(start)
-		if processed == true {
+		if processed {
 			statsCollector.IncDecodeMethods("ok", "", getMethodName(method, true))
 			log.Debugf("%s/%s %s - %s - %s", protoData.Uuid, protoData.Account, pogo.Method(method), elapsed, result)
 		} else {
@@ -209,7 +209,7 @@ func decodeGetFriendDetails(payload []byte) string {
 
 	if getFriendDetailsOutProto.GetResult() != pogo.InternalGetFriendDetailsOutProto_SUCCESS || getFriendDetailsOutProto.GetFriend() == nil {
 		statsCollector.IncDecodeGetFriendDetails("error", "non_success")
-		return fmt.Sprintf("unsuccessful get friends details")
+		return "unsuccessful get friends details"
 	}
 
 	failures := 0
@@ -239,7 +239,7 @@ func decodeSearchPlayer(proxyRequestProto *pogo.ProxyRequestProto, payload []byt
 
 	if searchPlayerOutProto.GetResult() != pogo.InternalSearchPlayerOutProto_SUCCESS || searchPlayerOutProto.GetPlayer() == nil {
 		statsCollector.IncDecodeSearchPlayer("error", "non_success")
-		return fmt.Sprintf("unsuccessful search player response")
+		return "unsuccessful search player response"
 	}
 
 	var searchPlayerProto pogo.InternalSearchPlayerProto
@@ -258,7 +258,7 @@ func decodeSearchPlayer(proxyRequestProto *pogo.ProxyRequestProto, payload []byt
 	}
 
 	statsCollector.IncDecodeSearchPlayer("ok", "")
-	return fmt.Sprintf("1 player decoded from SearchPlayerProto")
+	return "1 player decoded from SearchPlayerProto"
 }
 
 func decodeFortDetails(ctx context.Context, sDec []byte) string {
@@ -338,11 +338,11 @@ func decodeGetRoutes(ctx context.Context, payload []byte) string {
 			}
 			decodeError := decoder.UpdateRouteRecordWithSharedRouteProto(ctx, dbDetails, route)
 			if decodeError != nil {
-				if decodeErrors[route.Id] != true {
+				if !decodeErrors[route.Id] {
 					decodeErrors[route.Id] = true
 				}
 				log.Errorf("Failed to decode route %s", decodeError)
-			} else if decodeSuccesses[route.Id] != true {
+			} else if !decodeSuccesses[route.Id] {
 				decodeSuccesses[route.Id] = true
 			}
 		}
@@ -583,10 +583,6 @@ func decodeGMO(ctx context.Context, protoData *ProtoData, scanParameters decoder
 
 func isCellNotEmpty(mapCell *pogo.ClientMapCellProto) bool {
 	return len(mapCell.Stations) > 0 || len(mapCell.Fort) > 0 || len(mapCell.WildPokemon) > 0 || len(mapCell.NearbyPokemon) > 0 || len(mapCell.CatchablePokemon) > 0
-}
-
-func cellContainsForts(mapCell *pogo.ClientMapCellProto) bool {
-	return len(mapCell.Fort) > 0
 }
 
 func decodeGetContestData(ctx context.Context, request []byte, data []byte) string {

--- a/decoder/api_fort.go
+++ b/decoder/api_fort.go
@@ -119,7 +119,8 @@ func isFortDnfMatch(fortType FortType, fortLookup *FortLookup, filter *ApiFortDn
 		return false
 	}
 
-	if fortLookup.FortType == GYM {
+	switch fortLookup.FortType {
+	case GYM:
 		if filter.AvailableSlots != nil && (fortLookup.AvailableSlots < filter.AvailableSlots.Min || fortLookup.AvailableSlots > filter.AvailableSlots.Max) {
 			return false
 		}
@@ -139,7 +140,7 @@ func isFortDnfMatch(fortType FortType, fortLookup *FortLookup, filter *ApiFortDn
 				return false
 			}
 		}
-	} else if fortLookup.FortType == POKESTOP {
+	case POKESTOP:
 		if filter.LureId != nil && !slices.Contains(filter.LureId, fortLookup.LureId) {
 			return false
 		}
@@ -196,7 +197,7 @@ func isFortDnfMatch(fortType FortType, fortLookup *FortLookup, filter *ApiFortDn
 		if filter.IncidentPokemon != nil && !matchDnfIdPair(filter.IncidentPokemon, fortLookup.IncidentPokemonId, fortLookup.IncidentPokemonForm) {
 			return false
 		}
-	} else if fortLookup.FortType == STATION {
+	case STATION:
 		if filter.BattleLevel != nil || filter.BattlePokemon != nil {
 			// Check if battle has expired
 			if fortLookup.BattleEndTimestamp <= now {

--- a/decoder/fort.go
+++ b/decoder/fort.go
@@ -113,7 +113,8 @@ func CreateFortChangeWebhooks(fort *FortWebhook, change FortChange) {
 }
 
 func CreateFortWebHooks(old *FortWebhook, new *FortWebhook, change FortChange) {
-	if change == NEW {
+	switch change {
+	case NEW:
 		areas := MatchStatsGeofenceWithCell(new.Location.Latitude, new.Location.Longitude, new.CellId)
 		hook := FortChangeWebhook{
 			ChangeType: change.String(),
@@ -121,7 +122,7 @@ func CreateFortWebHooks(old *FortWebhook, new *FortWebhook, change FortChange) {
 		}
 		webhooksSender.AddMessage(webhooks.FortUpdate, hook, areas)
 		statsCollector.UpdateFortCount(areas, new.Type, "addition")
-	} else if change == REMOVAL {
+	case REMOVAL:
 		areas := MatchStatsGeofenceWithCell(old.Location.Latitude, old.Location.Longitude, old.CellId)
 		hook := FortChangeWebhook{
 			ChangeType: change.String(),
@@ -129,7 +130,7 @@ func CreateFortWebHooks(old *FortWebhook, new *FortWebhook, change FortChange) {
 		}
 		webhooksSender.AddMessage(webhooks.FortUpdate, hook, areas)
 		statsCollector.UpdateFortCount(areas, old.Type, "removal")
-	} else if change == EDIT {
+	case EDIT:
 		areas := MatchStatsGeofenceWithCell(new.Location.Latitude, new.Location.Longitude, new.CellId)
 		var editTypes []string
 

--- a/decoder/geography.go
+++ b/decoder/geography.go
@@ -2,8 +2,8 @@ package decoder
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"sync/atomic"
 
 	"golbat/config"
@@ -77,7 +77,7 @@ func ReadGeofences() error {
 		fc, err := GetKojiGeofence(kojiUrl)
 		if err != nil {
 			log.Warnf("KOJI: Unable to get geofence from koji - %s", err)
-			geofence, err := ioutil.ReadFile(kojiCacheFilename)
+			geofence, err := os.ReadFile(kojiCacheFilename)
 			if err != nil {
 				log.Warnf("KOJI: Unable to read cached geofence - %s", err)
 			} else {
@@ -93,12 +93,14 @@ func ReadGeofences() error {
 		} else {
 			log.Infof("KOJI: Loaded geofence from koji, caching")
 			bytes, _ := json.MarshalIndent(fc, "", "  ")
-			ioutil.WriteFile(kojiCacheFilename, []byte(bytes), 0644)
+			if err := os.WriteFile(kojiCacheFilename, bytes, 0644); err != nil {
+				log.Warnf("KOJI: Unable to cache geofence - %s", err)
+			}
 			statsFeatureCollection = fc
 
 		}
 	} else {
-		geofence, err := ioutil.ReadFile(geojsonFilename)
+		geofence, err := os.ReadFile(geojsonFilename)
 		if err != nil {
 			return err
 		}

--- a/decoder/gmo_decode.go
+++ b/decoder/gmo_decode.go
@@ -59,20 +59,18 @@ func UpdateFortBatch(ctx context.Context, db db.DbDetails, scanParameters ScanPa
 				incidents = []*pogo.PokestopIncidentDisplayProto{fort.Data.PokestopDisplay}
 			}
 
-			if incidents != nil {
-				for _, incidentProto := range incidents {
-					if incidentProto.IncidentId == "" {
-						continue
-					}
-					incident, unlock, err := getOrCreateIncidentRecord(ctx, db, incidentProto.IncidentId, fortId, "UpdateFortBatch")
-					if err != nil {
-						log.Errorf("getOrCreateIncidentRecord: %s", err)
-						continue
-					}
-					incident.updateFromPokestopIncidentDisplay(incidentProto)
-					saveIncidentRecord(ctx, db, incident)
-					unlock()
+			for _, incidentProto := range incidents {
+				if incidentProto.IncidentId == "" {
+					continue
 				}
+				incident, unlock, err := getOrCreateIncidentRecord(ctx, db, incidentProto.IncidentId, fortId, "UpdateFortBatch")
+				if err != nil {
+					log.Errorf("getOrCreateIncidentRecord: %s", err)
+					continue
+				}
+				incident.updateFromPokestopIncidentDisplay(incidentProto)
+				saveIncidentRecord(ctx, db, incident)
+				unlock()
 			}
 		}
 

--- a/decoder/gym_decode.go
+++ b/decoder/gym_decode.go
@@ -25,7 +25,7 @@ func calculatePowerUpPoints(fortData *pogo.PokemonFortProto) (null.Int, null.Int
 	now := time.Now().Unix()
 	powerUpLevelExpirationMs := int64(fortData.PowerUpLevelExpirationMs) / 1000
 	powerUpPoints := int64(fortData.PowerUpProgressPoints)
-	powerUpLevel := null.IntFrom(0)
+	var powerUpLevel null.Int
 	powerUpEndTimestamp := null.NewInt(0, false)
 	if powerUpPoints < 50 {
 		powerUpLevel = null.IntFrom(0)

--- a/decoder/gym_state.go
+++ b/decoder/gym_state.go
@@ -143,58 +143,6 @@ func getOrCreateGymRecord(ctx context.Context, db db.DbDetails, fortId string, c
 	return gym, func() { gym.Unlock() }, nil
 }
 
-// hasChangesGym compares two Gym structs
-// Float tolerance: Lat, Lon
-func hasChangesGym(old *Gym, new *Gym) bool {
-	return old.Id != new.Id ||
-		old.Name != new.Name ||
-		old.Url != new.Url ||
-		old.LastModifiedTimestamp != new.LastModifiedTimestamp ||
-		old.RaidEndTimestamp != new.RaidEndTimestamp ||
-		old.RaidSpawnTimestamp != new.RaidSpawnTimestamp ||
-		old.RaidBattleTimestamp != new.RaidBattleTimestamp ||
-		old.Updated != new.Updated ||
-		old.RaidPokemonId != new.RaidPokemonId ||
-		old.GuardingPokemonId != new.GuardingPokemonId ||
-		old.AvailableSlots != new.AvailableSlots ||
-		old.TeamId != new.TeamId ||
-		old.RaidLevel != new.RaidLevel ||
-		old.Enabled != new.Enabled ||
-		old.ExRaidEligible != new.ExRaidEligible ||
-		//		old.InBattle != new.InBattle ||
-		old.RaidPokemonMove1 != new.RaidPokemonMove1 ||
-		old.RaidPokemonMove2 != new.RaidPokemonMove2 ||
-		old.RaidPokemonForm != new.RaidPokemonForm ||
-		old.RaidPokemonAlignment != new.RaidPokemonAlignment ||
-		old.RaidPokemonCp != new.RaidPokemonCp ||
-		old.RaidIsExclusive != new.RaidIsExclusive ||
-		old.CellId != new.CellId ||
-		old.Deleted != new.Deleted ||
-		old.TotalCp != new.TotalCp ||
-		old.FirstSeenTimestamp != new.FirstSeenTimestamp ||
-		old.RaidPokemonGender != new.RaidPokemonGender ||
-		old.SponsorId != new.SponsorId ||
-		old.PartnerId != new.PartnerId ||
-		old.RaidPokemonCostume != new.RaidPokemonCostume ||
-		old.RaidPokemonEvolution != new.RaidPokemonEvolution ||
-		old.ArScanEligible != new.ArScanEligible ||
-		old.PowerUpLevel != new.PowerUpLevel ||
-		old.PowerUpPoints != new.PowerUpPoints ||
-		old.PowerUpEndTimestamp != new.PowerUpEndTimestamp ||
-		old.Description != new.Description ||
-		old.Rsvps != new.Rsvps ||
-		!floatAlmostEqual(old.Lat, new.Lat, floatTolerance) ||
-		!floatAlmostEqual(old.Lon, new.Lon, floatTolerance)
-
-}
-
-// hasChangesInternalGym compares two Gym structs for changes that will be stored in memory
-// Float tolerance: Lat, Lon
-func hasInternalChangesGym(old *Gym, new *Gym) bool {
-	return old.InBattle != new.InBattle ||
-		old.Defenders != new.Defenders
-}
-
 type GymDetailsWebhook struct {
 	Id                  string  `json:"id"`
 	Name                string  `json:"name"`

--- a/decoder/incident_decode.go
+++ b/decoder/incident_decode.go
@@ -31,10 +31,11 @@ func (incident *Incident) updateFromOpenInvasionCombatSessionOut(protoRes *pogo.
 	incident.SetSlot1PokemonId(null.NewInt(int64(protoRes.Combat.Opponent.ActivePokemon.PokedexId.Number()), true))
 	incident.SetSlot1Form(null.NewInt(int64(protoRes.Combat.Opponent.ActivePokemon.PokemonDisplay.Form.Number()), true))
 	for i, pokemon := range protoRes.Combat.Opponent.ReservePokemon {
-		if i == 0 {
+		switch i {
+		case 0:
 			incident.SetSlot2PokemonId(null.NewInt(int64(pokemon.PokedexId.Number()), true))
 			incident.SetSlot2Form(null.NewInt(int64(pokemon.PokemonDisplay.Form.Number()), true))
-		} else if i == 1 {
+		case 1:
 			incident.SetSlot3PokemonId(null.NewInt(int64(pokemon.PokedexId.Number()), true))
 			incident.SetSlot3Form(null.NewInt(int64(pokemon.PokemonDisplay.Form.Number()), true))
 		}

--- a/decoder/pokemon_decode.go
+++ b/decoder/pokemon_decode.go
@@ -330,7 +330,7 @@ func checkScans(old *grpc.PokemonScan, new *grpc.PokemonScan) error {
 	if old == nil || old.CompressedIv() == new.CompressedIv() {
 		return nil
 	}
-	return errors.New(fmt.Sprintf("Unexpected IV mismatch %s != %s", old, new))
+	return fmt.Errorf("unexpected IV mismatch %s != %s", old, new)
 }
 
 func (pokemon *Pokemon) setDittoAttributes(mode string, isDitto bool, old, new *grpc.PokemonScan) {
@@ -395,8 +395,8 @@ func (pokemon *Pokemon) detectDitto(scan *grpc.PokemonScan) (*grpc.PokemonScan, 
 				}
 			}
 			if scan.Level != expectedLevel || scan.CompressedIv() != strongScan.CompressedIv() {
-				return scan, errors.New(fmt.Sprintf("Unexpected strong Pokemon (Ditto?), %s -> %s",
-					strongScan, scan))
+				return scan, fmt.Errorf("unexpected strong Pokemon (Ditto?), %s -> %s",
+					strongScan, scan)
 			}
 		}
 		return scan, nil
@@ -418,8 +418,8 @@ func (pokemon *Pokemon) detectDitto(scan *grpc.PokemonScan) (*grpc.PokemonScan, 
 		} else if unboostedScan != nil {
 			unboostedLevel = unboostedScan.Level
 		} else {
-			pokemon.resetDittoAttributes("?", nil, nil, scan)
-			return scan, errors.New("Missing past scans. Ditto will be reset")
+			_, _ = pokemon.resetDittoAttributes("?", nil, nil, scan)
+			return scan, errors.New("missing past scans; Ditto will be reset")
 		}
 		// If IsDitto = true, then the IV sets in history are ALWAYS confirmed
 		scan.Confirmed = true
@@ -435,8 +435,8 @@ func (pokemon *Pokemon) detectDitto(scan *grpc.PokemonScan) (*grpc.PokemonScan, 
 					scan.Weather = int32(pogo.GameplayWeatherProto_PARTLY_CLOUDY)
 					return unboostedScan, checkScans(boostedScan, scan)
 				}
-				return scan, errors.New(fmt.Sprintf("Unexpected 0P Ditto level change, %s/%s -> %s",
-					unboostedScan, boostedScan, scan))
+				return scan, fmt.Errorf("unexpected 0P Ditto level change, %s/%s -> %s",
+					unboostedScan, boostedScan, scan)
 			}
 			return scan, checkScans(unboostedScan, scan)
 		case int32(pogo.GameplayWeatherProto_PARTLY_CLOUDY):
@@ -449,8 +449,8 @@ func (pokemon *Pokemon) detectDitto(scan *grpc.PokemonScan) (*grpc.PokemonScan, 
 		case unboostedLevel + 5:
 			return pokemon.resetDittoAttributes("BN", boostedScan, unboostedScan, scan)
 		}
-		return scan, errors.New(fmt.Sprintf("Unexpected B0 Ditto level change, %s/%s -> %s",
-			unboostedScan, boostedScan, scan))
+		return scan, fmt.Errorf("unexpected B0 Ditto level change, %s/%s -> %s",
+			unboostedScan, boostedScan, scan)
 	}
 
 	isBoosted := scan.Weather != int32(pogo.GameplayWeatherProto_NONE)
@@ -474,8 +474,8 @@ func (pokemon *Pokemon) detectDitto(scan *grpc.PokemonScan) (*grpc.PokemonScan, 
 				scan.Weather = int32(pogo.GameplayWeatherProto_PARTLY_CLOUDY)
 				return unboostedScan, nil
 			}
-			return scan, errors.New(fmt.Sprintf("Unexpected third level found %s, %s vs %s",
-				unboostedScan, boostedScan, scan))
+			return scan, fmt.Errorf("unexpected third level found %s, %s vs %s",
+				unboostedScan, boostedScan, scan)
 		}
 
 		levelAdjustment := int32(0)
@@ -628,7 +628,7 @@ func (pokemon *Pokemon) detectDitto(scan *grpc.PokemonScan) (*grpc.PokemonScan, 
 			scan.Weather = int32(pogo.GameplayWeatherProto_NONE)
 			return scan, nil
 		default:
-			return scan, errors.New(fmt.Sprintf("Unexpected level %s -> %s", matchingScan, scan))
+			return scan, fmt.Errorf("unexpected level %s -> %s", matchingScan, scan)
 		}
 	}
 	if isBoosted {
@@ -757,7 +757,7 @@ func (pokemon *Pokemon) updatePokemonFromEncounterProto(ctx context.Context, db 
 	}
 	pokemon.addEncounterPokemon(ctx, db, encounterData.Pokemon.Pokemon, username)
 
-	if pokemon.CellId.Valid == false {
+	if !pokemon.CellId.Valid {
 		centerCoord := s2.LatLngFromDegrees(pokemon.Lat, pokemon.Lon)
 		cellID := s2.CellIDFromLatLng(centerCoord).Parent(15)
 		pokemon.SetCellId(null.IntFrom(int64(cellID)))

--- a/decoder/pokemon_state.go
+++ b/decoder/pokemon_state.go
@@ -139,49 +139,6 @@ func getOrCreatePokemonRecord(ctx context.Context, db db.DbDetails, encounterId 
 	return pokemon, func() { pokemon.Unlock() }, nil
 }
 
-// hasChangesPokemon compares two Pokemon structs
-// Ignored: Username, Iv, Pvp
-// Float tolerance: Lat, Lon
-// Null Float tolerance: Weight, Height, Capture1, Capture2, Capture3
-func hasChangesPokemon(old *Pokemon, new *Pokemon) bool {
-	return old.Id != new.Id ||
-		old.PokestopId != new.PokestopId ||
-		old.SpawnId != new.SpawnId ||
-		old.Size != new.Size ||
-		old.ExpireTimestamp != new.ExpireTimestamp ||
-		old.Updated != new.Updated ||
-		old.PokemonId != new.PokemonId ||
-		old.Move1 != new.Move1 ||
-		old.Move2 != new.Move2 ||
-		old.Gender != new.Gender ||
-		old.Cp != new.Cp ||
-		old.AtkIv != new.AtkIv ||
-		old.DefIv != new.DefIv ||
-		old.StaIv != new.StaIv ||
-		old.Form != new.Form ||
-		old.Level != new.Level ||
-		old.IsStrong != new.IsStrong ||
-		old.Weather != new.Weather ||
-		old.Costume != new.Costume ||
-		old.FirstSeenTimestamp != new.FirstSeenTimestamp ||
-		old.Changed != new.Changed ||
-		old.CellId != new.CellId ||
-		old.ExpireTimestampVerified != new.ExpireTimestampVerified ||
-		old.DisplayPokemonId != new.DisplayPokemonId ||
-		old.DisplayPokemonForm != new.DisplayPokemonForm ||
-		old.IsDitto != new.IsDitto ||
-		old.SeenType != new.SeenType ||
-		old.Shiny != new.Shiny ||
-		old.IsEvent != new.IsEvent ||
-		!floatAlmostEqual(old.Lat, new.Lat, floatTolerance) ||
-		!floatAlmostEqual(old.Lon, new.Lon, floatTolerance) ||
-		!nullFloatAlmostEqual(old.Weight, new.Weight, floatTolerance) ||
-		!nullFloatAlmostEqual(old.Height, new.Height, floatTolerance) ||
-		!nullFloatAlmostEqual(old.Capture1, new.Capture1, floatTolerance) ||
-		!nullFloatAlmostEqual(old.Capture2, new.Capture2, floatTolerance) ||
-		!nullFloatAlmostEqual(old.Capture3, new.Capture3, floatTolerance)
-}
-
 func savePokemonRecordAsAtTime(ctx context.Context, db db.DbDetails, pokemon *Pokemon, isEncounter, writeDB, webhook bool, now int64) {
 	if !pokemon.newRecord && !pokemon.IsDirty() {
 		return

--- a/decoder/pokestop_decode.go
+++ b/decoder/pokestop_decode.go
@@ -228,13 +228,9 @@ func (stop *Pokestop) updatePokestopFromQuestProto(questProto *pogo.FortSearchOu
 		case pogo.QuestConditionProto_WITH_RAID_LOCATION:
 		case pogo.QuestConditionProto_WITH_FRIENDS_RAID:
 		case pogo.QuestConditionProto_WITH_POKEMON_COSTUME:
-		default:
-			break
 		}
 
-		if infoData != nil {
-			condition["info"] = infoData
-		}
+		condition["info"] = infoData
 		conditions = append(conditions, condition)
 	}
 
@@ -352,8 +348,6 @@ func (stop *Pokestop) updatePokestopFromQuestProto(questProto *pogo.FortSearchOu
 		case pogo.QuestRewardProto_LEVEL_CAP:
 		case pogo.QuestRewardProto_INCIDENT:
 		case pogo.QuestRewardProto_PLAYER_ATTRIBUTE:
-		default:
-			break
 		}
 		reward["info"] = infoData
 		rewards = append(rewards, reward)
@@ -378,7 +372,7 @@ func (stop *Pokestop) updatePokestopFromQuestProto(questProto *pogo.FortSearchOu
 		}
 	}
 
-	if questExpiry.Valid == false {
+	if !questExpiry.Valid {
 		questExpiry = null.IntFrom(time.Now().Unix() + 24*60*60) // Set expiry to 24 hours from now
 	}
 
@@ -434,7 +428,7 @@ func (stop *Pokestop) updatePokestopFromFortDetailsProto(fortData *pogo.FortDeta
 		stop.SetDescription(null.StringFrom(fortData.Description))
 	}
 
-	if fortData.Modifier != nil && len(fortData.Modifier) > 0 {
+	if len(fortData.Modifier) > 0 {
 		// DeployingPlayerCodename contains the name of the player if we want that
 		lureId := int16(fortData.Modifier[0].ModifierType)
 		lureExpiry := fortData.Modifier[0].ExpirationTimeMs / 1000

--- a/decoder/stats.go
+++ b/decoder/stats.go
@@ -167,7 +167,7 @@ func updateEncounterStats(pokemon *Pokemon) {
 	// We should only be called from encounters. It's important to do so,
 	// so that the 'DuplicateEncounters' stats below are correct.
 	// And double check that we have IVs, anyway.
-	if !(pokemon.AtkIv.Valid && pokemon.DefIv.Valid && pokemon.StaIv.Valid) {
+	if !pokemon.AtkIv.Valid || !pokemon.DefIv.Valid || !pokemon.StaIv.Valid {
 		return
 	}
 
@@ -183,7 +183,7 @@ func updateEncounterStats(pokemon *Pokemon) {
 	encounterCacheVal := encounterCache.GetOrCreate(uint64(pokemon.Id))
 	isNewEncounter := encounterCacheVal.NumAccountsSeen() == 0
 
-	if encounterCacheVal.SetAccountSeen(pokemon.Username.ValueOrZero()) {
+	if encounterCacheVal.SetAccountSeen(username) {
 		// account has already seen this encounter Id
 		statsCollector.IncDuplicateEncounters(true)
 		return
@@ -419,7 +419,7 @@ func updatePokemonStats(pokemon *Pokemon, areas []geo.AreaName, now int64) {
 		if monsSeenIncr > 0 || monsIvIncr > 0 || verifiedEncIncr > 0 || unverifiedEncIncr > 0 ||
 			bucket >= 0 || timeToEncounter > 0 || statsResetCountIncr > 0 ||
 			verifiedReEncounterIncr > 0 {
-			if locked == false {
+			if !locked {
 				pokemonStatsLock.Lock()
 				locked = true
 			}

--- a/decoder/writebehind/manager.go
+++ b/decoder/writebehind/manager.go
@@ -26,9 +26,8 @@ type QueueManager struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
-	startTime            time.Time
-	startupDelayComplete bool
-	startupDelaySeconds  int
+	startTime           time.Time
+	startupDelaySeconds int
 }
 
 // NewQueueManager creates a new queue manager

--- a/deviceList.go
+++ b/deviceList.go
@@ -42,13 +42,7 @@ type ApiDeviceLocation struct {
 func GetAllDevices() map[string]ApiDeviceLocation {
 	locations := map[string]ApiDeviceLocation{}
 	for _, key := range deviceLocation.Items() {
-		deviceLocation := key.Value()
-		locations[key.Key()] = ApiDeviceLocation{
-			Latitude:    deviceLocation.Latitude,
-			Longitude:   deviceLocation.Longitude,
-			LastUpdate:  deviceLocation.LastUpdate,
-			ScanContext: deviceLocation.ScanContext,
-		}
+		locations[key.Key()] = ApiDeviceLocation(key.Value())
 	}
 	return locations
 }

--- a/geo/geofence.go
+++ b/geo/geofence.go
@@ -124,11 +124,7 @@ func (p *Geofence) Add(point Location) {
 //	this should be sufficient for detecting if points
 //	are contained using the raycast algorithm.
 func (p *Geofence) IsClosed() bool {
-	if len(p.Fence) < 3 {
-		return false
-	}
-
-	return true
+	return len(p.Fence) >= 3
 }
 
 // Contains returns whether or not the current Polygon contains the passed in Point.

--- a/geo/location.go
+++ b/geo/location.go
@@ -57,5 +57,5 @@ func SplitRoute(route []Location, parts int) [][]Location {
 }
 
 func (l ApiLocation) ToLocation() Location {
-	return Location{l.Latitude, l.Longitude}
+	return Location(l)
 }

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 
 	logLevel := log.InfoLevel
 
-	if cfg.Logging.Debug == true {
+	if cfg.Logging.Debug {
 		logLevel = log.DebugLevel
 	}
 	SetupLogger(
@@ -237,19 +237,19 @@ func main() {
 		StartDatabaseArchiver(db)
 	}
 
-	if cfg.Cleanup.Incidents == true {
+	if cfg.Cleanup.Incidents {
 		StartIncidentExpiry(db)
 	}
 
-	if cfg.Cleanup.Tappables == true {
+	if cfg.Cleanup.Tappables {
 		StartTappableExpiry(db)
 	}
 
-	if cfg.Cleanup.Quests == true {
+	if cfg.Cleanup.Quests {
 		StartQuestExpiry(dbDetails)
 	}
 
-	if cfg.Cleanup.Stats == true {
+	if cfg.Cleanup.Stats {
 		StartStatsExpiry(db)
 	}
 

--- a/routes.go
+++ b/routes.go
@@ -70,7 +70,7 @@ func questsHeldHasARTask(quests_held any) *bool {
 
 func Raw(c *gin.Context) {
 	var w http.ResponseWriter = c.Writer
-	var r *http.Request = c.Request
+	r := c.Request
 
 	dataReceivedTimestamp := time.Now().UnixMilli()
 
@@ -258,7 +258,7 @@ func Raw(c *gin.Context) {
 		}
 	}
 
-	if decodeError == true {
+	if decodeError {
 		statsCollector.IncRawRequests("error", "decode")
 		log.Infof("Raw: Data could not be decoded. From User agent %s - Received data %s", userAgent, body)
 

--- a/stats.go
+++ b/stats.go
@@ -38,13 +38,12 @@ func StartDatabaseArchiver(db *sqlx.DB) {
 		for {
 			<-ticker.C
 			log.Infof("DB - Archive of pokemon table - starting")
-			start := time.Now()
 
 			var resultCounter int64
 			var result sql.Result
 			var err error
 
-			start = time.Now()
+			start := time.Now()
 
 			for {
 				pokemonId := []PokemonIdToDelete{}

--- a/webhooks/sender.go
+++ b/webhooks/sender.go
@@ -2,10 +2,13 @@ package webhooks
 
 import (
 	"context"
-	"golbat/config"
-	"golbat/geo"
 	"sync"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"golbat/config"
+	"golbat/geo"
 )
 
 type configInterface interface {
@@ -69,7 +72,9 @@ func (sender *webhooksSender) Flush() {
 		wg.Add(1)
 		go func(wh *webhook) {
 			defer wg.Done()
-			wh.sendCollection(currentCollection)
+			if err := wh.sendCollection(currentCollection); err != nil {
+				log.Warnf("webhooks: flush to %s failed: %s", wh.url, err)
+			}
 		}(wh)
 	}
 	wg.Wait()


### PR DESCRIPTION
Adds `golangci-lint` to CI and clears the baseline so it stays green.

## What's in
- `.golangci.yml` enables `errcheck`, `govet`, `ineffassign`, `staticcheck`, `unused`.
- `.github/workflows/lint.yml` runs it on push to `main` and on every PR.

## Exclusions
- `Close` / `io.Copy` on read paths — deferred `Close` after a successful read has nowhere actionable to go; wrapping every defer in `func() { _ = ... }()` is just noise.
- `peek*Record` / `get*RecordReadOnly` / `get*RecordForUpdate` under `decoder/` — kept for symmetry across entity types (see CLAUDE.md "Record Access Patterns") even when not currently called.

## Real bugs the lint caught
- `decoder/stats.go` — the `<NoUsername>` substitution was unused; the encounter cache was being keyed on the raw `pokemon.Username.ValueOrZero()` instead. Now uses the substituted value.
- `stats.go` — first `start := time.Now()` was overwritten before any read.
- `webhooks/sender.go` — `sendCollection` error during shutdown flush was silently dropped; now logged.

## Hygiene
- `io/ioutil` → `os` in `decoder/geography.go`; previously-ignored cache-write error now logged.
- 4× `errors.New(fmt.Sprintf(...))` → `fmt.Errorf` in `pokemon_decode.go`.
- 9× `if x == true` / `== false` → direct boolean tests.
- 3× `return fmt.Sprintf("literal")` → plain string returns.
- 3× `if change == NEW { ... } else if ...` → tagged switch (`fort.go`, `api_fort.go`, `incident_decode.go`).
- Struct-literal → conversion (`deviceList.go`, `geo/location.go`).
- `geo/geofence.go` `IsClosed` reduced to a single return.
- Dropped redundant `default: break` no-ops and a nil-before-len check in `pokestop_decode.go`.

## Removals
- `cellContainsForts` (decode.go), `hasChangesGym`, `hasInternalChangesGym`, `hasChangesPokemon` (diff helpers, never called), and the `startupDelayComplete` field on `QueueManager`.

## Verification
- \`go build -tags go_json ./...\`
- \`go vet -tags go_json ./...\`
- \`go test -tags go_json ./...\`
- \`golangci-lint run\` — 0 issues