### PR TITLE
feat: parse temp evolution branch quest rewards

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ version: "2"
 run:
   build-tags:
     - go_json
-  timeout: 5m
+  timeout: 10m
 
 linters:
   default: none
@@ -26,6 +26,8 @@ linters:
         - (*encoding/json.Decoder).Decode
 
   exclusions:
+    paths:
+      - pogo/  # generated protobuf package; excluded to avoid whole-program analysis timeout
     rules:
       # Entity access pattern: each entity type provides peek*Record /
       # get*RecordReadOnly / get*RecordForUpdate even when not currently

--- a/decoder/pokestop_decode.go
+++ b/decoder/pokestop_decode.go
@@ -343,6 +343,24 @@ func (stop *Pokestop) updatePokestopFromQuestProto(questProto *pogo.FortSearchOu
 				rewardAmount = null.IntFrom(int64(info.Amount))
 				rewardPokemonId = null.IntFrom(int64(info.PokemonId))
 			}
+		case pogo.QuestRewardProto_TEMP_EVO_BRANCH_RESOURCE:
+			info := rewardData.GetTempEvoResource()
+			if info == nil {
+				break
+			}
+			infoData["amount"] = info.Amount
+			if isFirst {
+				rewardAmount = null.IntFrom(int64(info.Amount))
+			}
+			if branch := info.GetTempEvoPokemonBranch(); branch != nil {
+				infoData["pokemon_id"] = int(branch.PokedexId)
+				if tempEvolution := int(branch.TempEvoId); tempEvolution != 0 {
+					infoData["temp_evolution"] = tempEvolution
+				}
+				if isFirst {
+					rewardPokemonId = null.IntFrom(int64(branch.PokedexId))
+				}
+			}
 		case pogo.QuestRewardProto_AVATAR_CLOTHING:
 		case pogo.QuestRewardProto_QUEST:
 		case pogo.QuestRewardProto_LEVEL_CAP:

--- a/decoder/pokestop_decode_test.go
+++ b/decoder/pokestop_decode_test.go
@@ -1,0 +1,74 @@
+package decoder
+
+import (
+	"encoding/json"
+	"testing"
+
+	"golbat/pogo"
+
+	"google.golang.org/protobuf/proto"
+)
+
+func TestUpdatePokestopFromQuestProtoTempEvoBranchResource(t *testing.T) {
+	stop := &Pokestop{}
+	quest := &pogo.FortSearchOutProto{
+		ChallengeQuest: &pogo.ClientQuestProto{
+			Quest: &pogo.QuestProto{
+				Goal:       &pogo.QuestGoalProto{},
+				TemplateId: "QUEST_TEMP_EVO_RESOURCE",
+				QuestRewards: []*pogo.QuestRewardProto{{
+					Type: pogo.QuestRewardProto_TEMP_EVO_BRANCH_RESOURCE,
+					Reward: &pogo.QuestRewardProto_TempEvoResource{
+						TempEvoResource: &pogo.TempEvoResourceRewardProto{
+							Amount: 150,
+							TempEvoPokemonBranch: &pogo.TempEvoPokemonBranch{
+								PokedexId: pogo.HoloPokemonId_MEWTWO,
+								TempEvoId: pogo.HoloTemporaryEvolutionId_TEMP_EVOLUTION_MEGA_X,
+							},
+						},
+					},
+				}},
+			},
+			QuestDisplay: &pogo.QuestDisplayProto{Description: "Earn Mega Energy"},
+		},
+	}
+
+	rawQuest, err := proto.Marshal(quest)
+	if err != nil {
+		t.Fatalf("marshal quest: %v", err)
+	}
+	var decodedQuest pogo.FortSearchOutProto
+	if err := proto.Unmarshal(rawQuest, &decodedQuest); err != nil {
+		t.Fatalf("unmarshal quest: %v", err)
+	}
+
+	stop.updatePokestopFromQuestProto(&decodedQuest, true)
+
+	if got := stop.QuestRewardType.ValueOrZero(); got != 20 {
+		t.Errorf("QuestRewardType = %d, want 20", got)
+	}
+	if got := stop.QuestRewardAmount.ValueOrZero(); got != 150 {
+		t.Errorf("QuestRewardAmount = %d, want 150", got)
+	}
+	if got := stop.QuestPokemonId.ValueOrZero(); got != 150 {
+		t.Errorf("QuestPokemonId = %d, want 150", got)
+	}
+
+	var rewards []struct {
+		Type int `json:"type"`
+		Info struct {
+			Amount        int `json:"amount"`
+			PokemonId     int `json:"pokemon_id"`
+			TempEvolution int `json:"temp_evolution"`
+		} `json:"info"`
+	}
+	if err := json.Unmarshal([]byte(stop.QuestRewards.ValueOrZero()), &rewards); err != nil {
+		t.Fatalf("unmarshal QuestRewards: %v", err)
+	}
+	if len(rewards) != 1 {
+		t.Fatalf("len(QuestRewards) = %d, want 1", len(rewards))
+	}
+	if got := rewards[0]; got.Type != 20 || got.Info.Amount != 150 || got.Info.PokemonId != 150 || got.Info.TempEvolution != 2 {
+		t.Errorf("QuestRewards[0] = %+v, want type 20, amount 150, pokemon 150, temp evolution 2", got)
+	}
+}

--- a/webhooks.md
+++ b/webhooks.md
@@ -860,6 +860,7 @@ numeric value from the bundled `pogo` proto definitions if you need it.
 | 12     | `MEGA_RESOURCE`                    | `amount` (int), `pokemon_id` (int). |
 | 13     | `INCIDENT`                         | (no info) |
 | 14     | `PLAYER_ATTRIBUTE`                 | (no info) |
+| 20     | `TEMP_EVO_BRANCH_RESOURCE`         | `amount` (int), `pokemon_id` (int), `temp_evolution` (int, omitted when unset). |
 
 **`POKEMON_ENCOUNTER` info**:
 


### PR DESCRIPTION
## Summary

- update the bundled generated protobuf definitions to Base 0.417.x using the exact `pogo/vbase.pb.go` from #360
- decode `TEMP_EVO_BRANCH_RESOURCE` (quest reward type 20) into `amount`, `pokemon_id`, and optional `temp_evolution` fields
- populate the indexed first-reward amount and Pokemon columns
- document the new reward payload and cover it with a protobuf wire round-trip regression test
- carry over #360's generated-protobuf lint exclusion and timeout increase, which are required for the larger generated file to pass CI

## Why

The protobuf bundled on `main` does not define reward type 20 or its field-24 payload. Golbat therefore preserves the numeric reward type but emits an empty `info` object and cannot populate the indexed reward details.

This keeps the upstream reward type truthful rather than rewriting type 20 as the older generic mega-resource type 12.

## ReactMap coordination

[WatWowMap/ReactMap@8756f38f](https://github.com/WatWowMap/ReactMap/commit/8756f38f964c7a330e16fb57888795e5bbd5da16) currently normalizes only the old empty type-20 payload through a temporary Mewtwo fallback. Once Golbat emits populated type-20 details, ReactMap needs a companion change that consumes those details as mega energy while retaining the empty-payload fallback for older Golbat deployments.

Keep this PR in draft until that consumer-side handling is ready if ReactMap compatibility is required for deployment.

## Validation

- `go test ./...`
- `golangci-lint v2.12.2 run` - 0 issues
- generated protobuf blob verified byte-for-byte against #360
