### PR TITLE
feat(api): GET /api/pokestop/available — in-memory available-pokestop aggregate (draft)

### DIFF
--- a/decoder/api_fort.go
+++ b/decoder/api_fort.go
@@ -137,7 +137,8 @@ func isFortDnfMatch(fortType FortType, fortLookup *FortLookup, filter *ApiFortDn
 			}
 		}
 	case POKESTOP:
-		if filter.LureId != nil && !slices.Contains(filter.LureId, fortLookup.LureId) {
+		if filter.LureId != nil &&
+			(fortLookup.LureExpireTimestamp <= now || !slices.Contains(filter.LureId, fortLookup.LureId)) {
 			return false
 		}
 
@@ -170,13 +171,17 @@ func isFortDnfMatch(fortType FortType, fortLookup *FortLookup, filter *ApiFortDn
 		}
 
 		// Contest filters
-		if filter.ContestPokemonType != nil && !slices.Contains(filter.ContestPokemonType, fortLookup.ContestPokemonType) {
+		if filter.ContestPokemonType != nil &&
+			(fortLookup.ShowcaseExpiry <= now || !slices.Contains(filter.ContestPokemonType, fortLookup.ContestPokemonType)) {
 			return false
 		}
-		if filter.ContestTotalEntries != nil && (fortLookup.ContestTotalEntries < filter.ContestTotalEntries.Min || fortLookup.ContestTotalEntries > filter.ContestTotalEntries.Max) {
+		if filter.ContestTotalEntries != nil &&
+			(fortLookup.ShowcaseExpiry <= now ||
+				fortLookup.ContestTotalEntries < filter.ContestTotalEntries.Min || fortLookup.ContestTotalEntries > filter.ContestTotalEntries.Max) {
 			return false
 		}
-		if filter.ContestPokemon != nil && !matchDnfIdPair(filter.ContestPokemon, fortLookup.ContestPokemonId, fortLookup.ContestPokemonForm) {
+		if filter.ContestPokemon != nil &&
+			(fortLookup.ShowcaseExpiry <= now || !matchDnfIdPair(filter.ContestPokemon, fortLookup.ContestPokemonId, fortLookup.ContestPokemonForm)) {
 			return false
 		}
 

--- a/decoder/api_fort.go
+++ b/decoder/api_fort.go
@@ -185,18 +185,32 @@ func isFortDnfMatch(fortType FortType, fortLookup *FortLookup, filter *ApiFortDn
 			return false
 		}
 
-		// Incident filters - flat field checks
-		if filter.IncidentDisplayType != nil && !slices.Contains(filter.IncidentDisplayType, fortLookup.IncidentDisplayType) {
-			return false
-		}
-		if filter.IncidentStyle != nil && !slices.Contains(filter.IncidentStyle, fortLookup.IncidentStyle) {
-			return false
-		}
-		if filter.IncidentCharacter != nil && !slices.Contains(filter.IncidentCharacter, fortLookup.IncidentCharacter) {
-			return false
-		}
-		if filter.IncidentPokemon != nil && !matchDnfIdPair(filter.IncidentPokemon, fortLookup.IncidentPokemonId, fortLookup.IncidentPokemonForm) {
-			return false
+		// Incident filters - match any non-expired incident in the slice
+		if filter.IncidentDisplayType != nil || filter.IncidentStyle != nil ||
+			filter.IncidentCharacter != nil || filter.IncidentPokemon != nil {
+			matched := false
+			for _, inc := range fortLookup.Incidents {
+				if inc.ExpireTimestamp <= now {
+					continue
+				}
+				if filter.IncidentDisplayType != nil && !slices.Contains(filter.IncidentDisplayType, inc.DisplayType) {
+					continue
+				}
+				if filter.IncidentStyle != nil && !slices.Contains(filter.IncidentStyle, inc.Style) {
+					continue
+				}
+				if filter.IncidentCharacter != nil && !slices.Contains(filter.IncidentCharacter, inc.Character) {
+					continue
+				}
+				if filter.IncidentPokemon != nil && !matchDnfIdPair(filter.IncidentPokemon, inc.Slot1PokemonId, inc.Slot1Form) {
+					continue
+				}
+				matched = true
+				break
+			}
+			if !matched {
+				return false
+			}
 		}
 	case STATION:
 		if filter.BattleLevel != nil || filter.BattlePokemon != nil {

--- a/decoder/api_pokestop_available.go
+++ b/decoder/api_pokestop_available.go
@@ -69,7 +69,13 @@ type ApiAvailablePokestops struct {
 // drift between the two.
 func GetAvailablePokestops(now int64) *ApiAvailablePokestops {
 	start := time.Now()
-	res := &ApiAvailablePokestops{}
+	// Initialize the slices so empty categories marshal as [] rather than null.
+	res := &ApiAvailablePokestops{
+		Quests:    []ApiPokestopQuestAvailable{},
+		Invasions: []ApiPokestopInvasionAvailable{},
+		Lures:     []ApiPokestopLureAvailable{},
+		Showcases: []ApiPokestopShowcaseAvailable{},
+	}
 	forts, incidents := 0, 0
 	lures := map[int16]int{}
 	shows := map[ApiPokestopShowcaseAvailable]int{} // key without Count

--- a/decoder/api_pokestop_available.go
+++ b/decoder/api_pokestop_available.go
@@ -11,52 +11,52 @@ import (
 // pokestops, with how many forts offer it. Sourced solely from the maintained
 // quest-conditions map (Task 3) — FortLookup itself omits title/target.
 type ApiPokestopQuestAvailable struct {
-	WithAr     bool   `json:"with_ar"`
-	RewardType int16  `json:"reward_type"`
-	ItemId     int16  `json:"item_id"`
-	Amount     int16  `json:"amount"`
-	PokemonId  int16  `json:"pokemon_id"`
-	FormId     int16  `json:"form_id"`
-	Title      string `json:"title"`
-	Target     int32  `json:"target"`
-	Count      int    `json:"count"`
+	WithAr     bool   `json:"with_ar" doc:"True for the AR quest slot, false for the no-AR slot"`
+	RewardType int16  `json:"reward_type" doc:"Quest reward type (pogo enum: 1=xp, 2=item, 3=stardust, 4=candy, 7=pokemon, 9=xl_candy, 12=mega_energy, …)"`
+	ItemId     int16  `json:"item_id" doc:"Item id when reward_type is item (2), else 0"`
+	Amount     int16  `json:"amount" doc:"Reward amount for stardust/xp/mega-energy rewards, else 0"`
+	PokemonId  int16  `json:"pokemon_id" doc:"Reward pokemon id for candy/xl-candy/pokemon/mega rewards, else 0"`
+	FormId     int16  `json:"form_id" doc:"Reward pokemon form id, else 0"`
+	Title      string `json:"title" doc:"Quest title/template string, for the advanced title/target sub-filter"`
+	Target     int32  `json:"target" doc:"Quest target count"`
+	Count      int    `json:"count" doc:"Number of resident forts currently offering this exact reward+title+target"`
 }
 
 // ApiPokestopInvasionAvailable is one distinct active invasion (grunt/leader/
 // showcase character + slot1 reward) currently present on resident
 // pokestops, with how many forts carry it. Sourced from FortLookup.Incidents.
 type ApiPokestopInvasionAvailable struct {
-	Character      int16 `json:"character"`
-	DisplayType    int16 `json:"display_type"`
-	Confirmed      bool  `json:"confirmed"`
-	Slot1PokemonId int16 `json:"slot1_pokemon_id"`
-	Slot1Form      int16 `json:"slot1_form"`
-	Count          int   `json:"count"`
+	Character      int16 `json:"character" doc:"Invasion character id (grunt/leader/giovanni); 0 for non-rocket displays"`
+	DisplayType    int16 `json:"display_type" doc:"Incident display type (1-4 rocket, 7 goldstop, 8 kecleon, 9 showcase/contest)"`
+	Confirmed      bool  `json:"confirmed" doc:"True when the lineup is confirmed (grunts only)"`
+	Slot1PokemonId int16 `json:"slot1_pokemon_id" doc:"Confirmed lead pokemon id (grunts only), else 0"`
+	Slot1Form      int16 `json:"slot1_form" doc:"Confirmed lead pokemon form, else 0"`
+	Count          int   `json:"count" doc:"Number of resident forts with this active invasion signature"`
 }
 
 // ApiPokestopLureAvailable is one distinct active lure type, with how many
 // resident pokestops currently carry it.
 type ApiPokestopLureAvailable struct {
-	LureId int16 `json:"lure_id"`
-	Count  int   `json:"count"`
+	LureId int16 `json:"lure_id" doc:"Active lure module id"`
+	Count  int   `json:"count" doc:"Number of resident forts with this active lure"`
 }
 
 // ApiPokestopShowcaseAvailable is one distinct active showcase contest
 // (pokemon/form/type), with how many resident pokestops currently run it.
 type ApiPokestopShowcaseAvailable struct {
-	PokemonId int16 `json:"pokemon_id"`
-	Form      int16 `json:"form"`
-	TypeId    int8  `json:"type_id"`
-	Count     int   `json:"count"`
+	PokemonId int16 `json:"pokemon_id" doc:"Showcase focus pokemon id, else 0"`
+	Form      int16 `json:"form" doc:"Showcase focus pokemon form, else 0"`
+	TypeId    int8  `json:"type_id" doc:"Showcase focus pokemon type id (type-based showcases), else 0"`
+	Count     int   `json:"count" doc:"Number of resident forts with this active showcase"`
 }
 
 // ApiAvailablePokestops is the whole-instance snapshot served by
 // GET /api/pokestop/available.
 type ApiAvailablePokestops struct {
-	Quests    []ApiPokestopQuestAvailable    `json:"quests"`
-	Invasions []ApiPokestopInvasionAvailable `json:"invasions"`
-	Lures     []ApiPokestopLureAvailable     `json:"lures"`
-	Showcases []ApiPokestopShowcaseAvailable `json:"showcases"`
+	Quests    []ApiPokestopQuestAvailable    `json:"quests" doc:"Distinct quest reward + title/target options currently offered"`
+	Invasions []ApiPokestopInvasionAvailable `json:"invasions" doc:"Distinct active invasion signatures"`
+	Lures     []ApiPokestopLureAvailable     `json:"lures" doc:"Distinct active lure module ids"`
+	Showcases []ApiPokestopShowcaseAvailable `json:"showcases" doc:"Distinct active showcase focus pokemon/type"`
 }
 
 // GetAvailablePokestops returns the distinct lures, active showcases, active

--- a/decoder/api_pokestop_available.go
+++ b/decoder/api_pokestop_available.go
@@ -168,9 +168,13 @@ func verifyQuestAggregate(fortRewards map[questRewardKey]int) {
 	}
 }
 
-// logAvailablePokestops is a temporary no-metric log line; Task 5 adds
-// StatsCollector observation alongside it.
-func logAvailablePokestops(took time.Duration, forts, incidents int, res *ApiAvailablePokestops) {
-	log.Infof("GetAvailablePokestops: %d forts, %d incidents, %d lures, %d showcases, %d invasions, %d quests (%s)",
-		forts, incidents, len(res.Lures), len(res.Showcases), len(res.Invasions), len(res.Quests), took)
+// logAvailablePokestops records the available-pokestops build time in the
+// api_scan_duration histogram (StatsCollector.ObserveApiScan) and logs a
+// summary of the scan.
+func logAvailablePokestops(dur time.Duration, forts, incidents int, res *ApiAvailablePokestops) {
+	if statsCollector != nil {
+		statsCollector.ObserveApiScan("available-pokestops", dur.Seconds())
+	}
+	log.Infof("available-pokestops built in %s: scanned %d forts / %d incidents -> %d quests, %d invasions, %d lures, %d showcases",
+		dur, forts, incidents, len(res.Quests), len(res.Invasions), len(res.Lures), len(res.Showcases))
 }

--- a/decoder/api_pokestop_available.go
+++ b/decoder/api_pokestop_available.go
@@ -1,0 +1,176 @@
+package decoder
+
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// ApiPokestopQuestAvailable is one distinct quest option (reward + title +
+// target, AR/no-AR distinguished by WithAr) currently offered by resident
+// pokestops, with how many forts offer it. Sourced solely from the maintained
+// quest-conditions map (Task 3) — FortLookup itself omits title/target.
+type ApiPokestopQuestAvailable struct {
+	WithAr     bool   `json:"with_ar"`
+	RewardType int16  `json:"reward_type"`
+	ItemId     int16  `json:"item_id"`
+	Amount     int16  `json:"amount"`
+	PokemonId  int16  `json:"pokemon_id"`
+	FormId     int16  `json:"form_id"`
+	Title      string `json:"title"`
+	Target     int32  `json:"target"`
+	Count      int    `json:"count"`
+}
+
+// ApiPokestopInvasionAvailable is one distinct active invasion (grunt/leader/
+// showcase character + slot1 reward) currently present on resident
+// pokestops, with how many forts carry it. Sourced from FortLookup.Incidents.
+type ApiPokestopInvasionAvailable struct {
+	Character      int16 `json:"character"`
+	DisplayType    int16 `json:"display_type"`
+	Confirmed      bool  `json:"confirmed"`
+	Slot1PokemonId int16 `json:"slot1_pokemon_id"`
+	Slot1Form      int16 `json:"slot1_form"`
+	Count          int   `json:"count"`
+}
+
+// ApiPokestopLureAvailable is one distinct active lure type, with how many
+// resident pokestops currently carry it.
+type ApiPokestopLureAvailable struct {
+	LureId int16 `json:"lure_id"`
+	Count  int   `json:"count"`
+}
+
+// ApiPokestopShowcaseAvailable is one distinct active showcase contest
+// (pokemon/form/type), with how many resident pokestops currently run it.
+type ApiPokestopShowcaseAvailable struct {
+	PokemonId int16 `json:"pokemon_id"`
+	Form      int16 `json:"form"`
+	TypeId    int8  `json:"type_id"`
+	Count     int   `json:"count"`
+}
+
+// ApiAvailablePokestops is the whole-instance snapshot served by
+// GET /api/pokestop/available.
+type ApiAvailablePokestops struct {
+	Quests    []ApiPokestopQuestAvailable    `json:"quests"`
+	Invasions []ApiPokestopInvasionAvailable `json:"invasions"`
+	Lures     []ApiPokestopLureAvailable     `json:"lures"`
+	Showcases []ApiPokestopShowcaseAvailable `json:"showcases"`
+}
+
+// GetAvailablePokestops returns the distinct lures, active showcases, active
+// invasions, and available quest options currently offered by resident
+// pokestops, each with a count of how many forts carry it. Quests are sourced
+// solely from the maintained quest-conditions map (Task 3); lures, showcases,
+// and invasions come from a single fortLookupCache.Range pass. The same pass
+// tallies FortLookup's own quest-reward fields and cross-checks that tally
+// against the maintained map (verifyQuestAggregate) to catch reconciliation
+// drift between the two.
+func GetAvailablePokestops(now int64) *ApiAvailablePokestops {
+	start := time.Now()
+	res := &ApiAvailablePokestops{}
+	forts, incidents := 0, 0
+	lures := map[int16]int{}
+	shows := map[ApiPokestopShowcaseAvailable]int{} // key without Count
+	inv := map[ApiPokestopInvasionAvailable]int{}   // key without Count
+
+	// Quests (rewards + title/target) come solely from the maintained conditions map — distinct+counted.
+	// ApiQuestConditionResult and ApiPokestopQuestAvailable share identical fields (name/order/type), so
+	// a direct conversion carries every field without restating them.
+	for _, c := range GetAvailableQuestConditions() {
+		res.Quests = append(res.Quests, ApiPokestopQuestAvailable(c))
+	}
+
+	// ONE range: lures + showcases + invasions (response) + a quest-reward tally (verification only).
+	rewards := map[questRewardKey]int{} // direct FortLookup reward count — cross-checks the maintained map
+	fortLookupCache.Range(func(_ string, fl FortLookup) bool {
+		if fl.FortType != POKESTOP {
+			return true
+		}
+		forts++
+		if fl.LureId != 0 && fl.LureExpireTimestamp > now {
+			lures[fl.LureId]++
+		}
+		if fl.ContestPokemonId != 0 && fl.ShowcaseExpiry > now {
+			shows[ApiPokestopShowcaseAvailable{PokemonId: fl.ContestPokemonId, Form: fl.ContestPokemonForm, TypeId: fl.ContestPokemonType}]++
+		}
+		for _, in := range fl.Incidents {
+			if in.ExpireTimestamp <= now {
+				continue
+			}
+			incidents++
+			inv[ApiPokestopInvasionAvailable{
+				Character: in.Character, DisplayType: int16(in.DisplayType), Confirmed: in.Confirmed,
+				Slot1PokemonId: in.Slot1PokemonId, Slot1Form: in.Slot1Form,
+			}]++
+		}
+		if fl.QuestNoArRewardType != 0 {
+			rewards[questRewardKey{false, fl.QuestNoArRewardType, fl.QuestNoArRewardItemId, fl.QuestNoArRewardAmount, fl.QuestNoArRewardPokemonId, fl.QuestNoArRewardPokemonForm}]++
+		}
+		if fl.QuestArRewardType != 0 {
+			rewards[questRewardKey{true, fl.QuestArRewardType, fl.QuestArRewardItemId, fl.QuestArRewardAmount, fl.QuestArRewardPokemonId, fl.QuestArRewardPokemonForm}]++
+		}
+		return true
+	})
+
+	for id, n := range lures {
+		res.Lures = append(res.Lures, ApiPokestopLureAvailable{LureId: id, Count: n})
+	}
+	for k, n := range shows {
+		k.Count = n
+		res.Showcases = append(res.Showcases, k)
+	}
+	for k, n := range inv {
+		k.Count = n
+		res.Invasions = append(res.Invasions, k)
+	}
+
+	verifyQuestAggregate(rewards) // alert if the maintained map drifted from the direct FortLookup tally
+	logAvailablePokestops(time.Since(start), forts, incidents, res)
+	return res
+}
+
+// questRewardKey is the reward signature shared by the maintained conditions map (minus title/target)
+// and the FortLookup reward tally used to detect reconciliation drift.
+type questRewardKey struct {
+	WithAr                                        bool
+	RewardType, ItemId, Amount, PokemonId, FormId int16
+}
+
+// verifyQuestAggregate cross-checks the maintained conditions map against a direct FortLookup tally.
+// Invariant: for each reward signature, sum(map counts over title/target) == resident forts carrying
+// it. A persistent mismatch means the Task-3 reconciliation drifted. (A single-cycle mismatch under
+// concurrent updates is possible since Range is a weakly-consistent snapshot — alert on persistence,
+// not one occurrence.)
+//
+// This only logs today; Task 5 wires the desync count into StatsCollector.
+func verifyQuestAggregate(fortRewards map[questRewardKey]int) {
+	mapRewards := map[questRewardKey]int{}
+	for _, c := range GetAvailableQuestConditions() {
+		mapRewards[questRewardKey{c.WithAr, c.RewardType, c.ItemId, c.Amount, c.PokemonId, c.FormId}] += c.Count
+	}
+	desync := 0
+	for k, fortN := range fortRewards {
+		if mapRewards[k] != fortN {
+			desync++
+			log.Debugf("quest aggregate desync %+v: fortLookup=%d map=%d", k, fortN, mapRewards[k])
+		}
+	}
+	for k := range mapRewards {
+		if _, ok := fortRewards[k]; !ok {
+			desync++
+			log.Debugf("quest aggregate desync %+v: fortLookup=0 map=%d", k, mapRewards[k])
+		}
+	}
+	if desync > 0 {
+		log.Warnf("quest aggregate desync: %d reward signatures differ (FortLookup tally vs maintained map)", desync)
+	}
+}
+
+// logAvailablePokestops is a temporary no-metric log line; Task 5 adds
+// StatsCollector observation alongside it.
+func logAvailablePokestops(took time.Duration, forts, incidents int, res *ApiAvailablePokestops) {
+	log.Infof("GetAvailablePokestops: %d forts, %d incidents, %d lures, %d showcases, %d invasions, %d quests (%s)",
+		forts, incidents, len(res.Lures), len(res.Showcases), len(res.Invasions), len(res.Quests), took)
+}

--- a/decoder/api_pokestop_available.go
+++ b/decoder/api_pokestop_available.go
@@ -111,11 +111,15 @@ func GetAvailablePokestops(now int64) *ApiAvailablePokestops {
 				Slot1PokemonId: in.Slot1PokemonId, Slot1Form: in.Slot1Form,
 			}]++
 		}
+		// FortLookup QuestNoAr* mirrors quest_* (the AR quest → with_ar=true);
+		// QuestAr* mirrors alternative_quest_* (non-AR → with_ar=false). Must
+		// match the questConditionKeysFromPokestop convention or the cross-check
+		// cries wolf.
 		if fl.QuestNoArRewardType != 0 {
-			rewards[questRewardKey{false, fl.QuestNoArRewardType, fl.QuestNoArRewardItemId, fl.QuestNoArRewardAmount, fl.QuestNoArRewardPokemonId, fl.QuestNoArRewardPokemonForm}]++
+			rewards[questRewardKey{true, fl.QuestNoArRewardType, fl.QuestNoArRewardItemId, fl.QuestNoArRewardAmount, fl.QuestNoArRewardPokemonId, fl.QuestNoArRewardPokemonForm}]++
 		}
 		if fl.QuestArRewardType != 0 {
-			rewards[questRewardKey{true, fl.QuestArRewardType, fl.QuestArRewardItemId, fl.QuestArRewardAmount, fl.QuestArRewardPokemonId, fl.QuestArRewardPokemonForm}]++
+			rewards[questRewardKey{false, fl.QuestArRewardType, fl.QuestArRewardItemId, fl.QuestArRewardAmount, fl.QuestArRewardPokemonId, fl.QuestArRewardPokemonForm}]++
 		}
 		return true
 	})

--- a/decoder/api_pokestop_available.go
+++ b/decoder/api_pokestop_available.go
@@ -138,13 +138,18 @@ type questRewardKey struct {
 	RewardType, ItemId, Amount, PokemonId, FormId int16
 }
 
-// verifyQuestAggregate cross-checks the maintained conditions map against a direct FortLookup tally.
-// Invariant: for each reward signature, sum(map counts over title/target) == resident forts carrying
-// it. A persistent mismatch means the Task-3 reconciliation drifted. (A single-cycle mismatch under
-// concurrent updates is possible since Range is a weakly-consistent snapshot — alert on persistence,
-// not one occurrence.)
+// verifyQuestAggregate is a Debug-level diagnostic, not a production alarm. It cross-checks the
+// maintained conditions map against a direct FortLookup tally. Invariant: for each reward signature,
+// sum(map counts over title/target) == resident forts carrying it. In practice benign, transient
+// divergences occur routinely and are indistinguishable here from a real reconciliation bug:
 //
-// This only logs today; Task 5 wires the desync count into StatsCollector.
+//   - Read-skew: the FortLookup reward tally and GetAvailableQuestConditions() are read at different
+//     instants, while updatePokestopLookup does its Store(FortLookup) then reconcile(map) non-atomically.
+//   - Pokestop→gym conversion lag: the maintained map keeps a converted stop's quest count until the
+//     stale pokestopCache entry evicts (up to the fort TTL, ~25h), but this range no longer tallies it.
+//
+// So a persistent mismatch is not reliably distinguishable from noise at this log level; a proper
+// metric-based drift alarm (excluding converted stops from the comparison) is a documented follow-up.
 func verifyQuestAggregate(fortRewards map[questRewardKey]int) {
 	mapRewards := map[questRewardKey]int{}
 	for _, c := range GetAvailableQuestConditions() {
@@ -164,7 +169,7 @@ func verifyQuestAggregate(fortRewards map[questRewardKey]int) {
 		}
 	}
 	if desync > 0 {
-		log.Warnf("quest aggregate desync: %d reward signatures differ (FortLookup tally vs maintained map)", desync)
+		log.Debugf("quest aggregate desync: %d reward signatures differ (FortLookup tally vs maintained map)", desync)
 	}
 }
 

--- a/decoder/api_pokestop_available_test.go
+++ b/decoder/api_pokestop_available_test.go
@@ -1,0 +1,41 @@
+package decoder
+
+import (
+	"testing"
+
+	"github.com/puzpuzpuz/xsync/v4"
+)
+
+// TestGetAvailablePokestops seeds fortLookupCache + the quest-conditions map
+// directly (initFortRtree pulls in pokestopCache/gymCache/stationCache wiring
+// that isn't set up in this unit test, so we init only what this aggregate
+// reads: fortLookupCache and the questConditionCount/questFortKeys pair via
+// initQuestConditions).
+func TestGetAvailablePokestops(t *testing.T) {
+	fortLookupCache = xsync.NewMap[string, FortLookup]()
+	initQuestConditions()
+	now := int64(1_000_000)
+	// quest reward + condition via the maintained map (the sole quest source)
+	adjustQuestConditions([]questConditionKey{{RewardType: 2, ItemId: 1, Title: "catch_x", Target: 3}}, +1)
+	// one fort: active lure, EXPIRED showcase (excluded), active grunt incident — all read in one range
+	fortLookupCache.Store("s1", FortLookup{
+		FortType: POKESTOP, LureId: 501, LureExpireTimestamp: now + 100,
+		ContestPokemonId: 1, ShowcaseExpiry: now - 1, // expired -> excluded
+		Incidents: []FortLookupIncident{
+			{DisplayType: 1, Character: 5, Confirmed: true, Slot1PokemonId: 41, ExpireTimestamp: now + 100},
+		},
+	})
+	res := GetAvailablePokestops(now)
+	if len(res.Lures) != 1 || res.Lures[0].LureId != 501 {
+		t.Fatalf("lure: %+v", res.Lures)
+	}
+	if len(res.Showcases) != 0 {
+		t.Fatalf("expired showcase should be excluded: %+v", res.Showcases)
+	}
+	if len(res.Quests) != 1 || res.Quests[0].RewardType != 2 {
+		t.Fatalf("quest: %+v", res.Quests)
+	}
+	if len(res.Invasions) != 1 || res.Invasions[0].Character != 5 {
+		t.Fatalf("invasion: %+v", res.Invasions)
+	}
+}

--- a/decoder/fortRtree.go
+++ b/decoder/fortRtree.go
@@ -82,6 +82,7 @@ func initFortRtree() {
 	// plenty and saves ~7.5 MiB vs sharing the pokemon constant.
 	fortTreeEvictor = newTreeEvictor[string]("fort", 65536, treeEvictorBatchSize, flushFortTreeEvictions)
 	fortLookupCache = xsync.NewMap[string, FortLookup]()
+	initQuestConditions()
 
 	// OnEviction registrations live here, after fortTreeEvictor and
 	// fortLookupCache are created (and after pokestopCache/gymCache/
@@ -134,6 +135,11 @@ func fortRtreeUpdatePokestopOnSave(pokestop *Pokestop) {
 	genericUpdateFort(pokestop.Id, pokestop.Lat, pokestop.Lon, pokestop.Deleted)
 	if !pokestop.Deleted {
 		updatePokestopLookup(pokestop)
+	} else {
+		// A deleted pokestop drops out of the lookup cache (genericUpdateFort
+		// above) without a matching updatePokestopLookup, so reconcile its
+		// quest contribution to zero here.
+		removeFortQuestConditions(pokestop.Id)
 	}
 }
 
@@ -210,6 +216,13 @@ func updatePokestopLookup(pokestop *Pokestop) {
 		ContestTotalEntries:        getContestTotalEntries(pokestop.ShowcaseRankings),
 		ShowcaseExpiry:             pokestop.ShowcaseExpiry.ValueOrZero(),
 	})
+
+	// This is the sole writer of a pokestop's FortLookup entry, so it is also
+	// the single place quest-condition counts are reconciled: it fires on
+	// cache-miss load, every save (incl. quest change), and startup preload.
+	// FortLookup omits quest title/target, so the previous keys are recovered
+	// from questFortKeys rather than the overwritten FortLookup.
+	reconcileFortQuestConditions(pokestop.Id, questConditionKeysFromPokestop(pokestop))
 }
 
 func updateGymLookup(gym *Gym) {
@@ -324,6 +337,18 @@ func flushFortTreeEvictions(entries []treeEvictionEntry[string]) {
 //     (pokestop↔gym) and this is the stale counterpart's cache entry
 //     expiring; the live counterpart owns the lookup and tree point now.
 func deferFortEviction(expected FortType, fortId string, lat, lon float64) {
+	// A pokestop leaving the cache must drop its quest-condition contribution
+	// whether its FortLookup entry is still the resident pokestop one (matched,
+	// deleted just below), was overwritten by a converted gym/station
+	// counterpart (mismatch), or is already gone (deleted). questFortKeys only
+	// ever holds pokestop entries, so this is a no-op miss for gyms/stations and
+	// for pokestops already reconciled to no-quest. Because deferFortEviction
+	// deletes the matched FortLookup entry, removing the count here keeps the
+	// aggregate in lockstep with lookup-cache membership.
+	if expected == POKESTOP {
+		removeFortQuestConditions(fortId)
+	}
+
 	fl, ok := fortLookupCache.Load(fortId)
 	if !ok || fl.FortType != expected {
 		return

--- a/decoder/fortRtree.go
+++ b/decoder/fortRtree.go
@@ -185,36 +185,42 @@ func fortRtreeUpdateStationOnGet(station *Station) {
 }
 
 func updatePokestopLookup(pokestop *Pokestop) {
-	// Preserve existing incidents slice if present
-	var incidents []FortLookupIncident
-	if existing, ok := fortLookupCache.Load(pokestop.Id); ok {
-		incidents = existing.Incidents
-	}
-
-	fortLookupCache.Store(pokestop.Id, FortLookup{
-		FortType:                   POKESTOP,
-		Lat:                        pokestop.Lat,
-		Lon:                        pokestop.Lon,
-		PowerUpLevel:               int8(valueOrMinus1(pokestop.PowerUpLevel)),
-		IsArScanEligible:           pokestop.ArScanEligible.ValueOrZero() == 1,
-		LureId:                     pokestop.LureId,
-		LureExpireTimestamp:        pokestop.LureExpireTimestamp.ValueOrZero(),
-		QuestNoArRewardType:        int16(pokestop.QuestRewardType.ValueOrZero()),
-		QuestNoArRewardAmount:      int16(pokestop.QuestRewardAmount.ValueOrZero()),
-		QuestNoArRewardItemId:      int16(pokestop.QuestItemId.ValueOrZero()),
-		QuestNoArRewardPokemonId:   int16(pokestop.QuestPokemonId.ValueOrZero()),
-		QuestNoArRewardPokemonForm: int16(pokestop.QuestPokemonFormId.ValueOrZero()),
-		QuestArRewardType:          int16(pokestop.AlternativeQuestRewardType.ValueOrZero()),
-		QuestArRewardAmount:        int16(pokestop.AlternativeQuestRewardAmount.ValueOrZero()),
-		QuestArRewardItemId:        int16(pokestop.AlternativeQuestItemId.ValueOrZero()),
-		QuestArRewardPokemonId:     int16(pokestop.AlternativeQuestPokemonId.ValueOrZero()),
-		QuestArRewardPokemonForm:   int16(pokestop.AlternativeQuestPokemonFormId.ValueOrZero()),
-		Incidents:                  incidents,
-		ContestPokemonId:           int16(pokestop.ShowcasePokemon.ValueOrZero()),
-		ContestPokemonForm:         int16(pokestop.ShowcasePokemonForm.ValueOrZero()),
-		ContestPokemonType:         int8(pokestop.ShowcasePokemonType.ValueOrZero()),
-		ContestTotalEntries:        getContestTotalEntries(pokestop.ShowcaseRankings),
-		ShowcaseExpiry:             pokestop.ShowcaseExpiry.ValueOrZero(),
+	// Atomic per-key read-modify-write via Compute: this writer (under the
+	// POKESTOP entity lock) and updatePokestopIncidentLookup (under the
+	// INCIDENT entity lock) update the same key from different lock domains,
+	// each preserving the other's fields. A plain Load->Store pair can
+	// interleave and clobber. Keep the callback to field copies — the
+	// showcase-rankings JSON parse is hoisted out.
+	contestTotalEntries := getContestTotalEntries(pokestop.ShowcaseRankings)
+	fortLookupCache.Compute(pokestop.Id, func(existing FortLookup, loaded bool) (FortLookup, xsync.ComputeOp) {
+		nl := FortLookup{
+			FortType:                   POKESTOP,
+			Lat:                        pokestop.Lat,
+			Lon:                        pokestop.Lon,
+			PowerUpLevel:               int8(valueOrMinus1(pokestop.PowerUpLevel)),
+			IsArScanEligible:           pokestop.ArScanEligible.ValueOrZero() == 1,
+			LureId:                     pokestop.LureId,
+			LureExpireTimestamp:        pokestop.LureExpireTimestamp.ValueOrZero(),
+			QuestNoArRewardType:        int16(pokestop.QuestRewardType.ValueOrZero()),
+			QuestNoArRewardAmount:      int16(pokestop.QuestRewardAmount.ValueOrZero()),
+			QuestNoArRewardItemId:      int16(pokestop.QuestItemId.ValueOrZero()),
+			QuestNoArRewardPokemonId:   int16(pokestop.QuestPokemonId.ValueOrZero()),
+			QuestNoArRewardPokemonForm: int16(pokestop.QuestPokemonFormId.ValueOrZero()),
+			QuestArRewardType:          int16(pokestop.AlternativeQuestRewardType.ValueOrZero()),
+			QuestArRewardAmount:        int16(pokestop.AlternativeQuestRewardAmount.ValueOrZero()),
+			QuestArRewardItemId:        int16(pokestop.AlternativeQuestItemId.ValueOrZero()),
+			QuestArRewardPokemonId:     int16(pokestop.AlternativeQuestPokemonId.ValueOrZero()),
+			QuestArRewardPokemonForm:   int16(pokestop.AlternativeQuestPokemonFormId.ValueOrZero()),
+			ContestPokemonId:           int16(pokestop.ShowcasePokemon.ValueOrZero()),
+			ContestPokemonForm:         int16(pokestop.ShowcasePokemonForm.ValueOrZero()),
+			ContestPokemonType:         int8(pokestop.ShowcasePokemonType.ValueOrZero()),
+			ContestTotalEntries:        contestTotalEntries,
+			ShowcaseExpiry:             pokestop.ShowcaseExpiry.ValueOrZero(),
+		}
+		if loaded {
+			nl.Incidents = existing.Incidents // preserve the incident writer's slice
+		}
+		return nl, xsync.UpdateOp
 	})
 
 	// This is the sole writer of a pokestop's FortLookup entry, so it is also
@@ -262,10 +268,6 @@ func updateStationLookupWithBattles(station *Station, stationBattles []StationBa
 // incidents slice (keyed by DisplayType+Character, unique per active incident on a stop),
 // pruning any expired entries in the same pass.
 func updatePokestopIncidentLookup(pokestopId string, incident *Incident) {
-	existing, ok := fortLookupCache.Load(pokestopId)
-	if !ok {
-		return
-	}
 	now := time.Now().Unix()
 	updated := FortLookupIncident{
 		DisplayType:     int8(incident.DisplayType),
@@ -276,24 +278,31 @@ func updatePokestopIncidentLookup(pokestopId string, incident *Incident) {
 		Slot1Form:       int16(incident.Slot1Form.ValueOrZero()),
 		ExpireTimestamp: incident.ExpirationTime,
 	}
-	out := existing.Incidents[:0:0] // fresh backing array; never mutate a shared slice in place
-	replaced := false
-	for _, inc := range existing.Incidents {
-		if inc.ExpireTimestamp <= now {
-			continue // prune expired
+	// Atomic per-key read-modify-write via Compute — see updatePokestopLookup
+	// for the cross-lock-domain clobber this prevents.
+	fortLookupCache.Compute(pokestopId, func(existing FortLookup, loaded bool) (FortLookup, xsync.ComputeOp) {
+		if !loaded {
+			return existing, xsync.CancelOp
 		}
-		if inc.DisplayType == updated.DisplayType && inc.Character == updated.Character {
-			out = append(out, updated) // replace the same incident
-			replaced = true
-		} else {
-			out = append(out, inc)
+		out := existing.Incidents[:0:0] // fresh backing array; never mutate a shared slice in place
+		replaced := false
+		for _, inc := range existing.Incidents {
+			if inc.ExpireTimestamp <= now {
+				continue // prune expired
+			}
+			if inc.DisplayType == updated.DisplayType && inc.Character == updated.Character {
+				out = append(out, updated) // replace the same incident
+				replaced = true
+			} else {
+				out = append(out, inc)
+			}
 		}
-	}
-	if !replaced && updated.ExpireTimestamp > now {
-		out = append(out, updated)
-	}
-	existing.Incidents = out
-	fortLookupCache.Store(pokestopId, existing)
+		if !replaced && updated.ExpireTimestamp > now {
+			out = append(out, updated)
+		}
+		existing.Incidents = out
+		return existing, xsync.UpdateOp
+	})
 }
 
 // getContestTotalEntries parses showcase rankings JSON to get total entries

--- a/decoder/fortRtree.go
+++ b/decoder/fortRtree.go
@@ -46,12 +46,9 @@ type FortLookup struct {
 	QuestArRewardPokemonId     int16
 	QuestArRewardPokemonForm   int16
 
-	// Pokestop - incident (first active incident, flat fields)
-	IncidentDisplayType int8
-	IncidentStyle       int8
-	IncidentCharacter   int16
-	IncidentPokemonId   int16
-	IncidentPokemonForm int16
+	// Pokestop - incidents (all active incidents; slot1 only — slots 2/3 are unused).
+	// Mirrors the StationBattles slice pattern.
+	Incidents []FortLookupIncident
 
 	// Pokestop - contest
 	ContestPokemonId    int16
@@ -182,18 +179,10 @@ func fortRtreeUpdateStationOnGet(station *Station) {
 }
 
 func updatePokestopLookup(pokestop *Pokestop) {
-	// Preserve existing incident fields if present
-	var incidentDisplayType int8
-	var incidentStyle int8
-	var incidentCharacter int16
-	var incidentPokemonId int16
-	var incidentPokemonForm int16
+	// Preserve existing incidents slice if present
+	var incidents []FortLookupIncident
 	if existing, ok := fortLookupCache.Load(pokestop.Id); ok {
-		incidentDisplayType = existing.IncidentDisplayType
-		incidentStyle = existing.IncidentStyle
-		incidentCharacter = existing.IncidentCharacter
-		incidentPokemonId = existing.IncidentPokemonId
-		incidentPokemonForm = existing.IncidentPokemonForm
+		incidents = existing.Incidents
 	}
 
 	fortLookupCache.Store(pokestop.Id, FortLookup{
@@ -214,11 +203,7 @@ func updatePokestopLookup(pokestop *Pokestop) {
 		QuestArRewardItemId:        int16(pokestop.AlternativeQuestItemId.ValueOrZero()),
 		QuestArRewardPokemonId:     int16(pokestop.AlternativeQuestPokemonId.ValueOrZero()),
 		QuestArRewardPokemonForm:   int16(pokestop.AlternativeQuestPokemonFormId.ValueOrZero()),
-		IncidentDisplayType:        incidentDisplayType,
-		IncidentStyle:              incidentStyle,
-		IncidentCharacter:          incidentCharacter,
-		IncidentPokemonId:          incidentPokemonId,
-		IncidentPokemonForm:        incidentPokemonForm,
+		Incidents:                  incidents,
 		ContestPokemonId:           int16(pokestop.ShowcasePokemon.ValueOrZero()),
 		ContestPokemonForm:         int16(pokestop.ShowcasePokemonForm.ValueOrZero()),
 		ContestPokemonType:         int8(pokestop.ShowcasePokemonType.ValueOrZero()),
@@ -260,24 +245,42 @@ func updateStationLookupWithBattles(station *Station, stationBattles []StationBa
 	fortLookupCache.Store(station.Id, lookup)
 }
 
-// updatePokestopIncidentLookup updates the incident fields on a pokestop's
-// FortLookup entry. Atomic via Compute — see updatePokestopLookup for the
-// cross-lock-domain clobber this prevents.
+// updatePokestopIncidentLookup upserts the observed incident into a pokestop's FortLookup
+// incidents slice (keyed by DisplayType+Character, unique per active incident on a stop),
+// pruning any expired entries in the same pass.
 func updatePokestopIncidentLookup(pokestopId string, incident *Incident) {
-	fortLookupCache.Compute(pokestopId, func(existing FortLookup, loaded bool) (FortLookup, xsync.ComputeOp) {
-		if !loaded {
-			// Incidents load before their pokestop only during preload
-			// edge cases; the pokestop writer will carry no incident until
-			// the next incident save.
-			return existing, xsync.CancelOp
+	existing, ok := fortLookupCache.Load(pokestopId)
+	if !ok {
+		return
+	}
+	now := time.Now().Unix()
+	updated := FortLookupIncident{
+		DisplayType:     int8(incident.DisplayType),
+		Style:           int8(incident.Style),
+		Character:       incident.Character,
+		Confirmed:       incident.Confirmed,
+		Slot1PokemonId:  int16(incident.Slot1PokemonId.ValueOrZero()),
+		Slot1Form:       int16(incident.Slot1Form.ValueOrZero()),
+		ExpireTimestamp: incident.ExpirationTime,
+	}
+	out := existing.Incidents[:0:0] // fresh backing array; never mutate a shared slice in place
+	replaced := false
+	for _, inc := range existing.Incidents {
+		if inc.ExpireTimestamp <= now {
+			continue // prune expired
 		}
-		existing.IncidentDisplayType = int8(incident.DisplayType)
-		existing.IncidentStyle = int8(incident.Style)
-		existing.IncidentCharacter = incident.Character
-		existing.IncidentPokemonId = int16(incident.Slot1PokemonId.ValueOrZero())
-		existing.IncidentPokemonForm = int16(incident.Slot1Form.ValueOrZero())
-		return existing, xsync.UpdateOp
-	})
+		if inc.DisplayType == updated.DisplayType && inc.Character == updated.Character {
+			out = append(out, updated) // replace the same incident
+			replaced = true
+		} else {
+			out = append(out, inc)
+		}
+	}
+	if !replaced && updated.ExpireTimestamp > now {
+		out = append(out, updated)
+	}
+	existing.Incidents = out
+	fortLookupCache.Store(pokestopId, existing)
 }
 
 // getContestTotalEntries parses showcase rankings JSON to get total entries

--- a/decoder/fortRtree.go
+++ b/decoder/fortRtree.go
@@ -34,6 +34,7 @@ type FortLookup struct {
 
 	// Pokestop - quest rewards only (both AR and no-AR stored, filter matches either)
 	LureId                     int16
+	LureExpireTimestamp        int64 // used to check expiry at filter time
 	QuestNoArRewardType        int16
 	QuestNoArRewardAmount      int16
 	QuestNoArRewardItemId      int16
@@ -57,6 +58,7 @@ type FortLookup struct {
 	ContestPokemonForm  int16
 	ContestPokemonType  int8
 	ContestTotalEntries int16
+	ShowcaseExpiry      int64 // used to check expiry at filter time
 
 	// Station
 	BattleEndTimestamp int64 // used to check expiry at filter time
@@ -180,47 +182,48 @@ func fortRtreeUpdateStationOnGet(station *Station) {
 }
 
 func updatePokestopLookup(pokestop *Pokestop) {
-	// Atomic per-key read-modify-write via Compute: this writer (under the
-	// POKESTOP entity lock) and updatePokestopIncidentLookup (under the
-	// INCIDENT entity lock) both update the same key, each preserving the
-	// other's fields. A plain Load->Store pair from the two lock domains
-	// can interleave and clobber — losing a just-stored incident or
-	// reverting quest fields until the next save. Compute's callback runs
-	// under the map's bucket lock, so keep it to field copies only (the
-	// showcase JSON parse happens out here).
-	contestTotalEntries := getContestTotalEntries(pokestop.ShowcaseRankings)
-	fortLookupCache.Compute(pokestop.Id, func(existing FortLookup, loaded bool) (FortLookup, xsync.ComputeOp) {
-		nl := FortLookup{
-			FortType:                   POKESTOP,
-			Lat:                        pokestop.Lat,
-			Lon:                        pokestop.Lon,
-			PowerUpLevel:               int8(valueOrMinus1(pokestop.PowerUpLevel)),
-			IsArScanEligible:           pokestop.ArScanEligible.ValueOrZero() == 1,
-			LureId:                     pokestop.LureId,
-			QuestNoArRewardType:        int16(pokestop.QuestRewardType.ValueOrZero()),
-			QuestNoArRewardAmount:      int16(pokestop.QuestRewardAmount.ValueOrZero()),
-			QuestNoArRewardItemId:      int16(pokestop.QuestItemId.ValueOrZero()),
-			QuestNoArRewardPokemonId:   int16(pokestop.QuestPokemonId.ValueOrZero()),
-			QuestNoArRewardPokemonForm: int16(pokestop.QuestPokemonFormId.ValueOrZero()),
-			QuestArRewardType:          int16(pokestop.AlternativeQuestRewardType.ValueOrZero()),
-			QuestArRewardAmount:        int16(pokestop.AlternativeQuestRewardAmount.ValueOrZero()),
-			QuestArRewardItemId:        int16(pokestop.AlternativeQuestItemId.ValueOrZero()),
-			QuestArRewardPokemonId:     int16(pokestop.AlternativeQuestPokemonId.ValueOrZero()),
-			QuestArRewardPokemonForm:   int16(pokestop.AlternativeQuestPokemonFormId.ValueOrZero()),
-			ContestPokemonId:           int16(pokestop.ShowcasePokemon.ValueOrZero()),
-			ContestPokemonForm:         int16(pokestop.ShowcasePokemonForm.ValueOrZero()),
-			ContestPokemonType:         int8(pokestop.ShowcasePokemonType.ValueOrZero()),
-			ContestTotalEntries:        contestTotalEntries,
-		}
-		if loaded {
-			// Preserve the incident writer's fields
-			nl.IncidentDisplayType = existing.IncidentDisplayType
-			nl.IncidentStyle = existing.IncidentStyle
-			nl.IncidentCharacter = existing.IncidentCharacter
-			nl.IncidentPokemonId = existing.IncidentPokemonId
-			nl.IncidentPokemonForm = existing.IncidentPokemonForm
-		}
-		return nl, xsync.UpdateOp
+	// Preserve existing incident fields if present
+	var incidentDisplayType int8
+	var incidentStyle int8
+	var incidentCharacter int16
+	var incidentPokemonId int16
+	var incidentPokemonForm int16
+	if existing, ok := fortLookupCache.Load(pokestop.Id); ok {
+		incidentDisplayType = existing.IncidentDisplayType
+		incidentStyle = existing.IncidentStyle
+		incidentCharacter = existing.IncidentCharacter
+		incidentPokemonId = existing.IncidentPokemonId
+		incidentPokemonForm = existing.IncidentPokemonForm
+	}
+
+	fortLookupCache.Store(pokestop.Id, FortLookup{
+		FortType:                   POKESTOP,
+		Lat:                        pokestop.Lat,
+		Lon:                        pokestop.Lon,
+		PowerUpLevel:               int8(valueOrMinus1(pokestop.PowerUpLevel)),
+		IsArScanEligible:           pokestop.ArScanEligible.ValueOrZero() == 1,
+		LureId:                     pokestop.LureId,
+		LureExpireTimestamp:        pokestop.LureExpireTimestamp.ValueOrZero(),
+		QuestNoArRewardType:        int16(pokestop.QuestRewardType.ValueOrZero()),
+		QuestNoArRewardAmount:      int16(pokestop.QuestRewardAmount.ValueOrZero()),
+		QuestNoArRewardItemId:      int16(pokestop.QuestItemId.ValueOrZero()),
+		QuestNoArRewardPokemonId:   int16(pokestop.QuestPokemonId.ValueOrZero()),
+		QuestNoArRewardPokemonForm: int16(pokestop.QuestPokemonFormId.ValueOrZero()),
+		QuestArRewardType:          int16(pokestop.AlternativeQuestRewardType.ValueOrZero()),
+		QuestArRewardAmount:        int16(pokestop.AlternativeQuestRewardAmount.ValueOrZero()),
+		QuestArRewardItemId:        int16(pokestop.AlternativeQuestItemId.ValueOrZero()),
+		QuestArRewardPokemonId:     int16(pokestop.AlternativeQuestPokemonId.ValueOrZero()),
+		QuestArRewardPokemonForm:   int16(pokestop.AlternativeQuestPokemonFormId.ValueOrZero()),
+		IncidentDisplayType:        incidentDisplayType,
+		IncidentStyle:              incidentStyle,
+		IncidentCharacter:          incidentCharacter,
+		IncidentPokemonId:          incidentPokemonId,
+		IncidentPokemonForm:        incidentPokemonForm,
+		ContestPokemonId:           int16(pokestop.ShowcasePokemon.ValueOrZero()),
+		ContestPokemonForm:         int16(pokestop.ShowcasePokemonForm.ValueOrZero()),
+		ContestPokemonType:         int8(pokestop.ShowcasePokemonType.ValueOrZero()),
+		ContestTotalEntries:        getContestTotalEntries(pokestop.ShowcaseRankings),
+		ShowcaseExpiry:             pokestop.ShowcaseExpiry.ValueOrZero(),
 	})
 }
 

--- a/decoder/fortRtree_compute_test.go
+++ b/decoder/fortRtree_compute_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/guregu/null/v6"
+	"github.com/puzpuzpuz/xsync/v4"
 )
 
 // updatePokestopLookup (pokestop entity lock) and
@@ -15,6 +16,9 @@ import (
 // read-modify-write atomic per key: after any concurrent pair, BOTH
 // halves' latest writes must be present.
 func TestFortLookupConcurrentPokestopAndIncidentWriters(t *testing.T) {
+	fortLookupCache = xsync.NewMap[string, FortLookup]()
+	initQuestConditions() // updatePokestopLookup reconciles quest conditions
+
 	const id = "compute-race-stop"
 	stop := &Pokestop{PokestopData: PokestopData{
 		Id: id, Lat: 50, Lon: 4,
@@ -25,6 +29,7 @@ func TestFortLookupConcurrentPokestopAndIncidentWriters(t *testing.T) {
 		Style:          2,
 		Character:      44,
 		Slot1PokemonId: null.IntFrom(215),
+		ExpirationTime: 9_999_999_999, // far future so the upsert does not prune it
 	}}
 
 	for i := 0; i < 2000; i++ {
@@ -44,8 +49,15 @@ func TestFortLookupConcurrentPokestopAndIncidentWriters(t *testing.T) {
 		if got.QuestNoArRewardType != 7 {
 			t.Fatalf("iteration %d: quest fields clobbered by incident writer (QuestNoArRewardType=%d)", i, got.QuestNoArRewardType)
 		}
-		if got.IncidentCharacter != 44 || got.IncidentPokemonId != 215 {
-			t.Fatalf("iteration %d: incident write lost (character=%d pokemonId=%d)", i, got.IncidentCharacter, got.IncidentPokemonId)
+		found := false
+		for _, in := range got.Incidents {
+			if in.Character == 44 && in.Slot1PokemonId == 215 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("iteration %d: incident write lost (incidents=%+v)", i, got.Incidents)
 		}
 	}
 }

--- a/decoder/fort_expiry_test.go
+++ b/decoder/fort_expiry_test.go
@@ -1,0 +1,29 @@
+package decoder
+
+import "testing"
+
+func TestFortDnfMatch_LureExpiry(t *testing.T) {
+	now := int64(1_000_000)
+	active := &FortLookup{FortType: POKESTOP, LureId: 501, LureExpireTimestamp: now + 100}
+	expired := &FortLookup{FortType: POKESTOP, LureId: 501, LureExpireTimestamp: now - 100}
+	f := &ApiFortDnfFilter{LureId: []int16{501}}
+	if !isFortDnfMatch(POKESTOP, active, f, now) {
+		t.Fatal("active lure should match")
+	}
+	if isFortDnfMatch(POKESTOP, expired, f, now) {
+		t.Fatal("expired lure should NOT match")
+	}
+}
+
+func TestFortDnfMatch_ShowcaseExpiry(t *testing.T) {
+	now := int64(1_000_000)
+	active := &FortLookup{FortType: POKESTOP, ContestPokemonId: 1, ShowcaseExpiry: now + 100}
+	expired := &FortLookup{FortType: POKESTOP, ContestPokemonId: 1, ShowcaseExpiry: now - 100}
+	f := &ApiFortDnfFilter{ContestPokemon: []ApiDnfId{{Pokemon: 1}}}
+	if !isFortDnfMatch(POKESTOP, active, f, now) {
+		t.Fatal("active showcase should match")
+	}
+	if isFortDnfMatch(POKESTOP, expired, f, now) {
+		t.Fatal("expired showcase should NOT match")
+	}
+}

--- a/decoder/fort_incident_test.go
+++ b/decoder/fort_incident_test.go
@@ -1,0 +1,28 @@
+package decoder
+
+import "testing"
+
+func TestFortDnfMatch_IncidentSlice(t *testing.T) {
+	now := int64(1_000_000)
+	fl := &FortLookup{FortType: POKESTOP, Incidents: []FortLookupIncident{
+		{DisplayType: 2, Character: 20, ExpireTimestamp: now + 100},                                                   // leader
+		{DisplayType: 9, ExpireTimestamp: now + 100},                                                                  // showcase
+		{DisplayType: 1, Character: 5, Confirmed: true, Slot1PokemonId: 41, Slot1Form: 0, ExpireTimestamp: now + 100}, // grunt
+		{DisplayType: 3, Character: 30, ExpireTimestamp: now - 100},                                                   // EXPIRED giovanni
+	}}
+	// both coexisting characters match (no clobber)
+	if !isFortDnfMatch(POKESTOP, fl, &ApiFortDnfFilter{IncidentCharacter: []int16{20}}, now) {
+		t.Fatal("leader (20) should match")
+	}
+	if !isFortDnfMatch(POKESTOP, fl, &ApiFortDnfFilter{IncidentDisplayType: []int8{9}}, now) {
+		t.Fatal("showcase (dt9) should match")
+	}
+	// slot1 pokemon matches
+	if !isFortDnfMatch(POKESTOP, fl, &ApiFortDnfFilter{IncidentPokemon: []ApiDnfId{{Pokemon: 41}}}, now) {
+		t.Fatal("slot1 pokemon 41 should match")
+	}
+	// expired incident does not match
+	if isFortDnfMatch(POKESTOP, fl, &ApiFortDnfFilter{IncidentCharacter: []int16{30}}, now) {
+		t.Fatal("expired giovanni (30) should NOT match")
+	}
+}

--- a/decoder/quest_conditions.go
+++ b/decoder/quest_conditions.go
@@ -1,0 +1,188 @@
+package decoder
+
+import "github.com/puzpuzpuz/xsync/v4"
+
+// questConditionKey identifies one distinct quest option (reward + title +
+// target) for a single quest slot. AR and no-AR slots are distinguished by
+// WithAr so a fort that offers the same option under both slots contributes two
+// keys. Reward fields mirror those held in FortLookup; Title/Target are the
+// extra dimensions FortLookup deliberately omits and that this aggregate exists
+// to carry.
+type questConditionKey struct {
+	WithAr     bool
+	RewardType int16
+	ItemId     int16
+	Amount     int16
+	PokemonId  int16
+	FormId     int16
+	Title      string
+	Target     int32
+}
+
+// ApiQuestConditionResult is the endpoint-facing view of one quest option and
+// how many resident forts currently offer it. Consumed by the available
+// endpoint (Task 4).
+type ApiQuestConditionResult struct {
+	WithAr     bool   `json:"with_ar"`
+	RewardType int16  `json:"reward_type"`
+	ItemId     int16  `json:"item_id"`
+	Amount     int16  `json:"amount"`
+	PokemonId  int16  `json:"pokemon_id"`
+	FormId     int16  `json:"form_id"`
+	Title      string `json:"title"`
+	Target     int32  `json:"target"`
+	Count      int    `json:"count"`
+}
+
+// questConditionCount is the running aggregate: how many resident pokestops
+// currently offer each quest option. Maintained as forts enter/leave/change,
+// mirroring the pokemonFormCount pattern (see adjustPokemonFormCount). Entries
+// are deleted when their count reaches zero.
+var questConditionCount *xsync.Map[questConditionKey, int64]
+
+// questFortKeys records the exact quest-condition keys each resident pokestop
+// currently contributes to questConditionCount. FortLookup intentionally omits
+// quest title/target, so this side map is the only place a fort's
+// previously-counted keys can be recovered — it lets every change/eviction
+// decrement exactly the keys that were incremented, independent of the evicted
+// *Pokestop's (possibly since-changed) quest fields. Only forts that currently
+// carry a quest hold an entry, so its footprint tracks the number of active
+// quests, not the whole fort population.
+var questFortKeys *xsync.Map[string, []questConditionKey]
+
+func initQuestConditions() {
+	questConditionCount = xsync.NewMap[questConditionKey, int64]()
+	questFortKeys = xsync.NewMap[string, []questConditionKey]()
+}
+
+// adjustQuestConditions applies delta to the aggregate count of each key,
+// deleting an entry once its count reaches zero (mirrors adjustPokemonFormCount).
+func adjustQuestConditions(keys []questConditionKey, delta int64) {
+	for _, k := range keys {
+		questConditionCount.Compute(k, func(old int64, _ bool) (int64, xsync.ComputeOp) {
+			if old+delta <= 0 {
+				return 0, xsync.DeleteOp // delete entry when count reaches zero
+			}
+			return old + delta, xsync.UpdateOp
+		})
+	}
+}
+
+// questConditionKeysFromPokestop returns one key per present quest slot (no-AR
+// slot first, then AR). Empty when the pokestop carries no quest. The fixed slot
+// order makes the result directly comparable via questKeysEqual.
+func questConditionKeysFromPokestop(p *Pokestop) []questConditionKey {
+	var keys []questConditionKey
+	if p.QuestRewardType.Valid {
+		keys = append(keys, questConditionKey{
+			WithAr:     false,
+			RewardType: int16(p.QuestRewardType.ValueOrZero()),
+			ItemId:     int16(p.QuestItemId.ValueOrZero()),
+			Amount:     int16(p.QuestRewardAmount.ValueOrZero()),
+			PokemonId:  int16(p.QuestPokemonId.ValueOrZero()),
+			FormId:     int16(p.QuestPokemonFormId.ValueOrZero()),
+			Title:      p.QuestTitle.ValueOrZero(),
+			Target:     int32(p.QuestTarget.ValueOrZero()),
+		})
+	}
+	if p.AlternativeQuestRewardType.Valid {
+		keys = append(keys, questConditionKey{
+			WithAr:     true,
+			RewardType: int16(p.AlternativeQuestRewardType.ValueOrZero()),
+			ItemId:     int16(p.AlternativeQuestItemId.ValueOrZero()),
+			Amount:     int16(p.AlternativeQuestRewardAmount.ValueOrZero()),
+			PokemonId:  int16(p.AlternativeQuestPokemonId.ValueOrZero()),
+			FormId:     int16(p.AlternativeQuestPokemonFormId.ValueOrZero()),
+			Title:      p.AlternativeQuestTitle.ValueOrZero(),
+			Target:     int32(p.AlternativeQuestTarget.ValueOrZero()),
+		})
+	}
+	return keys
+}
+
+// questKeysEqual reports whether two key slices are identical in order and
+// content. questConditionKeysFromPokestop emits a stable slot order, so plain
+// element comparison is sufficient.
+func questKeysEqual(a, b []questConditionKey) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// reconcileFortQuestConditions makes questConditionCount reflect newKeys as the
+// current contribution of fortId, decrementing whatever this fort contributed
+// before. It is the single accounting primitive for a fort that still exists as
+// a pokestop, called from updatePokestopLookup (the sole writer of a pokestop's
+// FortLookup entry) so it fires uniformly on cache-miss load, save, quest change
+// and startup preload.
+//
+// Concurrency: the count adjustment happens INSIDE the questFortKeys.Compute
+// callback, which runs under the map's per-bucket lock. That makes the pair
+// (swap this fort's stored keys, apply the matching +new/−old to the aggregate)
+// a single atomic step, and it serializes every reconcile/removal for the same
+// fortId. Without this, a concurrent add and remove could interleave so the
+// add's increment lands after the remove has already deleted the tracker entry
+// and decremented — orphaning a +1 with no tracker backing (a permanent leak).
+// The nested lock order is always questFortKeys -> questConditionCount and never
+// the reverse (GetAvailableQuestConditions only reads questConditionCount), so
+// there is no deadlock. Callers of updatePokestopLookup hold the pokestop entity
+// lock, but this primitive is self-contained and correct without it.
+func reconcileFortQuestConditions(fortId string, newKeys []questConditionKey) {
+	questFortKeys.Compute(fortId, func(old []questConditionKey, loaded bool) ([]questConditionKey, xsync.ComputeOp) {
+		if questKeysEqual(old, newKeys) {
+			return old, xsync.CancelOp // unchanged (covers the common no-quest and re-save cases)
+		}
+		adjustQuestConditions(old, -1)
+		adjustQuestConditions(newKeys, +1)
+		if len(newKeys) == 0 {
+			return nil, xsync.DeleteOp // fort no longer offers any quest
+		}
+		return newKeys, xsync.UpdateOp
+	})
+}
+
+// removeFortQuestConditions drops a fort's entire quest contribution — used when
+// a pokestop leaves the in-memory index (eviction, deletion, conversion away
+// from pokestop). The decrement runs inside the Compute callback (same atomicity
+// and per-fort serialization as reconcileFortQuestConditions), so the amount
+// removed is exactly what this fort last contributed; a fort with no quest (or
+// already removed) is a cheap no-op.
+func removeFortQuestConditions(fortId string) {
+	questFortKeys.Compute(fortId, func(old []questConditionKey, loaded bool) ([]questConditionKey, xsync.ComputeOp) {
+		if !loaded {
+			return old, xsync.CancelOp
+		}
+		adjustQuestConditions(old, -1)
+		return nil, xsync.DeleteOp
+	})
+}
+
+// GetAvailableQuestConditions returns the distinct quest options currently
+// offered by resident forts, with per-option counts. Consumed by the available
+// endpoint (Task 4).
+func GetAvailableQuestConditions() []ApiQuestConditionResult {
+	var out []ApiQuestConditionResult
+	questConditionCount.Range(func(k questConditionKey, count int64) bool {
+		if count > 0 {
+			out = append(out, ApiQuestConditionResult{
+				WithAr:     k.WithAr,
+				RewardType: k.RewardType,
+				ItemId:     k.ItemId,
+				Amount:     k.Amount,
+				PokemonId:  k.PokemonId,
+				FormId:     k.FormId,
+				Title:      k.Title,
+				Target:     k.Target,
+				Count:      int(count),
+			})
+		}
+		return true
+	})
+	return out
+}

--- a/decoder/quest_conditions.go
+++ b/decoder/quest_conditions.go
@@ -73,9 +73,12 @@ func adjustQuestConditions(keys []questConditionKey, delta int64) {
 // order makes the result directly comparable via questKeysEqual.
 func questConditionKeysFromPokestop(p *Pokestop) []questConditionKey {
 	var keys []questConditionKey
+	// quest_* is the AR quest (Golbat decode writes quest_* when haveAr is
+	// set), which ReactMap labels with_ar=true; alternative_quest_* is the
+	// non-AR quest (with_ar=false).
 	if p.QuestRewardType.Valid {
 		keys = append(keys, questConditionKey{
-			WithAr:     false,
+			WithAr:     true,
 			RewardType: int16(p.QuestRewardType.ValueOrZero()),
 			ItemId:     int16(p.QuestItemId.ValueOrZero()),
 			Amount:     int16(p.QuestRewardAmount.ValueOrZero()),
@@ -87,7 +90,7 @@ func questConditionKeysFromPokestop(p *Pokestop) []questConditionKey {
 	}
 	if p.AlternativeQuestRewardType.Valid {
 		keys = append(keys, questConditionKey{
-			WithAr:     true,
+			WithAr:     false,
 			RewardType: int16(p.AlternativeQuestRewardType.ValueOrZero()),
 			ItemId:     int16(p.AlternativeQuestItemId.ValueOrZero()),
 			Amount:     int16(p.AlternativeQuestRewardAmount.ValueOrZero()),

--- a/decoder/quest_conditions_test.go
+++ b/decoder/quest_conditions_test.go
@@ -1,0 +1,186 @@
+package decoder
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/guregu/null/v6"
+)
+
+func TestQuestConditions_Aggregate(t *testing.T) {
+	initQuestConditions()
+	k := []questConditionKey{{RewardType: 2, ItemId: 1, Title: "catch_x", Target: 3}}
+	adjustQuestConditions(k, +1)
+	adjustQuestConditions(k, +1)
+	got := GetAvailableQuestConditions()
+	if len(got) != 1 || got[0].Count != 2 || got[0].Title != "catch_x" {
+		t.Fatalf("want 1 entry count=2, got %+v", got)
+	}
+	adjustQuestConditions(k, -2)
+	if len(GetAvailableQuestConditions()) != 0 {
+		t.Fatal("entry should be removed at count 0")
+	}
+}
+
+// newQuestStop builds a pokestop carrying a no-AR quest slot (the primary
+// Quest* fields) with the given title/target.
+func newQuestStop(id, title string, target int64) *Pokestop {
+	return &Pokestop{PokestopData: PokestopData{
+		Id:                id,
+		Lat:               1.0,
+		Lon:               2.0,
+		QuestRewardType:   null.IntFrom(2),
+		QuestItemId:       null.IntFrom(1),
+		QuestRewardAmount: null.IntFrom(5),
+		QuestTitle:        null.StringFrom(title),
+		QuestTarget:       null.IntFrom(target),
+	}}
+}
+
+// findCondition returns the result matching title+target, or false.
+func findCondition(results []ApiQuestConditionResult, title string, target int32) (ApiQuestConditionResult, bool) {
+	for _, r := range results {
+		if r.Title == title && r.Target == target {
+			return r, true
+		}
+	}
+	return ApiQuestConditionResult{}, false
+}
+
+// TestQuestConditions_Lifecycle exercises the full reconcile path through the
+// real hook sites: load(+1) -> quest change(reconcile) -> evict(-1) nets to
+// empty, and a two-fort aggregate collapses onto one entry with count 2.
+func TestQuestConditions_Lifecycle(t *testing.T) {
+	initQuestConditions()
+
+	stop := newQuestStop("quest-life-1", "catch_x", 3)
+
+	// Load / first lookup -> +1.
+	updatePokestopLookup(stop)
+	if got := GetAvailableQuestConditions(); len(got) != 1 || got[0].Count != 1 || got[0].Title != "catch_x" {
+		t.Fatalf("after load: want 1 entry count=1 title=catch_x, got %+v", got)
+	}
+
+	// Quest change on the same fort -> old key removed, new key added, still one entry.
+	stop.QuestTitle = null.StringFrom("catch_y")
+	stop.QuestTarget = null.IntFrom(7)
+	updatePokestopLookup(stop)
+	got := GetAvailableQuestConditions()
+	if len(got) != 1 {
+		t.Fatalf("after change: want exactly 1 entry, got %+v", got)
+	}
+	if r, ok := findCondition(got, "catch_y", 7); !ok || r.Count != 1 {
+		t.Fatalf("after change: want single catch_y/target=7 count=1, got %+v", got)
+	}
+	if _, ok := findCondition(got, "catch_x", 3); ok {
+		t.Fatalf("after change: stale catch_x/target=3 should be gone, got %+v", got)
+	}
+
+	// A second fort offering the identical (now catch_y) option -> count 2.
+	stop2 := newQuestStop("quest-life-2", "catch_y", 7)
+	updatePokestopLookup(stop2)
+	got = GetAvailableQuestConditions()
+	if r, ok := findCondition(got, "catch_y", 7); !ok || r.Count != 2 {
+		t.Fatalf("after second fort: want catch_y/target=7 count=2, got %+v", got)
+	}
+
+	// Evict fort 1 -> back to count 1.
+	deferFortEviction(POKESTOP, stop.Id, stop.Lat, stop.Lon)
+	got = GetAvailableQuestConditions()
+	if r, ok := findCondition(got, "catch_y", 7); !ok || r.Count != 1 {
+		t.Fatalf("after evict fort1: want catch_y/target=7 count=1, got %+v", got)
+	}
+
+	// Evict fort 2 -> empty, and its tracker entry gone.
+	deferFortEviction(POKESTOP, stop2.Id, stop2.Lat, stop2.Lon)
+	if got := GetAvailableQuestConditions(); len(got) != 0 {
+		t.Fatalf("after evict fort2: want 0 entries, got %+v", got)
+	}
+	if _, ok := questFortKeys.Load(stop2.Id); ok {
+		t.Fatalf("after evict fort2: tracker entry should be gone")
+	}
+}
+
+// TestQuestConditions_DeleteAndConversion covers the two non-eviction removal
+// paths: a deleted pokestop (via fortRtreeUpdatePokestopOnSave's Deleted branch)
+// and a pokestop that converts to a gym (its stale contribution must be dropped
+// when the old pokestop finally evicts).
+func TestQuestConditions_DeleteAndConversion(t *testing.T) {
+	initQuestConditions()
+
+	// Deletion path.
+	del := newQuestStop("quest-del-1", "spin_x", 4)
+	updatePokestopLookup(del)
+	if len(GetAvailableQuestConditions()) != 1 {
+		t.Fatalf("delete setup: want 1 entry")
+	}
+	del.Deleted = true
+	fortRtreeUpdatePokestopOnSave(del)
+	if got := GetAvailableQuestConditions(); len(got) != 0 {
+		t.Fatalf("after delete: want 0 entries, got %+v", got)
+	}
+
+	// Conversion path: fort is a pokestop with a quest, then its FortLookup
+	// entry is overwritten by a gym. The pokestop's contribution lingers until
+	// its own eviction fires (FortType mismatch), which must still drop it.
+	conv := newQuestStop("quest-conv-1", "battle_x", 2)
+	updatePokestopLookup(conv)
+	if len(GetAvailableQuestConditions()) != 1 {
+		t.Fatalf("conversion setup: want 1 entry")
+	}
+	gym := &Gym{GymData: GymData{Id: conv.Id, Lat: conv.Lat, Lon: conv.Lon}}
+	updateGymLookup(gym) // overwrites FortLookup[id] to GYM; count still stale here
+	// Stale pokestop eviction: FortLookup is now GYM (mismatch) but the quest
+	// contribution must still be removed.
+	deferFortEviction(POKESTOP, conv.Id, conv.Lat, conv.Lon)
+	if got := GetAvailableQuestConditions(); len(got) != 0 {
+		t.Fatalf("after conversion+evict: want 0 entries, got %+v", got)
+	}
+	if _, ok := questFortKeys.Load(conv.Id); ok {
+		t.Fatalf("after conversion+evict: tracker entry should be gone")
+	}
+}
+
+// TestQuestConditions_ConcurrentReconcile hammers a single fort with concurrent
+// reconciles (load/save) and evictions, then quiesces with a lone eviction. The
+// telescoping invariant must leave the aggregate empty with no leaked or
+// negative counts. Run under -race to validate map/thread safety.
+func TestQuestConditions_ConcurrentReconcile(t *testing.T) {
+	initQuestConditions()
+
+	const goroutines = 16
+	const iterations = 500
+	stop := newQuestStop("quest-concurrent-1", "concurrent_x", 9)
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				updatePokestopLookup(stop)
+				deferFortEviction(POKESTOP, stop.Id, stop.Lat, stop.Lon)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Quiesce: the last operation on the fort is an eviction, so it must net to
+	// empty regardless of the interleavings above.
+	deferFortEviction(POKESTOP, stop.Id, stop.Lat, stop.Lon)
+
+	if got := GetAvailableQuestConditions(); len(got) != 0 {
+		t.Fatalf("after concurrent storm + final evict: want 0 entries, got %+v", got)
+	}
+	if _, ok := questFortKeys.Load(stop.Id); ok {
+		t.Fatalf("after concurrent storm + final evict: tracker entry should be gone")
+	}
+
+	// Belt and suspenders: no key anywhere should hold a non-positive or leaked
+	// count (GetAvailableQuestConditions already filters <=0, so any surviving
+	// entry is a leak).
+	questConditionCount.Range(func(k questConditionKey, count int64) bool {
+		t.Fatalf("leaked count entry %+v = %d", k, count)
+		return false
+	})
+}

--- a/decoder/station_battle.go
+++ b/decoder/station_battle.go
@@ -44,6 +44,20 @@ type FortLookupStationBattle struct {
 	BattlePokemonForm  int16
 }
 
+// FortLookupIncident is one active incident on a pokestop (slot1 only — slots 2/3 are
+// unused). Mirrors FortLookupStationBattle; FortLookup.Incidents holds all active
+// incidents on a stop so concurrent incidents (e.g. an invasion + a showcase) don't
+// clobber one another.
+type FortLookupIncident struct {
+	DisplayType     int8
+	Style           int8
+	Character       int16
+	Confirmed       bool
+	Slot1PokemonId  int16
+	Slot1Form       int16
+	ExpireTimestamp int64 // used to skip expired incidents at filter time
+}
+
 type stationBattleWrite struct {
 	StationId string
 	Battles   []StationBattleData

--- a/docs/superpowers/plans/2026-07-14-pokestop-available-api-golbat.md
+++ b/docs/superpowers/plans/2026-07-14-pokestop-available-api-golbat.md
@@ -1,0 +1,760 @@
+# Golbat `GET /api/pokestop/available` — Implementation Plan (Golbat side)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an in-memory `GET /api/pokestop/available` endpoint returning the distinct quest rewards (+conditions), lures, showcases and invasions currently available, so ReactMap can drop its ~30-query 15-minute SQL block.
+
+**Architecture:** Serve from the lightweight, value-stored `fortLookupCache` (quests/lures/showcases) + the tiny `incidentCache` (invasions) + a new maintained conditions map (quest title/target options). Fold in the `FortLookup` fixes the endpoint needs — two expiry fields and an incidents slice — which also correct existing `isFortDnfMatch` bugs. No DB scan; `FortInMemory`-gated.
+
+**Tech Stack:** Go; `puzpuzpuz/xsync/v4` (`xsync.Map`, `Compute`); `maypok86/otter` caches (`Range`, `Get`, `OnEviction`); Huma v2 routes (`huma.Register`); `prometheus/client_golang`; `logrus`.
+
+## Global Constraints
+
+- Branch `feat/pokestop-available-api` off `perf/eviction-lock-contention`; rebase before merge and re-verify cache accessor names (that branch actively reworks eviction).
+- Touch caches only via `Get`/`Range`/`OnEviction` — never internal eviction machinery.
+- Endpoint auth: security scheme `securitySchemeName` (`golbatSecret`, header `X-Golbat-Secret`); gate on `config.Config.FortInMemory` → `huma.Error503ServiceUnavailable("fort_in_memory not enabled")`.
+- Incident model: **slot1 only** (slots 2/3 are dead per production data); `confirmed`+slot1 only occur on grunts (display_type 1).
+- Conditions map supplies *options only*; title/target *filtering* is applied in ReactMap — never add title/target to `FortLookup` or `isFortDnfMatch`.
+- Structured tuples on the wire; ReactMap builds filter keys and maps display_type labels (7→goldstop, 8→kecleon, 9→showcase).
+- Format with `gofmt`; keep functions in the file that owns the responsibility (see File Structure).
+- Design reference: `docs/superpowers/specs/2026-07-14-pokestop-available-api-design.md`.
+
+## File Structure
+
+- `decoder/fortRtree.go` (modify) — `FortLookup` struct (+2 expiry fields, +`Incidents` slice, −flat incident fields); `updatePokestopLookup`, `updatePokestopIncidentLookup`; conditions eviction hook in `initFortRtree`.
+- `decoder/api_fort.go` (modify) — `isFortDnfMatch` POKESTOP branch: lure/showcase expiry checks + incident-slice iteration.
+- `decoder/quest_conditions.go` (create) — the maintained conditions map: key type, `xsync.Map`, `adjustQuestConditionCount`, `questConditionKeysFromPokestop`, `reconcileQuestConditions`, init.
+- `decoder/pokestop_process.go` (modify) — snapshot old / reconcile new around quest apply.
+- `decoder/pokestop_state.go` / `decoder/fortRtree.go` (modify) — increment conditions on fort load/preload, decrement on eviction.
+- `decoder/api_pokestop_available.go` (create) — response structs + `GetAvailablePokestops()` (ranges the three sources) + timing/log.
+- `routes_huma.go` (modify) — register `GET /api/pokestop/available` (`FortInMemory`-gated).
+- `stats_collector/stats_collector.go`, `stats_collector/prometheus.go`, and the no-op collector (modify) — `ObserveApiScan`.
+- `decoder/*_test.go` (create/modify) — one test file per task.
+
+---
+
+### Task 1: `FortLookup` lure + showcase expiry (aggregate needs active-only; also fixes the scan)
+
+**Files:**
+- Modify: `decoder/fortRtree.go` — `FortLookup` struct; `updatePokestopLookup` (`:197-223`)
+- Modify: `decoder/api_fort.go` — `isFortDnfMatch` POKESTOP branch (`:139-181`)
+- Test: `decoder/fort_expiry_test.go` (create)
+
+**Interfaces:**
+- Produces: `FortLookup.LureExpireTimestamp int64`, `FortLookup.ShowcaseExpiry int64` (used by Task 4 and the scan).
+
+- [ ] **Step 1: Write the failing test** — an active lure matches, an expired lure does not; likewise showcase.
+
+```go
+package decoder
+
+import "testing"
+
+func TestFortDnfMatch_LureExpiry(t *testing.T) {
+	now := int64(1_000_000)
+	active := &FortLookup{FortType: POKESTOP, LureId: 501, LureExpireTimestamp: now + 100}
+	expired := &FortLookup{FortType: POKESTOP, LureId: 501, LureExpireTimestamp: now - 100}
+	f := &ApiFortDnfFilter{LureId: []int16{501}}
+	if !isFortDnfMatch(POKESTOP, active, f, now) {
+		t.Fatal("active lure should match")
+	}
+	if isFortDnfMatch(POKESTOP, expired, f, now) {
+		t.Fatal("expired lure should NOT match")
+	}
+}
+
+func TestFortDnfMatch_ShowcaseExpiry(t *testing.T) {
+	now := int64(1_000_000)
+	active := &FortLookup{FortType: POKESTOP, ContestPokemonId: 1, ShowcaseExpiry: now + 100}
+	expired := &FortLookup{FortType: POKESTOP, ContestPokemonId: 1, ShowcaseExpiry: now - 100}
+	f := &ApiFortDnfFilter{ContestPokemon: []ApiDnfId{{Id: 1, Form: 0}}}
+	if !isFortDnfMatch(POKESTOP, active, f, now) {
+		t.Fatal("active showcase should match")
+	}
+	if isFortDnfMatch(POKESTOP, expired, f, now) {
+		t.Fatal("expired showcase should NOT match")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./decoder/ -run 'TestFortDnfMatch_(Lure|Showcase)Expiry' -v`
+Expected: FAIL — `LureExpireTimestamp`/`ShowcaseExpiry` undefined.
+
+- [ ] **Step 3: Add the two fields to `FortLookup`** (in the `// Pokestop` region of the struct, `fortRtree.go`):
+
+```go
+	LureId              int16
+	LureExpireTimestamp int64 // used to check expiry at filter time
+	// ... existing quest reward fields ...
+	ContestPokemonId    int16
+	ContestPokemonForm  int16
+	ContestPokemonType  int8
+	ContestTotalEntries int16
+	ShowcaseExpiry      int64 // used to check expiry at filter time
+```
+
+- [ ] **Step 4: Populate them in `updatePokestopLookup`** — add to the `FortLookup{...}` literal (`fortRtree.go:197`):
+
+```go
+		LureId:              pokestop.LureId,
+		LureExpireTimestamp: pokestop.LureExpireTimestamp.ValueOrZero(),
+		// ...
+		ShowcaseExpiry:      pokestop.ShowcaseExpiry.ValueOrZero(),
+```
+
+- [ ] **Step 5: Add expiry gates in `isFortDnfMatch`** — the lure check (`api_fort.go:140`) becomes:
+
+```go
+		if filter.LureId != nil &&
+			(fortLookup.LureExpireTimestamp <= now || !slices.Contains(filter.LureId, fortLookup.LureId)) {
+			return false
+		}
+```
+
+and gate the three Contest checks (`api_fort.go:172-181`) on `fortLookup.ShowcaseExpiry > now`, e.g.:
+
+```go
+		if filter.ContestPokemon != nil &&
+			(fortLookup.ShowcaseExpiry <= now ||
+				!matchDnfIdPair(filter.ContestPokemon, fortLookup.ContestPokemonId, fortLookup.ContestPokemonForm)) {
+			return false
+		}
+```
+
+(apply the same `ShowcaseExpiry <= now ||` guard to the `ContestPokemonType` and `ContestTotalEntries` clauses).
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./decoder/ -run 'TestFortDnfMatch_(Lure|Showcase)Expiry' -v` → PASS
+Run: `go build ./...` → no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add decoder/fortRtree.go decoder/api_fort.go decoder/fort_expiry_test.go
+git commit -m "feat(fort): add lure/showcase expiry to FortLookup and enforce at scan filter"
+```
+
+---
+
+### Task 2: `FortLookup` incidents slice (fix multi-incident clobbering, expiry, slot1 matching)
+
+**Files:**
+- Modify: `decoder/fortRtree.go` — `FortLookup` (−5 flat incident fields, +`Incidents` slice); `updatePokestopLookup` (preserve slice); `updatePokestopIncidentLookup` (`:259-273`, upsert+prune)
+- Modify: `decoder/api_fort.go` — `isFortDnfMatch` incident block (`:183-195`)
+- Test: `decoder/fort_incident_test.go` (create)
+
+**Interfaces:**
+- Produces: `type FortLookupIncident struct { DisplayType int8; Style int8; Character int16; Confirmed bool; Slot1PokemonId int16; Slot1Form int16; ExpireTimestamp int64 }`; `FortLookup.Incidents []FortLookupIncident`. Consumed by **both** Task 4's aggregate (invasions, in the shared range) and `isFortDnfMatch` (scan). Load-bearing for Phase 1 — ensure preload populates slices (forts before incidents).
+
+- [ ] **Step 1: Write the failing test** — two incidents on one stop (leader + showcase) are both filterable; an expired incident is skipped; slot1 pokemon matches.
+
+```go
+package decoder
+
+import "testing"
+
+func TestFortDnfMatch_IncidentSlice(t *testing.T) {
+	now := int64(1_000_000)
+	fl := &FortLookup{FortType: POKESTOP, Incidents: []FortLookupIncident{
+		{DisplayType: 2, Character: 20, ExpireTimestamp: now + 100},               // leader
+		{DisplayType: 9, ExpireTimestamp: now + 100},                              // showcase
+		{DisplayType: 1, Character: 5, Confirmed: true, Slot1PokemonId: 41, Slot1Form: 0, ExpireTimestamp: now + 100}, // grunt
+		{DisplayType: 3, Character: 30, ExpireTimestamp: now - 100},               // EXPIRED giovanni
+	}}
+	// both coexisting characters match (no clobber)
+	if !isFortDnfMatch(POKESTOP, fl, &ApiFortDnfFilter{IncidentCharacter: []int16{20}}, now) {
+		t.Fatal("leader (20) should match")
+	}
+	if !isFortDnfMatch(POKESTOP, fl, &ApiFortDnfFilter{IncidentDisplayType: []int8{9}}, now) {
+		t.Fatal("showcase (dt9) should match")
+	}
+	// slot1 pokemon matches
+	if !isFortDnfMatch(POKESTOP, fl, &ApiFortDnfFilter{IncidentPokemon: []ApiDnfId{{Id: 41, Form: 0}}}, now) {
+		t.Fatal("slot1 pokemon 41 should match")
+	}
+	// expired incident does not match
+	if isFortDnfMatch(POKESTOP, fl, &ApiFortDnfFilter{IncidentCharacter: []int16{30}}, now) {
+		t.Fatal("expired giovanni (30) should NOT match")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./decoder/ -run TestFortDnfMatch_IncidentSlice -v`
+Expected: FAIL — `FortLookupIncident` / `Incidents` undefined.
+
+- [ ] **Step 3: Define the slice type and field; remove the flat incident fields** — in `fortRtree.go`, replace the `// Pokestop - incident (first active incident, flat fields)` block with:
+
+```go
+	// Pokestop - incidents (all active incidents; slot1 only — slots 2/3 are unused).
+	// Mirrors the StationBattles slice pattern.
+	Incidents []FortLookupIncident
+```
+
+and add, near `FortLookupStationBattle` (`decoder/station_battle.go`):
+
+```go
+type FortLookupIncident struct {
+	DisplayType     int8
+	Style           int8
+	Character       int16
+	Confirmed       bool
+	Slot1PokemonId  int16
+	Slot1Form       int16
+	ExpireTimestamp int64 // used to skip expired incidents at filter time
+}
+```
+
+- [ ] **Step 4: Preserve the slice in `updatePokestopLookup`** — replace the flat-field snapshot/restore (`fortRtree.go:183-195, 214-218`) with slice preservation:
+
+```go
+	var incidents []FortLookupIncident
+	if existing, ok := fortLookupCache.Load(pokestop.Id); ok {
+		incidents = existing.Incidents
+	}
+	// ... in the FortLookup{...} literal, replace the five Incident* fields with:
+		Incidents: incidents,
+```
+
+- [ ] **Step 5: Upsert + prune in `updatePokestopIncidentLookup`** — replace the body (`fortRtree.go:260-272`) with a merge keyed by display slot semantics (one entry per incident id is not available here, so key by `DisplayType`+`Character`, which is unique per active incident on a stop):
+
+```go
+func updatePokestopIncidentLookup(pokestopId string, incident *Incident) {
+	existing, ok := fortLookupCache.Load(pokestopId)
+	if !ok {
+		return
+	}
+	now := time.Now().Unix()
+	updated := FortLookupIncident{
+		DisplayType:     int8(incident.DisplayType),
+		Style:           int8(incident.Style),
+		Character:       incident.Character,
+		Confirmed:       incident.Confirmed,
+		Slot1PokemonId:  int16(incident.Slot1PokemonId.ValueOrZero()),
+		Slot1Form:       int16(incident.Slot1Form.ValueOrZero()),
+		ExpireTimestamp: incident.ExpirationTime,
+	}
+	out := existing.Incidents[:0:0] // fresh backing array; never mutate a shared slice in place
+	replaced := false
+	for _, inc := range existing.Incidents {
+		if inc.ExpireTimestamp <= now {
+			continue // prune expired
+		}
+		if inc.DisplayType == updated.DisplayType && inc.Character == updated.Character {
+			out = append(out, updated) // replace the same incident
+			replaced = true
+		} else {
+			out = append(out, inc)
+		}
+	}
+	if !replaced && updated.ExpireTimestamp > now {
+		out = append(out, updated)
+	}
+	existing.Incidents = out
+	fortLookupCache.Store(pokestopId, existing)
+}
+```
+
+- [ ] **Step 6: Iterate the slice in `isFortDnfMatch`** — replace the flat incident block (`api_fort.go:183-195`) with match-any-over-active, mirroring the `StationBattles` loop (`api_fort.go:210-227`):
+
+```go
+		if filter.IncidentDisplayType != nil || filter.IncidentStyle != nil ||
+			filter.IncidentCharacter != nil || filter.IncidentPokemon != nil {
+			matched := false
+			for _, inc := range fortLookup.Incidents {
+				if inc.ExpireTimestamp <= now {
+					continue
+				}
+				if filter.IncidentDisplayType != nil && !slices.Contains(filter.IncidentDisplayType, inc.DisplayType) {
+					continue
+				}
+				if filter.IncidentStyle != nil && !slices.Contains(filter.IncidentStyle, inc.Style) {
+					continue
+				}
+				if filter.IncidentCharacter != nil && !slices.Contains(filter.IncidentCharacter, inc.Character) {
+					continue
+				}
+				if filter.IncidentPokemon != nil && !matchDnfIdPair(filter.IncidentPokemon, inc.Slot1PokemonId, inc.Slot1Form) {
+					continue
+				}
+				matched = true
+				break
+			}
+			if !matched {
+				return false
+			}
+		}
+```
+
+- [ ] **Step 7: Run tests + build**
+
+Run: `go test ./decoder/ -run TestFortDnfMatch_IncidentSlice -v` → PASS
+Run: `go test ./decoder/ -run TestFortDnfMatch -v` (Task 1 still green) → PASS
+Run: `go build ./...` → confirm no remaining references to the removed `Incident*` flat fields (fix any).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add decoder/fortRtree.go decoder/station_battle.go decoder/api_fort.go decoder/fort_incident_test.go
+git commit -m "feat(fort): store pokestop incidents as a slice; fix multi-incident scan filtering"
+```
+
+---
+
+### Task 3: Maintained quest-conditions map (per-reward title/target options)
+
+**Files:**
+- Create: `decoder/quest_conditions.go`
+- Modify: `decoder/pokestop_process.go` — `UpdatePokestopWithQuest` (`:31`): snapshot old, reconcile new
+- Modify: `decoder/fortRtree.go` — `initFortRtree` (`:92`): decrement on pokestop eviction; increment on `fortRtreeUpdatePokestopOnGet`
+- Test: `decoder/quest_conditions_test.go` (create)
+
+**Interfaces:**
+- Produces: `type questConditionKey struct { WithAr bool; RewardType, ItemId, Amount, PokemonId, FormId int16; Title string; Target int32 }`; `func questConditionKeysFromPokestop(p *Pokestop) []questConditionKey`; `func adjustQuestConditions(keys []questConditionKey, delta int64)`; `func GetAvailableQuestConditions() []ApiQuestConditionResult` (consumed by Task 4).
+
+- [ ] **Step 1: Write the failing test** — counting: two forts with the same (reward,title,target) → one entry, count 2; decrement to zero removes it.
+
+```go
+package decoder
+
+import "testing"
+
+func TestQuestConditions_Aggregate(t *testing.T) {
+	initQuestConditions()
+	k := []questConditionKey{{RewardType: 2, ItemId: 1, Title: "catch_x", Target: 3}}
+	adjustQuestConditions(k, +1)
+	adjustQuestConditions(k, +1)
+	got := GetAvailableQuestConditions()
+	if len(got) != 1 || got[0].Count != 2 || got[0].Title != "catch_x" {
+		t.Fatalf("want 1 entry count=2, got %+v", got)
+	}
+	adjustQuestConditions(k, -2)
+	if len(GetAvailableQuestConditions()) != 0 {
+		t.Fatal("entry should be removed at count 0")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./decoder/ -run TestQuestConditions_Aggregate -v`
+Expected: FAIL — undefined symbols.
+
+- [ ] **Step 3: Implement `decoder/quest_conditions.go`** — mirror `pokemonFormCount`/`adjustPokemonFormCount`:
+
+```go
+package decoder
+
+import "github.com/puzpuzpuz/xsync/v4"
+
+type questConditionKey struct {
+	WithAr     bool
+	RewardType int16
+	ItemId     int16
+	Amount     int16
+	PokemonId  int16
+	FormId     int16
+	Title      string
+	Target     int32
+}
+
+type ApiQuestConditionResult struct {
+	WithAr     bool   `json:"with_ar"`
+	RewardType int16  `json:"reward_type"`
+	ItemId     int16  `json:"item_id"`
+	Amount     int16  `json:"amount"`
+	PokemonId  int16  `json:"pokemon_id"`
+	FormId     int16  `json:"form_id"`
+	Title      string `json:"title"`
+	Target     int32  `json:"target"`
+	Count      int    `json:"count"`
+}
+
+var questConditionCount *xsync.Map[questConditionKey, int64]
+
+func initQuestConditions() { questConditionCount = xsync.NewMap[questConditionKey, int64]() }
+
+func adjustQuestConditions(keys []questConditionKey, delta int64) {
+	for _, k := range keys {
+		questConditionCount.Compute(k, func(old int64, _ bool) (int64, xsync.ComputeOp) {
+			if old+delta <= 0 {
+				return 0, xsync.DeleteOp
+			}
+			return old + delta, xsync.UpdateOp
+		})
+	}
+}
+
+// questConditionKeysFromPokestop returns one key per present quest slot (AR + no-AR).
+func questConditionKeysFromPokestop(p *Pokestop) []questConditionKey {
+	var keys []questConditionKey
+	if p.QuestRewardType.Valid {
+		keys = append(keys, questConditionKey{
+			WithAr: false, RewardType: int16(p.QuestRewardType.ValueOrZero()),
+			ItemId: int16(p.QuestItemId.ValueOrZero()), Amount: int16(p.QuestRewardAmount.ValueOrZero()),
+			PokemonId: int16(p.QuestPokemonId.ValueOrZero()), FormId: int16(p.QuestPokemonFormId.ValueOrZero()),
+			Title: p.QuestTitle.ValueOrZero(), Target: int32(p.QuestTarget.ValueOrZero()),
+		})
+	}
+	if p.AlternativeQuestRewardType.Valid {
+		keys = append(keys, questConditionKey{
+			WithAr: true, RewardType: int16(p.AlternativeQuestRewardType.ValueOrZero()),
+			ItemId: int16(p.AlternativeQuestItemId.ValueOrZero()), Amount: int16(p.AlternativeQuestRewardAmount.ValueOrZero()),
+			PokemonId: int16(p.AlternativeQuestPokemonId.ValueOrZero()), FormId: int16(p.AlternativeQuestPokemonFormId.ValueOrZero()),
+			Title: p.AlternativeQuestTitle.ValueOrZero(), Target: int32(p.AlternativeQuestTarget.ValueOrZero()),
+		})
+	}
+	return keys
+}
+
+func GetAvailableQuestConditions() []ApiQuestConditionResult {
+	var out []ApiQuestConditionResult
+	questConditionCount.Range(func(k questConditionKey, count int64) bool {
+		if count > 0 {
+			out = append(out, ApiQuestConditionResult{
+				WithAr: k.WithAr, RewardType: k.RewardType, ItemId: k.ItemId, Amount: k.Amount,
+				PokemonId: k.PokemonId, FormId: k.FormId, Title: k.Title, Target: k.Target, Count: int(count),
+			})
+		}
+		return true
+	})
+	return out
+}
+```
+> Verify exact `Pokestop` field/getter names against `decoder/pokestop.go` (`QuestTitle`, `QuestTarget`, `AlternativeQuest*`) — adjust `.ValueOrZero()` vs `.String`/`.Int64` per their `null.*` types.
+
+- [ ] **Step 4: Run the aggregate test** → PASS. `go test ./decoder/ -run TestQuestConditions_Aggregate -v`
+
+- [ ] **Step 5: Wire init** — call `initQuestConditions()` from `initFortRtree()` (`fortRtree.go:80`, alongside the lookup-cache init).
+
+- [ ] **Step 6: Reconcile on quest change** — in `UpdatePokestopWithQuest` (`pokestop_process.go:31`), snapshot before the quest proto is applied and reconcile after save:
+
+```go
+	old := questConditionKeysFromPokestop(pokestop) // BEFORE updatePokestopFromQuestProto(...)
+	// ... existing decode + savePokestopRecord(...) ...
+	if config.Config.FortInMemory {
+		adjustQuestConditions(old, -1)
+		adjustQuestConditions(questConditionKeysFromPokestop(pokestop), +1)
+	}
+```
+> If the fort was not previously resident (cache-miss load path also increments in Step 7), the `old` snapshot reads empty/zero and nets correctly.
+
+- [ ] **Step 7: Increment on load, decrement on eviction** — in `fortRtreeUpdatePokestopOnGet` (`fortRtree.go:156`), after `updatePokestopLookup`, add `adjustQuestConditions(questConditionKeysFromPokestop(pokestop), +1)`; and in `initFortRtree` (`fortRtree.go:93`) extend the pokestop `OnEviction` callback:
+
+```go
+		pokestopCache.OnEviction(func(_ string, p *Pokestop, _ ottercache.EvictionReason) {
+			adjustQuestConditions(questConditionKeysFromPokestop(p), -1)
+			deferFortEviction(POKESTOP, p.Id, p.Lat, p.Lon)
+		})
+```
+> Preload: add the same `+1` where preload calls `updatePokestopLookup` (`decoder/preload.go`), so startup population is counted once.
+
+- [ ] **Step 8: Write + run a lifecycle test** — load(+1) → quest change(reconcile) → evict(−1) nets to empty. (Seed via the same helpers; assert `GetAvailableQuestConditions()` length transitions.) Run `go test ./decoder/ -run TestQuestConditions -v` → PASS; `go build ./...`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add decoder/quest_conditions.go decoder/pokestop_process.go decoder/fortRtree.go decoder/preload.go decoder/quest_conditions_test.go
+git commit -m "feat(quest): maintain in-memory quest-condition (title/target) aggregate"
+```
+
+**RISK NOTE for the implementer:** the increment/decrement must net to exactly one per resident fort-with-quest. The eviction callback races re-caches (see `handlePokemonEviction`'s `Has`+lock guard, `pokemonRtree.go:168`). Verify with a concurrency test (load+evict+re-save interleavings) and confirm counts never go negative / never leak. **Drift is caught continuously by `verifyQuestAggregate` (Task 4)** — a direct FortLookup reward tally cross-checked against this map on every endpoint call — so a reconciliation bug surfaces as a logged/metriced desync, not silent wrong data. If that warning fires persistently in practice, switch to the more robust per-fort current-key tracker (`map[fortId][]questConditionKey`, updated in one place) — accept its memory rather than risk drift.
+
+---
+
+### Task 4: `GetAvailablePokestops()` aggregate + endpoint
+
+**Files:**
+- Create: `decoder/api_pokestop_available.go`
+- Modify: `routes_huma.go` — new `huma.Register` (in `registerFortScanRoutes` or a new `registerPokestopReadRoutes`)
+- Test: `decoder/api_pokestop_available_test.go` (create)
+
+**Interfaces:**
+- Consumes: `FortLookup` incl. the `Incidents` slice (Task 1/2), `GetAvailableQuestConditions()` (Task 3). **Not** `incidentCache` — invasions come from the fort lookup slice in the same range.
+- Produces: `func GetAvailablePokestops(now int64) *ApiAvailablePokestops` and the wire structs below.
+
+- [ ] **Step 1: Write the failing test** — seed `fortLookupCache` + `incidentCache`, assert distinct tuples, expiry exclusion, counts.
+
+```go
+package decoder
+
+import "testing"
+
+func TestGetAvailablePokestops(t *testing.T) {
+	initFortRtree()
+	initQuestConditions()
+	now := int64(1_000_000)
+	// quest reward + condition via the maintained map (the sole quest source)
+	adjustQuestConditions([]questConditionKey{{RewardType: 2, ItemId: 1, Title: "catch_x", Target: 3}}, +1)
+	// one fort: active lure, EXPIRED showcase (excluded), active grunt incident — all read in one range
+	fortLookupCache.Store("s1", FortLookup{
+		FortType: POKESTOP, LureId: 501, LureExpireTimestamp: now + 100,
+		ContestPokemonId: 1, ShowcaseExpiry: now - 1, // expired -> excluded
+		Incidents: []FortLookupIncident{
+			{DisplayType: 1, Character: 5, Confirmed: true, Slot1PokemonId: 41, ExpireTimestamp: now + 100},
+		},
+	})
+	res := GetAvailablePokestops(now)
+	if len(res.Lures) != 1 || res.Lures[0].LureId != 501 { t.Fatalf("lure: %+v", res.Lures) }
+	if len(res.Showcases) != 0 { t.Fatalf("expired showcase should be excluded: %+v", res.Showcases) }
+	if len(res.Quests) != 1 || res.Quests[0].RewardType != 2 { t.Fatalf("quest: %+v", res.Quests) }
+	if len(res.Invasions) != 1 || res.Invasions[0].Character != 5 { t.Fatalf("invasion: %+v", res.Invasions) }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./decoder/ -run TestGetAvailablePokestops -v` — FAIL (undefined).
+
+- [ ] **Step 3: Implement response structs + aggregate** in `decoder/api_pokestop_available.go`:
+
+```go
+package decoder
+
+import "time"
+
+type ApiPokestopQuestAvailable struct {
+	WithAr     bool   `json:"with_ar"`
+	RewardType int16  `json:"reward_type"`
+	ItemId     int16  `json:"item_id"`
+	Amount     int16  `json:"amount"`
+	PokemonId  int16  `json:"pokemon_id"`
+	FormId     int16  `json:"form_id"`
+	Title      string `json:"title"`
+	Target     int32  `json:"target"`
+	Count      int    `json:"count"`
+}
+type ApiPokestopInvasionAvailable struct {
+	Character      int16 `json:"character"`
+	DisplayType    int16 `json:"display_type"`
+	Confirmed      bool  `json:"confirmed"`
+	Slot1PokemonId int16 `json:"slot1_pokemon_id"`
+	Slot1Form      int16 `json:"slot1_form"`
+	Count          int   `json:"count"`
+}
+type ApiPokestopLureAvailable struct {
+	LureId int16 `json:"lure_id"`
+	Count  int   `json:"count"`
+}
+type ApiPokestopShowcaseAvailable struct {
+	PokemonId int16 `json:"pokemon_id"`
+	Form      int16 `json:"form"`
+	TypeId    int8  `json:"type_id"`
+	Count     int   `json:"count"`
+}
+type ApiAvailablePokestops struct {
+	Quests    []ApiPokestopQuestAvailable    `json:"quests"`
+	Invasions []ApiPokestopInvasionAvailable `json:"invasions"`
+	Lures     []ApiPokestopLureAvailable     `json:"lures"`
+	Showcases []ApiPokestopShowcaseAvailable `json:"showcases"`
+}
+
+func GetAvailablePokestops(now int64) *ApiAvailablePokestops {
+	start := time.Now()
+	res := &ApiAvailablePokestops{}
+	forts, incidents := 0, 0
+	lures := map[int16]int{}
+	shows := map[ApiPokestopShowcaseAvailable]int{} // key without Count
+	inv := map[ApiPokestopInvasionAvailable]int{}   // key without Count
+
+	// Quests (rewards + title/target) come solely from the maintained conditions map — distinct+counted.
+	for _, c := range GetAvailableQuestConditions() {
+		res.Quests = append(res.Quests, ApiPokestopQuestAvailable{
+			WithAr: c.WithAr, RewardType: c.RewardType, ItemId: c.ItemId, Amount: c.Amount,
+			PokemonId: c.PokemonId, FormId: c.FormId, Title: c.Title, Target: c.Target, Count: c.Count,
+		})
+	}
+
+	// ONE range: lures + showcases + invasions (response) + a quest-reward tally (verification only).
+	rewards := map[questRewardKey]int{} // direct FortLookup reward count — cross-checks the maintained map
+	fortLookupCache.Range(func(_ string, fl FortLookup) bool {
+		if fl.FortType != POKESTOP {
+			return true
+		}
+		forts++
+		if fl.LureId != 0 && fl.LureExpireTimestamp > now {
+			lures[fl.LureId]++
+		}
+		if fl.ContestPokemonId != 0 && fl.ShowcaseExpiry > now {
+			shows[ApiPokestopShowcaseAvailable{PokemonId: fl.ContestPokemonId, Form: fl.ContestPokemonForm, TypeId: fl.ContestPokemonType}]++
+		}
+		for _, in := range fl.Incidents {
+			if in.ExpireTimestamp <= now {
+				continue
+			}
+			incidents++
+			inv[ApiPokestopInvasionAvailable{
+				Character: in.Character, DisplayType: int16(in.DisplayType), Confirmed: in.Confirmed,
+				Slot1PokemonId: in.Slot1PokemonId, Slot1Form: in.Slot1Form,
+			}]++
+		}
+		if fl.QuestNoArRewardType != 0 {
+			rewards[questRewardKey{false, fl.QuestNoArRewardType, fl.QuestNoArRewardItemId, fl.QuestNoArRewardAmount, fl.QuestNoArRewardPokemonId, fl.QuestNoArRewardPokemonForm}]++
+		}
+		if fl.QuestArRewardType != 0 {
+			rewards[questRewardKey{true, fl.QuestArRewardType, fl.QuestArRewardItemId, fl.QuestArRewardAmount, fl.QuestArRewardPokemonId, fl.QuestArRewardPokemonForm}]++
+		}
+		return true
+	})
+
+	for id, n := range lures {
+		res.Lures = append(res.Lures, ApiPokestopLureAvailable{LureId: id, Count: n})
+	}
+	for k, n := range shows {
+		k.Count = n
+		res.Showcases = append(res.Showcases, k)
+	}
+	for k, n := range inv {
+		k.Count = n
+		res.Invasions = append(res.Invasions, k)
+	}
+
+	verifyQuestAggregate(rewards) // alert if the maintained map drifted from the direct FortLookup tally
+	logAvailablePokestops(time.Since(start), forts, incidents, res)
+	return res
+}
+
+// questRewardKey is the reward signature shared by the maintained conditions map (minus title/target)
+// and the FortLookup reward tally used to detect reconciliation drift.
+type questRewardKey struct {
+	WithAr                                              bool
+	RewardType, ItemId, Amount, PokemonId, FormId int16
+}
+
+// verifyQuestAggregate cross-checks the maintained conditions map against a direct FortLookup tally.
+// Invariant: for each reward signature, sum(map counts over title/target) == resident forts carrying
+// it. A persistent mismatch means the Task-3 reconciliation drifted. (A single-cycle mismatch under
+// concurrent updates is possible since Range is a weakly-consistent snapshot — alert on persistence,
+// not one occurrence.)
+func verifyQuestAggregate(fortRewards map[questRewardKey]int) {
+	mapRewards := map[questRewardKey]int{}
+	for _, c := range GetAvailableQuestConditions() {
+		mapRewards[questRewardKey{c.WithAr, c.RewardType, c.ItemId, c.Amount, c.PokemonId, c.FormId}] += c.Count
+	}
+	desync := 0
+	for k, fortN := range fortRewards {
+		if mapRewards[k] != fortN {
+			desync++
+			log.Debugf("quest aggregate desync %+v: fortLookup=%d map=%d", k, fortN, mapRewards[k])
+		}
+	}
+	for k := range mapRewards {
+		if _, ok := fortRewards[k]; !ok {
+			desync++
+			log.Debugf("quest aggregate desync %+v: fortLookup=0 map=%d", k, mapRewards[k])
+		}
+	}
+	if desync > 0 {
+		log.Warnf("quest aggregate desync: %d reward signatures differ (FortLookup tally vs maintained map)", desync)
+		if statsCollector != nil {
+			statsCollector.ObserveApiScan("quest-aggregate-desync-count", float64(desync)) // or a dedicated counter (Task 5)
+		}
+	}
+}
+```
+> Confirm `fortLookupCache.Range` and `incidentCache.Range` callback signatures against `ottercache` / `xsync` on this branch; `fortLookupCache` value is `FortLookup` (value), `incidentCache` value is `*Incident`.
+
+- [ ] **Step 4: Run aggregate test** → PASS (`logAvailablePokestops` may be a temporary no-op until Task 5).
+
+- [ ] **Step 5: Register the route** in `routes_huma.go` — mirror `available-pokemon` (`:108`) with the `FortInMemory` gate from `registerFortScanRoutes` (`:172`):
+
+```go
+type pokestopAvailableOutput struct{ Body *decoder.ApiAvailablePokestops }
+
+// inside registerFortScanRoutes (or a new registerPokestopReadRoutes wired in main.go):
+op := huma.Operation{
+	OperationID:   "available-pokestops",
+	Method:        http.MethodGet,
+	Path:          "/api/pokestop/available",
+	Summary:       "List currently available pokestop rewards/invasions/lures/showcases",
+	Tags:          []string{"Pokestop"},
+	Security:      []map[string][]string{{securitySchemeName: {}}},
+	DefaultStatus: http.StatusOK,
+}
+huma.Register(api, op, func(ctx context.Context, _ *struct{}) (*pokestopAvailableOutput, error) {
+	if !config.Config.FortInMemory {
+		return nil, huma.Error503ServiceUnavailable("fort_in_memory not enabled")
+	}
+	return &pokestopAvailableOutput{Body: decoder.GetAvailablePokestops(time.Now().Unix())}, nil
+})
+```
+
+- [ ] **Step 6: Build + manual smoke** — `go build ./...`; run Golbat with `FortInMemory` on, then `curl -sH "X-Golbat-Secret: $SECRET" localhost:<port>/api/pokestop/available | jq '.quests|length, .invasions|length'`. Confirm `503` when `FortInMemory` off.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add decoder/api_pokestop_available.go routes_huma.go decoder/api_pokestop_available_test.go
+git commit -m "feat(api): add GET /api/pokestop/available (in-memory aggregate)"
+```
+
+---
+
+### Task 5: Instrumentation (build-time histogram + log)
+
+**Files:**
+- Modify: `stats_collector/stats_collector.go` (interface), `stats_collector/prometheus.go` (impl + histogram), and the no-op collector impl (search `func .*ObserveDbQuery` to find it)
+- Modify: `decoder/api_pokestop_available.go` — `logAvailablePokestops`
+- Test: manual/observability
+
+**Interfaces:**
+- Produces: `StatsCollector.ObserveApiScan(operation string, seconds float64)`.
+
+- [ ] **Step 1: Add to the interface** (`stats_collector/stats_collector.go`, next to `ObserveDbQuery` `:61`):
+
+```go
+	ObserveApiScan(operation string, seconds float64)
+```
+
+- [ ] **Step 2: Add the histogram + method** in `stats_collector/prometheus.go` — mirror `dbQueryDuration` (`:362`) and its `Observe` (`:765`) and `MustRegister` (`:810`):
+
+```go
+	apiScanDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{Namespace: namespace, Name: "api_scan_duration", Help: "In-memory API scan build time by operation"},
+		[]string{"operation"},
+	)
+// ...
+func (col *promCollector) ObserveApiScan(operation string, seconds float64) {
+	apiScanDuration.WithLabelValues(operation).Observe(seconds)
+}
+// ... add apiScanDuration to the prometheus.MustRegister(...) list at :810
+```
+Add a no-op `ObserveApiScan` to the other `StatsCollector` implementation(s) so the build stays green.
+
+- [ ] **Step 3: Implement `logAvailablePokestops`** in `decoder/api_pokestop_available.go`:
+
+```go
+func logAvailablePokestops(dur time.Duration, forts, incidents int, res *ApiAvailablePokestops) {
+	if statsCollector != nil {
+		statsCollector.ObserveApiScan("available-pokestops", dur.Seconds())
+	}
+	log.Infof("available-pokestops built in %s: scanned %d forts / %d incidents -> %d quests, %d invasions, %d lures, %d showcases",
+		dur, forts, incidents, len(res.Quests), len(res.Invasions), len(res.Lures), len(res.Showcases))
+}
+```
+> Use the same `statsCollector` package-level the decoder already uses (see `db/timing.go` / `decoder` usages of `statsCollector`); add the `log "github.com/sirupsen/logrus"` import.
+
+- [ ] **Step 4: Build + verify** — `go build ./...`; hit the endpoint; confirm the log line and that `api_scan_duration` appears on `/metrics`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add stats_collector/ decoder/api_pokestop_available.go
+git commit -m "feat(metrics): instrument available-pokestops build time"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** endpoint (Task 4) · in-memory sources fortLookup/incidentCache (Task 4) · lure/showcase expiry (Task 1) · incident slice + scan fix D7 (Task 2) · conditions map D8 (Task 3) · structured tuples D3 (Task 4) · FortInMemory gate D2 (Task 4) · instrumentation D5 (Task 5) · slot1-only D9 (Task 2). ReactMap consumer D6 → separate plan.
+- **Types:** `FortLookupIncident`/`Incidents` (Task 2) consumed only by the scan; the aggregate reads `incidentCache` (Task 4) — consistent. `questConditionKey`/`GetAvailableQuestConditions` (Task 3) consumed by Task 4. `ObserveApiScan` (Task 5) consumed by Task 4's `logAvailablePokestops`.
+- **Known verification points (flagged inline):** exact `null.*` getter names on `Pokestop`/`Incident`; `ottercache.Range`/`Set` signatures; the no-op `StatsCollector` impl location; Task 3's count-lifecycle race (concurrency test required).
+
+## Follow-up
+
+ReactMap consumer is a **separate plan** (`docs/superpowers/plans/…-pokestop-available-reactmap.md`): add `mem`/HTTP path to `Pokestop.getAvailable` mirroring `Pokemon.getAvailable`, map tuples → `{available, conditions}`, SQL fallback on no-`mem`/503, apply title/target sub-filter locally. Phase 2 (map-data via Golbat) is out of scope here.

--- a/docs/superpowers/specs/2026-07-14-pokestop-available-api-design.md
+++ b/docs/superpowers/specs/2026-07-14-pokestop-available-api-design.md
@@ -1,0 +1,203 @@
+# Golbat `GET /api/pokestop/available` — Design Spec
+
+- **Date:** 2026-07-14
+- **Status:** Approved design → planning
+- **Golbat branch:** `feat/pokestop-available-api` (worktree `~/GolandProjects/Golbat-wt/pokestop-available-api`), off `perf/eviction-lock-contention`
+- **ReactMap branch:** to be cut off `develop`
+- **Author:** James Berry (with Claude)
+
+## 1. Problem
+
+ReactMap builds its pokestop filter options (quest rewards + conditions, invasions, lures,
+showcases) via `Pokestop.getAvailable()` (`server/src/models/Pokestop.js:1253`) — **~30 concurrent
+`DISTINCT`/`GROUP BY` scans** over the whole `pokestop`/`incident` tables, **no geo filter, always
+raw SQL**, re-run every **15 min** (`EventManager.js:227`, `api.queryUpdateHours.quests`=0.25). It's
+the most expensive periodic query ReactMap issues. Golbat already solves the Pokémon analog
+(`GET /api/pokemon/available`, in-memory, no DB scan). This adds the pokestop equivalent.
+
+## 2. Goals / Non-Goals
+
+**Goals**
+- `GET /api/pokestop/available` returning quest rewards + conditions, invasions, lures, showcases —
+  computed **in-memory, no DB scan**, whole-instance, `FortInMemory`-gated.
+- Serve from the **lightweight `fortLookupCache`** (value-stored `FortLookup`) + tiny `incidentCache`
+  + a maintained quest-conditions map — not the heavy `pokestopCache` full records.
+- Fix `FortLookup`'s incident representation (currently a single flat, last-write-wins slot) so the
+  **scan filter `isFortDnfMatch` is correct** for multi-incident stops — folded in now.
+- Structured tuples; ReactMap builds its own filter keys. Instrumented build time.
+- ReactMap consumes it via the existing `mem`/`evalQuery` path (SQL fallback). **Hybrid**: only the
+  available-list moves to the API in Phase 1; map-data stays on DB.
+
+**Non-Goals**
+- Not the pokestop map-data migration (Phase 2 — needs incidents in the scan response + per-fort
+  quest title/target for `adv` filtering).
+- No per-area/geofenced variant.
+- Not a full maintained aggregate for rewards/lures/showcases (the "fully aggregated total" — a
+  later efficiency project; only quest *conditions* get a maintained map now).
+
+## 3. Decisions (locked)
+
+| # | Decision |
+|---|---|
+| D1 | Scope: full replacement of the available-list query (quests+conditions, invasions, lures, showcases) |
+| D2 | Serve from `fortLookupCache` (lightweight, value-stored) + `incidentCache` + maintained conditions map. No DB scan. `FortInMemory`-gated (503 otherwise) |
+| D3 | Wire format: structured tuples; ReactMap builds keys and maps display_type labels (e.g. 7→goldstop) |
+| D4 | Geo scope: whole-instance |
+| D5 | Instrument build/response time |
+| D6 | ReactMap: hybrid (available via API, map-data via DB/SQL fallback) |
+| D7 | **Incident slice + `isFortDnfMatch` fix folded into Phase 1** (not deferred) |
+| D8 | **Conditions via a maintained titles map** (part of the aggregate totals) — the available API returns per-reward title/target *options*, reconciled from the `Pokestop` record at quest-save/eviction (no strings in `FortLookup`). The actual title/target *filtering* is applied **locally in ReactMap**, so the scan filter never needs per-fort title/target |
+| D9 | Incident model: **slot1 only** (slots 2/3 validated dead); per-incident `confirmed`+slot1 only on grunts (dt1) |
+
+## 4. Validation data (production snapshot, `incident` table, drove D7–D9)
+
+- **Slots 2/3 never populated:** of 1838 active incidents, slot1=110, slot2=0, slot3=0 → carry slot1 only.
+- **Field richness by display_type:** dt1 grunt (149; 110 confirmed+slot1), dt2 leader (426; char only), dt3 giovanni (388; char only), dt8 kecleon (14; display+expiry), dt9 showcase (861; display+expiry). Non-rocket = display+expiry only. **dt7 = goldstop** (`INVASION_GENERIC`; none active in snapshot; behaves like 8/9).
+- **Multi-incident stops ~11%:** 1464 stops ×1 incident, 175 ×2, 8 ×3.
+- **Coexistence incl. two rockets:** giovanni+showcase 85, leader+showcase 71, **leader+giovanni 40** (two rocket incidents on one stop), plus rarer. → a flat/two-channel `FortLookup` incident is provably wrong; the **slice** is required for correct per-stop filtering.
+
+Display-type taxonomy the design relies on:
+
+| dt | label | aggregate keys | per-incident fields |
+|----|-------|----------------|---------------------|
+| 1 | grunt | `i` + `a` | character, confirmed, slot1 |
+| 2 / 3 | leader / giovanni | `i` | character |
+| 7 | goldstop | `b7` | display+expiry |
+| 8 | kecleon | `b8` | display+expiry |
+| 9 | showcase | `b9` (+`f`/`h` from pokestop fields) | display+expiry |
+
+## 5. ReactMap output contract to reproduce
+
+`Pokestop.getAvailable()` → `{ available: string[], conditions }` consumed by
+`server/src/filters/builder/pokestop.js`:
+
+| Category | Key | Source |
+|---|---|---|
+| Items(2)/Stardust(3)/XP(1)/Mega(12)/Candy(4)/XL(9)/Pokémon(7)/other | `q`/`d`/`p`/`m<id>-<amt>`/`c`/`x`/`<id>`(`-<form>`)/`u<type>` | quest reward fields |
+| Invasion grunt | `i<character>` | incident character |
+| Confirmed rocket mon | `a<pokemonId>-<form>` | incident slot1 (grunts, confirmed) |
+| Event/display | `b<displayType>` | incident display_type (goldstop 7, kecleon 8, showcase 9) |
+| Lures | `l<lureId>` | active lure |
+| Showcases | `f<pokemonId>-<form>`, `h<typeId>` | showcase pokemon/type (active) |
+
+`conditions` = `{ [rewardKey]: { "<title>-<target>": {title, target} } }` — the per-reward
+title/target *options*, supplied by Golbat's maintained conditions map (§6.2) as part of the
+aggregate response. The actual title/target *filtering* (matching a stop to a selected condition) is
+applied **locally in ReactMap** (`QuestConditions.jsx` / `Pokestop.js:1110`), so Golbat's scan filter
+never needs per-fort title/target. ReactMap keeps owning special cases (GO-Fest Mewtwo fallback,
+temp-evo type 20, Ditto normalization).
+
+## 6. Golbat design
+
+### 6.1 `FortLookup` changes (`decoder/fortRtree.go`)
+`FortLookup` is `xsync.Map[string, FortLookup]` **stored by value** (compact, cache-friendly) — the
+purpose-built query index the scan filter already uses. Changes:
+
+1. **`LureExpireTimestamp int64`** + **`ShowcaseExpiry int64`** — populated in `updatePokestopLookup`
+   from the `Pokestop` record; used to filter *active* lures/showcases in both the aggregate and the
+   scan (follows the existing `RaidEndTimestamp`/`BattleEndTimestamp` precedent; also fixes the scan
+   returning expired lures/showcases today, `api_fort.go:140,172`).
+2. **Incidents as a slice** — replace the flat incident fields with
+   `Incidents []FortLookupIncident{ DisplayType int8; Style int8; Character int16; Confirmed bool;
+   Slot1PokemonId int16; Slot1Form int16; ExpireTimestamp int64 }`, mirroring `StationBattles`
+   (`fortRtree.go:66`, `api_fort.go:210-227`). Slot1 only (D9).
+   - `updatePokestopIncidentLookup` (`fortRtree.go:259`): upsert the incident into the slice by
+     incident id, drop expired entries. Full `*Incident` is already in hand at the call site
+     (`incident_state.go:157`), so `Confirmed`/`ExpireTimestamp`/slot1 are available.
+   - `updatePokestopLookup` (`fortRtree.go:182-218`): preserve the slice across pokestop re-saves
+     (as it preserves flat fields today).
+   - `isFortDnfMatch` (`api_fort.go:183-195`): iterate the slice, skip expired, match-any — exactly
+     the `StationBattles` pattern. Fixes clobbering (~11% of stops), the missing incident-expiry
+     check, and slot-1-only matching.
+
+### 6.2 Maintained quest-conditions map (new)
+Provides the per-reward `conditions` *options* without scanning or storing strings in `FortLookup`:
+- Key: `{ reward signature (with_ar, reward_type, item_id, amount, pokemon_id, form_id), title, target }` → count.
+- Reconcile at the quest save path (snapshot the pre-apply quest title/target, then increment the
+  new key / decrement the old) and decrement at fort eviction (the evicted `*Pokestop` carries the
+  quest title/target) — the `pokemonFormCount` reconcile+eviction pattern, hooked in the quest path
+  because `FortLookup` deliberately holds no title/target.
+- The endpoint ranges it to emit distinct `(reward, title, target)` per reward key.
+- **Only supplies options.** Filtering by a selected title/target is applied locally in ReactMap, so
+  the scan filter (`isFortDnfMatch`) never gains title/target.
+
+### 6.3 Endpoint + aggregate (`decoder/api_pokestop.go` new, `routes_huma.go`)
+```
+GET /api/pokestop/available   — X-Golbat-Secret; 503 when !FortInMemory; whole-instance; no params
+```
+`GetAvailablePokestops()` builds, all in-memory:
+- **quests** — reward keys from the maintained conditions map (or `fortLookupCache` reward fields);
+  each tuple carries `title`/`target` for `conditions`.
+- **lures** — `fortLookupCache.Range`, `LureExpireTimestamp > now`.
+- **showcases** — `fortLookupCache.Range` (`ContestPokemonId/Form/Type`), `ShowcaseExpiry > now`.
+- **invasions** — from the *same* `fortLookupCache.Range`, iterating each fort's `Incidents` slice
+  (Task 2), `ExpireTimestamp > now`: character→`i`, display_type→`b`, confirmed+slot1→`a`. One range
+  covers lures+showcases+invasions; `incidentCache` is **not** scanned.
+- **quest cross-check** — the same range also tallies FortLookup reward fields and compares them to
+  the maintained conditions map (`verifyQuestAggregate`); any divergence logs/metrics a desync, so
+  the map's reconciliation (§6.2) is continuously verified against a bulletproof direct read.
+
+Response (structured tuples; distinct rows + `count`):
+```jsonc
+{
+  "quests":    [{ "with_ar": false, "reward_type": 2, "item_id": 1, "amount": 3,
+                  "pokemon_id": 0, "form_id": 0, "title": "challenge_x", "target": 3, "count": 42 }],
+  "invasions": [{ "character": 1, "display_type": 1, "confirmed": true,
+                  "slot1_pokemon_id": 41, "slot1_form": 0, "count": 5 }],
+  "lures":     [{ "lure_id": 501, "count": 12 }],
+  "showcases": [{ "pokemon_id": 1, "form": 0, "type_id": 0, "count": 3 }]
+}
+```
+Register one `huma.Register` (new `registerPokestopReadRoutes` or in `registerFortScanRoutes`),
+`FortInMemory`-gated, `Security: golbatSecret`.
+
+### 6.4 Instrumentation (D5)
+`time.Now()`/`time.Since()` + `log.Infof` per build (like `routes_huma.go:613`): duration + scanned
+forts/incidents + per-category counts. Prometheus histogram via `StatsCollector`
+(`ObserveApiScan("available-pokestops", seconds)`, mirroring `ObserveDbQuery`).
+
+## 7. ReactMap design (branch off `develop`)
+
+Mirror `Pokemon.getAvailable` (`models/Pokemon.js:874`): `Pokestop.getAvailable({ mem, secret,
+httpAuth, ... })` — when `mem` set, `GET {mem}/api/pokestop/available` via `evalQuery`, map tuples
+→ existing `{ available, conditions }` (§5). SQL path unchanged when `mem` falsy **or** endpoint 503.
+`DbManager.getDbContext` already provides `mem/secret/httpAuth`. No change to
+`filters/builder/pokestop.js`, resolvers, `getPokestops` (map-data stays SQL), or the interval.
+
+## 8. Coverage caveats
+
+- **Resident set vs whole DB:** aggregate reflects the ~25h-resident fort set + active incidents —
+  fresher, but undercounts reward types only on forts this instance never scans (shared-DB). Keep
+  SQL for such connections.
+- **`FortInMemory` required** (whole-cache `Range` has no per-key DB fallback) → 503, ReactMap
+  falls back to SQL.
+- **Base-branch coordination:** design touches `fortRtree.go`/`api_fort.go` (hot incident path) on a
+  branch actively reworking eviction; uses only `Get`/`Range` + additive struct fields; rebase and
+  re-verify accessor names before merge.
+
+## 9. Phasing
+
+- **Phase 1 (this spec):** endpoint + `FortLookup` `+2 ints` + incident slice + `isFortDnfMatch` fix
+  + maintained conditions map + instrumentation; ReactMap hybrid consumer.
+- **Phase 2 (separate spec):** add `incidents[]` to the pokestop scan response + per-fort quest
+  title/target (for `adv` filtering) → move ReactMap `getPokestops` to Golbat → full API retrieval;
+  optionally the "fully aggregated total" for rewards/lures/showcases; retire `getFilterContext()`.
+
+## 10. Testing
+
+**Golbat** — unit: seed `fortLookupCache`/`incidentCache`/conditions-map fixtures (active+expired
+lure/showcase/incident; grunt-confirmed-slot1; leader+giovanni and rocket+showcase coexisting stops;
+AR+no-AR quests w/ distinct titles) → assert aggregate tuples, expiry exclusion, counts, and
+`isFortDnfMatch` per-incident matching. Gating: `!FortInMemory`→503; bad secret→401/403.
+Instrumentation emitted.
+
+**ReactMap** — unit: mock response → `getAvailable` yields the same `{available, conditions}` keys as
+the SQL path (golden). Fallback: `mem` unset / 503 → SQL. Integration: dev ReactMap → Golbat
+(`FortInMemory` on), diff filter options vs SQL baseline via `GET /api/v1/available/quests?current=`.
+
+## 11. Open questions
+
+1. Status code (`200` vs `202` to match `/api/pokemon/available`).
+2. Log level (`Info` vs `Debug`) at ~15-min cadence.
+3. Whether the maintained conditions map also supplants the `fortLookupCache` reward scan in Phase 1
+   or that's left to the Phase-2 "fully aggregated total".

--- a/routes_huma.go
+++ b/routes_huma.go
@@ -226,6 +226,7 @@ func registerFortScanRoutes(api huma.API) {
 		Security:      []map[string][]string{{securitySchemeName: {}}},
 		DefaultStatus: http.StatusOK,
 	}
+	draftBadge(&availableOp)
 	huma.Register(api, availableOp, func(ctx context.Context, _ *struct{}) (*pokestopAvailableOutput, error) {
 		if !config.Config.FortInMemory {
 			return nil, huma.Error503ServiceUnavailable("fort_in_memory not enabled")

--- a/routes_huma.go
+++ b/routes_huma.go
@@ -222,6 +222,7 @@ func registerFortScanRoutes(api huma.API) {
 		Method:        http.MethodGet,
 		Path:          "/api/pokestop/available",
 		Summary:       "List currently available pokestop rewards/invasions/lures/showcases",
+		Description:   "Returns everything currently available on resident pokestops — distinct quest rewards (with title/target conditions), invasions, lures and showcases — from the in-memory fort cache, no DB scan. Whole-instance; requires fort_in_memory (503 otherwise). Presence-oriented: `count` is the number of resident forts offering each tuple; consumers typically use the distinct tuples to build filter options.",
 		Tags:          []string{"Pokestop"},
 		Security:      []map[string][]string{{securitySchemeName: {}}},
 		DefaultStatus: http.StatusOK,

--- a/routes_huma.go
+++ b/routes_huma.go
@@ -137,8 +137,13 @@ type fortScanOutput struct {
 	Body decoder.ApiFortCombinedScanResult
 }
 
-// registerFortScanRoutes registers the four in-memory fort scan operations.
-// These are gated by config.Config.FortInMemory and return 503 when disabled.
+type pokestopAvailableOutput struct {
+	Body *decoder.ApiAvailablePokestops
+}
+
+// registerFortScanRoutes registers the four in-memory fort scan operations
+// plus the pokestop-available aggregate. These are gated by
+// config.Config.FortInMemory and return 503 when disabled.
 func registerFortScanRoutes(api huma.API) {
 	gymOp := huma.Operation{
 		OperationID:   "scan-gyms",
@@ -210,6 +215,22 @@ func registerFortScanRoutes(api huma.API) {
 			return nil, huma.Error503ServiceUnavailable("fort_in_memory not enabled")
 		}
 		return &fortScanOutput{Body: *decoder.FortCombinedScanEndpoint(in.Body, dbDetails)}, nil
+	})
+
+	availableOp := huma.Operation{
+		OperationID:   "available-pokestops",
+		Method:        http.MethodGet,
+		Path:          "/api/pokestop/available",
+		Summary:       "List currently available pokestop rewards/invasions/lures/showcases",
+		Tags:          []string{"Pokestop"},
+		Security:      []map[string][]string{{securitySchemeName: {}}},
+		DefaultStatus: http.StatusOK,
+	}
+	huma.Register(api, availableOp, func(ctx context.Context, _ *struct{}) (*pokestopAvailableOutput, error) {
+		if !config.Config.FortInMemory {
+			return nil, huma.Error503ServiceUnavailable("fort_in_memory not enabled")
+		}
+		return &pokestopAvailableOutput{Body: decoder.GetAvailablePokestops(time.Now().Unix())}, nil
 	})
 }
 

--- a/stats_collector/noop.go
+++ b/stats_collector/noop.go
@@ -59,6 +59,7 @@ func (col *noopCollector) IncSlowDbQuery(string)                       {}
 func (col *noopCollector) IncStatsEventsDropped()                      {}
 func (col *noopCollector) AddCacheEvictionsDropped(string, float64)    {}
 func (col *noopCollector) ObserveDbQuery(string, float64)              {}
+func (col *noopCollector) ObserveApiScan(string, float64)              {}
 func (col *noopCollector) SetWriteBehindQueueDepth(string, float64)    {}
 func (col *noopCollector) IncWriteBehindSquashed(string)               {}
 func (col *noopCollector) IncWriteBehindRateLimited(string)            {}

--- a/stats_collector/prometheus.go
+++ b/stats_collector/prometheus.go
@@ -373,6 +373,7 @@ var (
 			Namespace: ns,
 			Name:      "api_scan_duration",
 			Help:      "In-memory API scan build time by operation",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 14), // 1ms .. ~8s
 		},
 		[]string{"operation"},
 	)

--- a/stats_collector/prometheus.go
+++ b/stats_collector/prometheus.go
@@ -368,6 +368,14 @@ var (
 		},
 		[]string{"caller"},
 	)
+	apiScanDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: ns,
+			Name:      "api_scan_duration",
+			Help:      "In-memory API scan build time by operation",
+		},
+		[]string{"operation"},
+	)
 	statsEventsDroppedCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: ns,
@@ -766,6 +774,10 @@ func (col *promCollector) ObserveDbQuery(caller string, seconds float64) {
 	dbQueryDuration.WithLabelValues(caller).Observe(seconds)
 }
 
+func (col *promCollector) ObserveApiScan(operation string, seconds float64) {
+	apiScanDuration.WithLabelValues(operation).Observe(seconds)
+}
+
 func (col *promCollector) SetWriteBehindQueueDepth(entityType string, depth float64) {
 	writeBehindQueueDepth.WithLabelValues(entityType).Set(depth)
 }
@@ -807,7 +819,7 @@ func (col *promCollector) SetS2CellBatchSize(size int) {
 }
 
 func initPrometheus() {
-	prometheus.MustRegister(workerBacklog, rawProcessingWaitingGauge, rawPacketsShed, slowDbQueries, statsEventsDroppedCounter, dbQueryDuration, cacheEvictionsDropped)
+	prometheus.MustRegister(workerBacklog, rawProcessingWaitingGauge, rawPacketsShed, slowDbQueries, statsEventsDroppedCounter, dbQueryDuration, apiScanDuration, cacheEvictionsDropped)
 	prometheus.MustRegister(
 		rawRequests, decodeMethods, decodeFortDetails, decodeGetMapForts, decodeGetGymInfo, decodeEncounter,
 		decodeDiskEncounter, decodeQuest, decodeSocialActionWithRequest, decodeGMO, decodeGMOType,

--- a/stats_collector/stats_collector.go
+++ b/stats_collector/stats_collector.go
@@ -59,6 +59,7 @@ type StatsCollector interface {
 	IncStatsEventsDropped()
 	AddCacheEvictionsDropped(cache string, n float64)
 	ObserveDbQuery(caller string, seconds float64)
+	ObserveApiScan(operation string, seconds float64)
 
 	// Write-behind queue metrics
 	SetWriteBehindQueueDepth(entityType string, depth float64)


### PR DESCRIPTION
## Summary

Adds `GET /api/pokestop/available` — an in-memory, whole-instance aggregate of currently-available pokestop **quest rewards (+ title/target conditions), invasions, lures, and showcases** — so ReactMap can replace its ~30-query, 15-minute SQL block (`Pokestop.getAvailable()`) with a single HTTP call, mirroring the existing `/api/pokemon/available` pattern. `FortInMemory`-gated (503 otherwise); auth via `X-Golbat-Secret`. Marked **draft** (`draftBadge`) — the wire format is unproven and no consumer ships against it yet.

## How it works

- **Quests + conditions** — a new maintained in-memory aggregate (`questConditionCount`, keyed by reward signature + title/target), reconciled in `updatePokestopLookup` + eviction via a per-fort key tracker, with atomic swap-and-adjust under the per-fort bucket lock (mirrors `pokemonFormCount`). No DB scan.
- **Lures + showcases + invasions** — one `fortLookupCache.Range`. This required:
  - `FortLookup` gains `LureExpireTimestamp` / `ShowcaseExpiry` (active-only filtering; also fixes the scan filter previously returning expired lures/showcases).
  - `FortLookup`'s flat incident fields → an `Incidents []FortLookupIncident` slice (slot1 only, per production data), fixing multi-incident **scan-filter** clobbering and adding per-incident expiry/slot handling — the `StationBattles` pattern.
- **Cross-check** — the same range tallies FortLookup reward fields and compares them to the maintained map (`verifyQuestAggregate`) as a Debug-level drift diagnostic.
- **Instrumentation** — an `apiScanDuration` Prometheus histogram for build time.

## Testing

`go build ./...`, `go vet`, `gofmt` clean; `go test ./decoder/... ./stats_collector/...` green, including a 16-goroutine × 500-iteration `-race` reconcile storm on the quest-conditions aggregate.

## Design docs

- `docs/superpowers/specs/2026-07-14-pokestop-available-api-design.md`
- `docs/superpowers/plans/2026-07-14-pokestop-available-api-golbat.md`

## Follow-ups (deferred, non-blocking)

- Store `incident.Id` in `FortLookupIncident` for exact dedup (currently keyed on `DisplayType + Character`).
- Convert the two `fortLookupCache` writers to `Compute` to close a pre-existing read-modify-write race.
- Broaden `TestGetAvailablePokestops` (multi-fort dedup, `FortType` skip) + add AR-slot / two-slot conditions tests.
- ReactMap consumer (separate repo/PR).

## Notes

- Built on `perf/eviction-lock-contention` (depends on its `otter` cache layer); PR targets that branch. Rebase + re-verify cache accessor names before it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
