### PR TITLE
fix: drop transaction from station_battle flush to relieve DB contention

### DIFF
--- a/decoder/station_battle.go
+++ b/decoder/station_battle.go
@@ -574,15 +574,19 @@ func flushStationBattleBatch(ctx context.Context, dbDetails db.DbDetails, snapsh
 	if len(stationIds) == 0 {
 		return nil
 	}
-	tx, err := dbDetails.GeneralDb.BeginTxx(ctx, nil)
-	statsCollector.IncDbQuery("begin station_battle", err)
-	if err != nil {
-		return err
-	}
 
+	// No surrounding transaction. Every other write-behind flush is a single
+	// autocommit upsert; wrapping these two statements in a transaction held the
+	// upsert's *and* the delete's InnoDB locks together until commit, so under
+	// concurrent overlapping batches the flushes blocked each other (lock-waits /
+	// 1213 deadlocks) and pinned shared-pool connections, starving the synchronous
+	// station reads. Run upsert-then-prune in autocommit so each statement releases
+	// its locks immediately. The brief gap between them is over-inclusive only (the
+	// reader filters battle_end > now and the upsert runs first), and a crash
+	// between them leaves a few obsolete rows that the next flush — or expiry —
+	// removes. Both are acceptable, self-healing states for battle data.
 	if len(battles) > 0 {
-		if _, err = tx.NamedExecContext(ctx, stationBattleBatchUpsertQuery, battles); err != nil {
-			_ = tx.Rollback()
+		if _, err := dbDetails.GeneralDb.NamedExecContext(ctx, stationBattleBatchUpsertQuery, battles); err != nil {
 			statsCollector.IncDbQuery("upsert station_battle", err)
 			return err
 		}
@@ -591,22 +595,18 @@ func flushStationBattleBatch(ctx context.Context, dbDetails db.DbDetails, snapsh
 
 	deleteQuery, deleteArgs, err := buildDeleteObsoleteStationBattlesQuery(stationIds, battles)
 	if err != nil {
-		_ = tx.Rollback()
 		statsCollector.IncDbQuery("delete obsolete station_battle", err)
 		return err
 	}
 	if deleteQuery != "" {
-		if _, err = tx.ExecContext(ctx, deleteQuery, deleteArgs...); err != nil {
-			_ = tx.Rollback()
+		if _, err := dbDetails.GeneralDb.ExecContext(ctx, deleteQuery, deleteArgs...); err != nil {
 			statsCollector.IncDbQuery("delete obsolete station_battle", err)
 			return err
 		}
 		statsCollector.IncDbQuery("delete obsolete station_battle", nil)
 	}
 
-	err = tx.Commit()
-	statsCollector.IncDbQuery("commit station_battle", err)
-	return err
+	return nil
 }
 
 func loadStationBattlesForStation(ctx context.Context, dbDetails db.DbDetails, stationId string, now int64) ([]StationBattleData, error) {


### PR DESCRIPTION
## Problem

Production on `main` is flooding with `getOrCreateStationRecord: context deadline exceeded`.

`flushStationBattleBatch` (added in #353) is the **only** write-behind flush wrapped in a transaction — every other flush (`flushPokestopBatch`, `flushGymBatch`, `flushStationBatch`, …) is a single autocommit `INSERT … ON DUPLICATE KEY UPDATE`. Wrapping the batch upsert **and** the obsolete-prune `DELETE … WHERE station_id IN (…) AND bread_battle_seed NOT IN (…)` in `BeginTxx … Commit` holds *both* statements' InnoDB locks (incl. next-key/gap locks on `ix_station_battle_station_end`) until commit.

Under concurrent overlapping batches (up to 50 write-behind workers × 50-station batches), those transactions block each other (lock-waits up to `innodb_lock_wait_timeout`, or 1213 deadlock-retries) and pin connections on the shared `GeneralDb` pool (`PokemonDb` and `GeneralDb` are the same handle). That starves the **synchronous** station reads (`loadStationFromDatabase` + the new battle hydrate) which run under the station entity lock with only the GMO's 5s context — surfacing as the `context deadline exceeded` flood.

This is **not** a Go mutex deadlock (the battle cache is a lock-free `xsync.MapOf`; the enqueue is non-blocking) — it's DB-level lock/connection contention.

## Fix

Drop the transaction. Run the upsert as a single autocommit `NamedExecContext` (matching every other flush) and the prune `DELETE` as a separate autocommit `ExecContext`, **upsert-first**. Each statement releases its locks immediately, the cross-statement deadlock shape is gone, and the pool connection is returned between statements.

No query text changed — only the `BeginTxx`/`Commit`/`Rollback` wrapper is removed.

### Consistency tradeoff (acceptable, self-healing)
Losing atomicity between the two statements means:
- A reader in the sub-ms gap can see the new battles plus a few about-to-be-pruned superseded ones — **over-inclusive only** (the reader filters `battle_end > now`, and the upsert runs first); the next hydrate corrects it.
- A crash *between* the statements leaves a few obsolete rows, removed by the next flush or by expiry.

## Test Plan

- [x] `go build -tags go_json ./...`, `go vet ./...`, `go test ./...` — all green (incl. all station-battle tests; `buildDeleteObsoleteStationBattlesQuery` query-building unchanged).
- [ ] **Deploy and confirm the `getOrCreateStationRecord: context deadline exceeded` flood stops under load** — the contention relief is operational and can only be confirmed against a live DB. If it persists, the dominant factor may be raw write volume rather than lock-hold time (next levers: separate read pool, larger `max_pool`, move battle hydrate out from under the entity lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)