### PR TITLE
feat: optionally break down shiny stats by geofence area

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -121,3 +121,4 @@ proactive_iv_switching_to_db = false # Write proactive IV changes to database (d
 #raid_stats_interval_minutes = 10       # Interval for writing raid stats (default: 10 minutes)
 #invasion_stats_interval_minutes = 15   # Interval for writing invasion stats (default: 15 minutes)
 #quest_stats_interval_minutes = 15      # Interval for writing quest stats (default: 15 minutes)
+#shiny_stats_per_area = false           # Break down pokemon_shiny_stats by geofence area instead of world-only (default: false). Increases write volume similar to pokemon_hundo_stats/pokemon_nundo_stats.

--- a/config/config.go
+++ b/config/config.go
@@ -169,11 +169,12 @@ type weather struct {
 }
 
 type statsIntervals struct {
-	PokemonStatsIntervalMinutes  int `koanf:"pokemon_stats_interval_minutes"`
-	PokemonCountIntervalMinutes  int `koanf:"pokemon_count_interval_minutes"`
-	RaidStatsIntervalMinutes     int `koanf:"raid_stats_interval_minutes"`
-	InvasionStatsIntervalMinutes int `koanf:"invasion_stats_interval_minutes"`
-	QuestStatsIntervalMinutes    int `koanf:"quest_stats_interval_minutes"`
+	PokemonStatsIntervalMinutes  int  `koanf:"pokemon_stats_interval_minutes"`
+	PokemonCountIntervalMinutes  int  `koanf:"pokemon_count_interval_minutes"`
+	RaidStatsIntervalMinutes     int  `koanf:"raid_stats_interval_minutes"`
+	InvasionStatsIntervalMinutes int  `koanf:"invasion_stats_interval_minutes"`
+	QuestStatsIntervalMinutes    int  `koanf:"quest_stats_interval_minutes"`
+	ShinyStatsPerArea            bool `koanf:"shiny_stats_per_area"` // if true, shiny stats are broken down by geofence area instead of world-only
 }
 
 var Config configDefinition

