### PR TITLE
feat: expose v3 pokemon scan limit status

### DIFF
--- a/decoder/api_pokemon_common.go
+++ b/decoder/api_pokemon_common.go
@@ -63,6 +63,18 @@ type PokemonScanRetrieveParameters interface {
 	GetLimit() int
 }
 
+func pokemonScanLimit(retrieveParameters PokemonScanRetrieveParameters) int {
+	maxPokemon := config.Config.Tuning.MaxPokemonResults
+	if retrieveParameters.GetLimit() > 0 && retrieveParameters.GetLimit() < maxPokemon {
+		maxPokemon = retrieveParameters.GetLimit()
+	}
+	return maxPokemon
+}
+
+func pokemonScanLimitReached(retrieveParameters PokemonScanRetrieveParameters, resultCount int) bool {
+	return resultCount >= pokemonScanLimit(retrieveParameters)
+}
+
 func internalGetPokemonInArea[F any](
 	retrieveParameters PokemonScanRetrieveParameters,
 	dnfFilters map[dnfFilterLookup][]F,
@@ -73,10 +85,7 @@ func internalGetPokemonInArea[F any](
 	minLocation := retrieveParameters.GetMin()
 	maxLocation := retrieveParameters.GetMax()
 
-	maxPokemon := config.Config.Tuning.MaxPokemonResults
-	if retrieveParameters.GetLimit() > 0 && retrieveParameters.GetLimit() < maxPokemon {
-		maxPokemon = retrieveParameters.GetLimit()
-	}
+	maxPokemon := pokemonScanLimit(retrieveParameters)
 
 	pokemonExamined := 0
 	pokemonSkipped := 0

--- a/decoder/api_pokemon_common_test.go
+++ b/decoder/api_pokemon_common_test.go
@@ -1,0 +1,38 @@
+package decoder
+
+import (
+	"testing"
+
+	"golbat/config"
+)
+
+func TestPokemonScanLimitReached(t *testing.T) {
+	previousLimit := config.Config.Tuning.MaxPokemonResults
+	config.Config.Tuning.MaxPokemonResults = 100
+	t.Cleanup(func() {
+		config.Config.Tuning.MaxPokemonResults = previousLimit
+	})
+
+	tests := []struct {
+		name         string
+		requestLimit int
+		resultCount  int
+		want         bool
+	}{
+		{name: "below requested limit", requestLimit: 10, resultCount: 9, want: false},
+		{name: "at requested limit", requestLimit: 10, resultCount: 10, want: true},
+		{name: "above requested limit", requestLimit: 10, resultCount: 11, want: true},
+		{name: "below server default", requestLimit: 0, resultCount: 99, want: false},
+		{name: "at server default", requestLimit: 0, resultCount: 100, want: true},
+		{name: "requested limit capped by server", requestLimit: 200, resultCount: 100, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := ApiPokemonScan3{Limit: tt.requestLimit}
+			if got := pokemonScanLimitReached(req, tt.resultCount); got != tt.want {
+				t.Errorf("pokemonScanLimitReached() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/decoder/api_pokemon_response.go
+++ b/decoder/api_pokemon_response.go
@@ -159,10 +159,11 @@ func buildApiPvpRankings(pokemon *Pokemon) ApiPvpRankings {
 // ApiPokemonScanResultV3 is the v3-only response envelope wrapping the matched
 // pokemon together with the spatial-index candidate counts.
 type ApiPokemonScanResultV3 struct {
-	Pokemon  []ApiPokemonResult `json:"pokemon" doc:"Matched pokemon"`
-	Examined int                `json:"examined" doc:"Candidates examined from the spatial index"`
-	Skipped  int                `json:"skipped" doc:"Candidates skipped (expired or filtered)"`
-	Total    int                `json:"total" doc:"Total candidates in the bounding box"`
+	Pokemon      []ApiPokemonResult `json:"pokemon" doc:"Matched pokemon"`
+	Examined     int                `json:"examined" doc:"Candidates examined from the spatial index"`
+	Skipped      int                `json:"skipped" doc:"Candidates skipped (expired or filtered)"`
+	Total        int                `json:"total" doc:"Total candidates in the bounding box"`
+	LimitReached bool               `json:"limit_reached" doc:"Whether the pre-filtered result list reached the effective result limit"`
 }
 
 // GetPokemonInArea2Clean runs the v2 rtree/DNF search and returns a bare array of
@@ -177,10 +178,11 @@ func GetPokemonInArea2Clean(req ApiPokemonScan2) []ApiPokemonResult {
 func GetPokemonInArea3Clean(req ApiPokemonScan3) *ApiPokemonScanResultV3 {
 	keys, examined, skipped, total := internalGetPokemonInArea3(req)
 	return &ApiPokemonScanResultV3{
-		Pokemon:  collectApiPokemonResults(keys, "API.ScanPokemon.v3.clean"),
-		Examined: examined,
-		Skipped:  skipped,
-		Total:    total,
+		Pokemon:      collectApiPokemonResults(keys, "API.ScanPokemon.v3.clean"),
+		Examined:     examined,
+		Skipped:      skipped,
+		Total:        total,
+		LimitReached: pokemonScanLimitReached(req, len(keys)),
 	}
 }
 

--- a/decoder/api_pokemon_response_test.go
+++ b/decoder/api_pokemon_response_test.go
@@ -148,10 +148,11 @@ func TestApiPvpRankings_OmitsEmptyLeagues(t *testing.T) {
 
 func TestApiPokemonScanResultV3_WireShape(t *testing.T) {
 	res := ApiPokemonScanResultV3{
-		Pokemon:  []ApiPokemonResult{{Id: "1", PokemonId: 25}},
-		Examined: 5,
-		Skipped:  1,
-		Total:    6,
+		Pokemon:      []ApiPokemonResult{{Id: "1", PokemonId: 25}},
+		Examined:     5,
+		Skipped:      1,
+		Total:        6,
+		LimitReached: true,
 	}
 	b, err := json.Marshal(res)
 	if err != nil {
@@ -161,10 +162,13 @@ func TestApiPokemonScanResultV3_WireShape(t *testing.T) {
 	if err := json.Unmarshal(b, &m); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	for _, k := range []string{"pokemon", "examined", "skipped", "total"} {
+	for _, k := range []string{"pokemon", "examined", "skipped", "total", "limit_reached"} {
 		if _, ok := m[k]; !ok {
 			t.Errorf("v3 wrapper missing key %q", k)
 		}
+	}
+	if string(m["limit_reached"]) != "true" {
+		t.Errorf("limit_reached = %s, want true", m["limit_reached"])
 	}
 }
 

--- a/huma_routes_test.go
+++ b/huma_routes_test.go
@@ -63,7 +63,7 @@ func TestHumaScanEndpointsE2E(t *testing.T) {
 		if err := gojson.Unmarshal([]byte(body), &m); err != nil {
 			t.Fatalf("v3 body is not a JSON object: %v; body=%s", err, body)
 		}
-		for _, key := range []string{"pokemon", "examined", "skipped", "total"} {
+		for _, key := range []string{"pokemon", "examined", "skipped", "total", "limit_reached"} {
 			if _, ok := m[key]; !ok {
 				t.Errorf("v3 body missing key %q: %s", key, body)
 			}


### PR DESCRIPTION
## Summary
- add `limit_reached` to the v3 Pokemon scan HTTP response
- calculate it from the pre-expiry-filter key list and the effective request/server limit
- cover requested, default, and server-capped limits

## Testing
- `go test ./decoder/`
- `go test .`
- `go test -tags go_json ./...`
- `go build -tags go_json ./...`