### PR TITLE
feat: add -c/--config runtime arg for config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ At this time this is likely to be mostly development discussion.
 1. copy `config.toml.example` to `config.toml`
 2. `go run .`
 
+Golbat reads `config.toml` from the working directory by default. To load a
+different file, pass `-c` or `--config`:
+
+```
+go run . --config /etc/golbat/config.toml
+```
+
+The default `config.toml` is optional - without it Golbat starts on built-in
+defaults plus any `GOLBAT_*` environment variables. A file passed with
+`-c`/`--config` must exist, otherwise startup fails.
+
 ## Run in pm2
 
 1. `make` 

--- a/config/reader.go
+++ b/config/reader.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"strconv"
 	"strings"
 
@@ -15,7 +17,15 @@ import (
 
 var k = koanf.New(".")
 
-func ReadConfig() (configDefinition, error) {
+// DefaultConfigPath is used when no config file is given on the command line.
+// A missing file at this path is not an error: the whole config can be supplied
+// through GOLBAT_* environment variables instead.
+const DefaultConfigPath = "config.toml"
+
+// ReadConfig loads configuration from defaults, then the TOML file at
+// configPath, then GOLBAT_* environment variables, each layer overriding the
+// previous one. Pass DefaultConfigPath for the standard location.
+func ReadConfig(configPath string) (configDefinition, error) {
 	// Default values
 	defaultErr := k.Load(structs.Provider(configDefinition{
 		ApiDocs: true,
@@ -83,9 +93,15 @@ func ReadConfig() (configDefinition, error) {
 		fmt.Println(fmt.Errorf("failed to load default config: %w", defaultErr))
 	}
 
-	readConfigErr := k.Load(file.Provider("config.toml"), toml.Parser())
-	if readConfigErr != nil && readConfigErr.Error() != "open config.toml: no such file or directory" {
-		fmt.Println(fmt.Errorf("failed to read config file: %w", readConfigErr))
+	readConfigErr := k.Load(file.Provider(configPath), toml.Parser())
+	if readConfigErr != nil {
+		if !errors.Is(readConfigErr, fs.ErrNotExist) {
+			fmt.Println(fmt.Errorf("failed to read config file %s: %w", configPath, readConfigErr))
+		} else if configPath != DefaultConfigPath {
+			// The default file is optional, but a file the user explicitly asked
+			// for must exist - otherwise we would silently start on defaults.
+			return Config, fmt.Errorf("config file %s not found", configPath)
+		}
 	}
 
 	envLoadingErr := k.Load(ProviderWithValue("GOLBAT.", ".", func(rawKey string, value string, currentMap map[string]interface{}) (string, interface{}) {

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ReadConfig layers onto a package-level koanf instance, so these cases share
+// state. Each one asserts only on what it sets itself.
+
+func TestReadConfigMissingDefaultPathIsNotAnError(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if _, err := ReadConfig(DefaultConfigPath); err != nil {
+		t.Fatalf("missing %s should fall back to defaults and env vars, got: %v", DefaultConfigPath, err)
+	}
+}
+
+func TestReadConfigMissingExplicitPathIsAnError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "absent.toml")
+
+	_, err := ReadConfig(missing)
+	if err == nil {
+		t.Fatalf("explicitly requested config %s is missing, expected an error", missing)
+	}
+}
+
+func TestReadConfigLoadsExplicitPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "custom.toml")
+	if err := os.WriteFile(path, []byte("port = 12345\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := ReadConfig(path)
+	if err != nil {
+		t.Fatalf("ReadConfig(%s): %v", path, err)
+	}
+	if cfg.Port != 12345 {
+		t.Errorf("Port = %d, want 12345 from %s", cfg.Port, path)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net"
 	"net/http"
@@ -37,6 +38,10 @@ var dbDetails db2.DbDetails
 var statsCollector stats_collector.StatsCollector
 
 func main() {
+	configPath := flag.String("config", config.DefaultConfigPath, "path to the TOML config file")
+	flag.StringVar(configPath, "c", config.DefaultConfigPath, "path to the TOML config file (shorthand)")
+	flag.Parse()
+
 	var wg sync.WaitGroup
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()
@@ -47,7 +52,7 @@ func main() {
 		watchForShutdown(ctx, cancelFn)
 	}()
 
-	cfg, err := config.ReadConfig()
+	cfg, err := config.ReadConfig(*configPath)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Golbat has always read `config.toml` from the working directory. This adds a `-c` / `--config` flag so the file can live somewhere else, which matters for packaged installs (`/etc/golbat/config.toml`) and for running more than one instance from a single binary.

Both spellings work, since Go's `flag` package treats `-x` and `--x` the same:

```
golbat -c /etc/golbat/config.toml
golbat --config /etc/golbat/config.toml
```

## Behavior

Without the flag nothing changes: `config.toml` in the working directory, and a missing file there is still fine, because the whole config can come from `GOLBAT_*` environment variables instead.

A path passed explicitly has to exist. If it doesn't, startup fails instead of quietly falling back to defaults. A typo'd `--config` that boots Golbat on stock settings looks alive but points at the wrong database, which is the worse of the two failures.

## The old missing-file check

`ReadConfig` detected a missing file by comparing the error text against a hardcoded `"open config.toml: no such file or directory"`. That stops matching as soon as the path becomes a variable, so every missing custom config would have printed a spurious warning. It is now `errors.Is(err, fs.ErrNotExist)`.

## Testing

`config/reader_test.go` covers the three cases: a missing default path is not an error, a missing explicit path is, and an explicit file actually loads.

- `go build -tags go_json ./...` clean
- `go test -tags go_json ./config/ .` both packages ok
- `golangci-lint run ./config/... .` 0 issues
- Built binary: `-h` lists both flags; `-c /nope.toml` and `--config /nope.toml` both fail with `config file /nope.toml not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