--- a/config/reader.go
+++ b/config/reader.go
@@ -76,6 +76,7 @@ func ReadConfig() (configDefinition, error) {
 			RaidStatsIntervalMinutes:     10,
 			InvasionStatsIntervalMinutes: 15,
 			QuestStatsIntervalMinutes:    15,
+			ShinyStatsPerArea:            false,
 		},
 	}, "koanf"), nil)
 	if defaultErr != nil {

--- a/decoder/pokemon_process.go
+++ b/decoder/pokemon_process.go
@@ -5,12 +5,23 @@ import (
 	"fmt"
 	"time"
 
+	"golbat/config"
 	"golbat/db"
+	"golbat/geo"
 	"golbat/pogo"
 
 	"github.com/jellydator/ttlcache/v3"
 	log "github.com/sirupsen/logrus"
 )
+
+// shinyStatsAreas returns the geofence areas to break shiny stats down by,
+// following the same unmatched/world fallback as updatePokemonStats et al.
+func shinyStatsAreas(pokemon *Pokemon) []geo.AreaName {
+	if !config.Config.StatsIntervals.ShinyStatsPerArea {
+		return nil
+	}
+	return MatchStatsGeofenceWithCell(pokemon.Lat, pokemon.Lon, uint64(pokemon.CellId.ValueOrZero()))
+}
 
 func UpdatePokemonRecordWithEncounterProto(ctx context.Context, db db.DbDetails, encounter *pogo.EncounterOutProto, username string, timestamp int64) string {
 	if encounter.Pokemon == nil {
@@ -30,7 +41,7 @@ func UpdatePokemonRecordWithEncounterProto(ctx context.Context, db db.DbDetails,
 	savePokemonRecordAsAtTime(ctx, db, pokemon, true, true, true, timestamp/1000)
 	// updateEncounterStats() should only be called for encounters, and called
 	// even if we have the pokemon record already.
-	updateEncounterStats(pokemon)
+	updateEncounterStats(pokemon, shinyStatsAreas(pokemon))
 
 	return fmt.Sprintf("%d %d Pokemon %d CP%d", encounter.Pokemon.EncounterId, encounterId, pokemon.PokemonId, encounter.Pokemon.Pokemon.Cp)
 }
@@ -62,7 +73,7 @@ func UpdatePokemonRecordWithDiskEncounterProto(ctx context.Context, db db.DbDeta
 	savePokemonRecordAsAtTime(ctx, db, pokemon, true, true, true, time.Now().Unix())
 	// updateEncounterStats() should only be called for encounters, and called
 	// even if we have the pokemon record already.
-	updateEncounterStats(pokemon)
+	updateEncounterStats(pokemon, shinyStatsAreas(pokemon))
 
 	return fmt.Sprintf("%d Disk Pokemon %d CP%d", encounterId, pokemon.PokemonId, encounter.Pokemon.Cp)
 }
@@ -81,7 +92,7 @@ func UpdatePokemonRecordWithTappableEncounter(ctx context.Context, db db.DbDetai
 	savePokemonRecordAsAtTime(ctx, db, pokemon, true, true, true, time.Now().Unix())
 	// updateEncounterStats() should only be called for encounters, and called
 	// even if we have the pokemon record already.
-	updateEncounterStats(pokemon)
+	updateEncounterStats(pokemon, shinyStatsAreas(pokemon))
 
 	return fmt.Sprintf("%d Tappable Pokemon %d CP%d", encounterId, pokemon.PokemonId, encounter.Pokemon.Cp)
 }

--- a/decoder/stats.go
+++ b/decoder/stats.go
@@ -163,7 +163,7 @@ func ReloadGeofenceAndClearStats() {
 }
 
 // update stats for an encounterId
-func updateEncounterStats(pokemon *Pokemon) {
+func updateEncounterStats(pokemon *Pokemon, areas []geo.AreaName) {
 	// We should only be called from encounters. It's important to do so,
 	// so that the 'DuplicateEncounters' stats below are correct.
 	// And double check that we have IVs, anyway.
@@ -207,31 +207,39 @@ func updateEncounterStats(pokemon *Pokemon) {
 
 	// For the DB
 	func() {
-		areaName := geo.AreaName{Parent: "world", Name: "world"}
+		if len(areas) == 0 {
+			areas = []geo.AreaName{{Parent: "unmatched", Name: "unmatched"}}
+		}
+		areas = append(areas, geo.AreaName{Parent: "world", Name: "world"})
+
+		pf := pokemonForm{pokemonId: pokemon.PokemonId, formId: formId}
+		isShiny := pokemon.Shiny.ValueOrZero()
 
 		pokemonStatsLock.Lock()
 		defer pokemonStatsLock.Unlock()
 
-		countStats, exists := pokemonCount[areaName]
-		if !exists {
-			countStats = &areaPokemonCountDetail{
-				hundos:      make(map[pokemonForm]int),
-				nundos:      make(map[pokemonForm]int),
-				count:       make(map[pokemonForm]int),
-				ivCount:     make(map[pokemonForm]int),
-				shinyChecks: make(map[pokemonForm]shinyChecks),
+		for i := 0; i < len(areas); i++ {
+			areaName := areas[i]
+
+			countStats, exists := pokemonCount[areaName]
+			if !exists {
+				countStats = &areaPokemonCountDetail{
+					hundos:      make(map[pokemonForm]int),
+					nundos:      make(map[pokemonForm]int),
+					count:       make(map[pokemonForm]int),
+					ivCount:     make(map[pokemonForm]int),
+					shinyChecks: make(map[pokemonForm]shinyChecks),
+				}
+				pokemonCount[areaName] = countStats
 			}
-			pokemonCount[areaName] = countStats
-		}
 
-		pf := pokemonForm{pokemonId: pokemon.PokemonId, formId: formId}
-
-		entry := countStats.shinyChecks[pf]
-		entry.total++
-		if pokemon.Shiny.ValueOrZero() {
-			entry.shiny++
+			entry := countStats.shinyChecks[pf]
+			entry.total++
+			if isShiny {
+				entry.shiny++
+			}
+			countStats.shinyChecks[pf] = entry
 		}
-		countStats.shinyChecks[pf] = entry
 	}()
 
 	// Prometheus


### PR DESCRIPTION
## Summary
- `pokemon_shiny_stats` was always written as a single world-only row per pokemon/form — inconsistent with `pokemon_stats`, `pokemon_hundo_stats`, `pokemon_nundo_stats`, `raid_stats`, `invasion_stats`, and `quest_stats`, which all break down by geofence area (with an "unmatched" fallback).
- Adds a `shiny_stats_per_area` config flag (default `false`) under `[stats_intervals]`. When enabled, shiny stats use the same area/fence lookup and unmatched/world fallback pattern already used by `updatePokemonStats` and the other stats functions.
- No schema changes needed — `pokemon_shiny_stats` already has `area`/`fence` columns.

## Behavior
- Flag disabled (default): unchanged — one row per pokemon/form under `world`.
- Flag enabled: one row per pokemon/form per matched geofence area (plus `unmatched`/`world` fallback), same write pattern as `pokemon_hundo_stats`/`pokemon_nundo_stats`. This increases write volume proportionally to the number of configured geofences, so it's opt-in.

## Test plan
- [ ] `go build ./...`
- [ ] Manually verify with `shiny_stats_per_area = false`: shiny stats still land only under `world` as before.
- [ ] Manually verify with `shiny_stats_per_area = true` and a geofence configured: shiny stats land under the matching area/fence plus `world`.