### PR TITLE
feat(api): add Buddy Showcase focus filtering

### DIFF
--- a/decoder/api_fort.go
+++ b/decoder/api_fort.go
@@ -90,14 +90,23 @@ type ApiFortDnfFilter struct {
 	IncidentCharacter   []int16 `json:"incident_character" required:"false" doc:"Pokestop only: allowed incident character ids; omitted or null means no incident character constraint."`
 
 	// Pokestop - contest
-	ContestPokemon     []ApiDnfId `json:"contest_pokemon" required:"false" doc:"Pokestop only: allowed contest focus pokemon/form pairs; omitted or null means no contest pokemon constraint."`
-	ContestPokemonType []int8     `json:"contest_pokemon_type" required:"false" doc:"Pokestop only: allowed contest pokemon types; omitted or null means no contest type constraint."`
+	ContestPokemon     []ApiDnfId               `json:"contest_pokemon" required:"false" doc:"Pokestop only: allowed contest focus pokemon/form pairs; omitted or null means no contest pokemon constraint."`
+	ContestPokemonType []int8                   `json:"contest_pokemon_type" required:"false" doc:"Pokestop only: allowed contest pokemon types; omitted or null means no contest type constraint."`
+	ContestFocus       []ApiFortDnfContestFocus `json:"contest_focus" required:"false" doc:"Pokestop only: allowed structured contest focuses. Currently supports exact Buddy minimum levels. Omitted or null means no structured focus constraint; an empty list matches nothing."`
 
 	// Station
 	BattleLevel   []int8     `json:"battle_level" required:"false" doc:"Station only: allowed active max battle levels; omitted or null means no battle level constraint. Only matches stations with an active battle."`
 	BattlePokemon []ApiDnfId `json:"battle_pokemon" required:"false" doc:"Station only: allowed active max battle pokemon/form pairs; omitted or null means no battle pokemon constraint. Only matches stations with an active battle."`
 	StationedGmax *bool      `json:"stationed_gmax" required:"false" doc:"Station only: when true, only match stations with at least one stationed Gigantamax pokemon; when false, only stations without any. Null means no constraint."`
 	StationActive *bool      `json:"station_active" required:"false" doc:"Station only: when true, only match stations whose end_time is in the future (still present); when false, only expired stations. Stations are the one ephemeral fort type — expired ones accumulate in the index. Null means no constraint."`
+}
+
+// ApiFortDnfContestFocus is one structured contest-focus selector. The wire
+// shape mirrors showcase_focus. Buddy selectors require min_level; unknown
+// focus types and Buddy selectors without a level safely match nothing.
+type ApiFortDnfContestFocus struct {
+	Type     string `json:"type" doc:"Focus type; currently buddy is supported"`
+	MinLevel *int8  `json:"min_level" required:"false" doc:"Exact minimum Buddy level when type is buddy"`
 }
 
 type ApiDnfId struct {
@@ -146,6 +155,18 @@ type ApiFortCombinedScanResult struct {
 func matchDnfIdPair(filter []ApiDnfId, pokemonId int16, form int16) bool {
 	for _, f := range filter {
 		if f.Pokemon == pokemonId && (f.Form == nil || *f.Form == form) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchContestFocus(filter []ApiFortDnfContestFocus, buddyMinLevel int8) bool {
+	if buddyMinLevel <= 0 {
+		return false
+	}
+	for _, focus := range filter {
+		if contestFocusType(focus.Type) == focusBuddy && focus.MinLevel != nil && *focus.MinLevel == buddyMinLevel {
 			return true
 		}
 	}
@@ -223,6 +244,10 @@ func isFortDnfMatch(fortType FortType, fortLookup *FortLookup, filter *ApiFortDn
 		}
 		if filter.ContestPokemon != nil &&
 			(fortLookup.ShowcaseExpiry <= now || !matchDnfIdPair(filter.ContestPokemon, fortLookup.ContestPokemonId, fortLookup.ContestPokemonForm)) {
+			return false
+		}
+		if filter.ContestFocus != nil &&
+			(fortLookup.ShowcaseExpiry <= now || !matchContestFocus(filter.ContestFocus, fortLookup.ShowcaseBuddyMinLevel)) {
 			return false
 		}
 

--- a/decoder/api_fort_available_test.go
+++ b/decoder/api_fort_available_test.go
@@ -13,13 +13,16 @@ func TestGetAvailableForts(t *testing.T) {
 	now := int64(1_000_000)
 
 	observeRaid(&FortLookup{RaidLevel: 5, RaidPokemonId: 150, RaidEndTimestamp: now + 100}, now)
-	observePokestop(&FortLookup{LureId: 501, LureExpireTimestamp: now + 100}, now)
+	observePokestop(&FortLookup{LureId: 501, LureExpireTimestamp: now + 100}, nil, now)
 	observeInvasion(&FortLookupIncident{Character: 5, DisplayType: 1, ExpireTimestamp: now + 100}, now)
 	observeStationBattles(&FortLookup{StationBattles: []FortLookupStationBattle{
 		{BattleLevel: 5, BattlePokemonId: 150, BattleEndTimestamp: now + 100},
 	}}, now)
 
 	combined := GetAvailableForts(now)
+	if !combined.Pokestops.ShowcaseFocusFilter {
+		t.Fatal("combined availability must carry the nested showcase-focus filter capability")
+	}
 	if len(combined.Gyms.Raids) != 1 {
 		t.Fatalf("gyms: %+v", combined.Gyms)
 	}

--- a/decoder/api_fort_showcase_test.go
+++ b/decoder/api_fort_showcase_test.go
@@ -1,0 +1,104 @@
+package decoder
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/puzpuzpuz/xsync/v4"
+	"github.com/tidwall/rtree"
+
+	"golbat/config"
+)
+
+// TestBuddyShowcaseDnfRunsBeforeResultCap locks the endpoint correctness
+// invariant: unrelated showcases must never consume max_fort_results before
+// the exact structured-focus predicate runs.
+func TestBuddyShowcaseDnfRunsBeforeResultCap(t *testing.T) {
+	oldLookup := fortLookupCache
+	oldSnapshot := fortTreeSnapshot.Load()
+	oldMax := config.Config.Tuning.MaxFortResults
+	fortTreeMutex.Lock()
+	oldTree := fortTree
+	fortTree = rtree.RTreeG[string]{}
+	fortTreeMutex.Unlock()
+	fortLookupCache = xsync.NewMap[string, FortLookup]()
+	fortTreeSnapshot.Store(nil)
+	config.Config.Tuning.MaxFortResults = 1
+	t.Cleanup(func() {
+		config.Config.Tuning.MaxFortResults = oldMax
+		fortLookupCache = oldLookup
+		fortTreeMutex.Lock()
+		fortTree = oldTree
+		fortTreeMutex.Unlock()
+		fortTreeSnapshot.Store(oldSnapshot)
+	})
+
+	now := time.Now().Unix()
+	const count = 8
+	fortTreeMutex.Lock()
+	for i := 0; i < count; i++ {
+		id := fmt.Sprintf("buddy-cap-%d", i)
+		lon := -70.0 + float64(i)/1000
+		lat := 40.0
+		fortTree.Insert([2]float64{lon, lat}, [2]float64{lon, lat}, id)
+		fortLookupCache.Store(id, FortLookup{
+			FortType:              POKESTOP,
+			Lat:                   lat,
+			Lon:                   lon,
+			ShowcaseBuddyMinLevel: 2,
+			ShowcaseExpiry:        now + 3600,
+		})
+	}
+	fortTreeMutex.Unlock()
+	fortTreeSnapshot.Store(nil)
+
+	// Discover the snapshot's actual traversal order, then put the sole exact
+	// match last. The production calls below reuse this same snapshot.
+	snapshot := getFortTreeSnapshot()
+	order := make([]string, 0, count)
+	snapshot.Search([2]float64{-71, 39}, [2]float64{-69, 41}, func(_, _ [2]float64, id string) bool {
+		order = append(order, id)
+		return true
+	})
+	if len(order) != count {
+		t.Fatalf("setup traversal found %d forts, want %d", len(order), count)
+	}
+	target := order[len(order)-1]
+	lookup, ok := fortLookupCache.Load(target)
+	if !ok {
+		t.Fatalf("setup target %q missing from lookup", target)
+	}
+	lookup.ShowcaseBuddyMinLevel = 3
+	fortLookupCache.Store(target, lookup)
+
+	great := int8(3)
+	filter := ApiFortDnfFilter{ContestFocus: []ApiFortDnfContestFocus{{Type: "buddy", MinLevel: &great}}}
+	scan := ApiFortScan{
+		Min:        ApiLatLon{Lat: 39, Lon: -71},
+		Max:        ApiLatLon{Lat: 41, Lon: -69},
+		Limit:      0,
+		DnfFilters: []ApiFortDnfFilter{filter},
+	}
+
+	keys, examined, skipped, total := internalGetForts(POKESTOP, scan)
+	if len(keys) != 1 || keys[0] != target {
+		t.Fatalf("single-type scan returned %v, want only later exact match %q", keys, target)
+	}
+	if examined != count || skipped != 0 || total != count {
+		t.Fatalf("single-type scan stats = examined:%d skipped:%d total:%d, want %d/0/%d", examined, skipped, total, count, count)
+	}
+
+	gyms, stops, stations, examined, skipped, total := internalGetFortsCombined(ApiFortCombinedScan{
+		Min:       scan.Min,
+		Max:       scan.Max,
+		Limit:     0,
+		Pokestops: &ApiFortTypeScanGroup{DnfFilters: []ApiFortDnfFilter{filter}},
+	})
+	if len(gyms) != 0 || len(stations) != 0 || len(stops) != 1 || stops[0] != target {
+		t.Fatalf("combined scan returned gyms=%v stops=%v stations=%v, want only stop %q", gyms, stops, stations, target)
+	}
+	if examined != count || skipped != 0 || total != count {
+		t.Fatalf("combined scan stats = examined:%d skipped:%d total:%d, want %d/0/%d", examined, skipped, total, count, count)
+	}
+}

--- a/decoder/api_pokestop_available.go
+++ b/decoder/api_pokestop_available.go
@@ -42,20 +42,23 @@ type ApiPokestopLureAvailable struct {
 }
 
 // ApiPokestopShowcaseAvailable is one distinct active showcase contest
-// (pokemon/form/type) currently run by resident pokestops.
+// currently run by resident pokestops. Legacy pokemon/form/type mirrors remain
+// available while ShowcaseFocus carries every modern focus type.
 type ApiPokestopShowcaseAvailable struct {
-	PokemonId *int16 `json:"pokemon_id" doc:"Showcase focus pokemon id; null for a type-based showcase"`
-	Form      *int16 `json:"form" doc:"Showcase focus pokemon form (0 is a valid form); null for a type-based showcase"`
-	TypeId    *int8  `json:"type_id" doc:"Showcase focus pokemon type id (type-based showcases); null for a pokemon-based showcase"`
+	PokemonId     *int16            `json:"pokemon_id" doc:"Legacy showcase focus pokemon id; null for a type-based or non-pokemon showcase"`
+	Form          *int16            `json:"form" doc:"Legacy showcase focus pokemon form (0 is valid); null for a type-based or non-pokemon showcase"`
+	TypeId        *int8             `json:"type_id" doc:"Legacy showcase focus pokemon type id; null for a pokemon-based or other showcase"`
+	ShowcaseFocus *ApiShowcaseFocus `json:"showcase_focus" nullable:"true" doc:"Structured showcase focus as a native JSON object; null only for legacy rows without showcase_focus"`
 }
 
 // ApiAvailablePokestops is the whole-instance snapshot served by
 // GET /api/pokestop/available.
 type ApiAvailablePokestops struct {
-	Quests    []ApiPokestopQuestAvailable    `json:"quests" doc:"Distinct quest reward + title/target options currently offered"`
-	Invasions []ApiPokestopInvasionAvailable `json:"invasions" doc:"Distinct active invasion signatures"`
-	Lures     []ApiPokestopLureAvailable     `json:"lures" doc:"Distinct active lure module ids"`
-	Showcases []ApiPokestopShowcaseAvailable `json:"showcases" doc:"Distinct active showcase focus pokemon/type"`
+	ShowcaseFocusFilter bool                           `json:"showcase_focus_filter" doc:"True when contest_focus Buddy selectors are supported by fort scans before the result cap"`
+	Quests              []ApiPokestopQuestAvailable    `json:"quests" doc:"Distinct quest reward + title/target options currently offered"`
+	Invasions           []ApiPokestopInvasionAvailable `json:"invasions" doc:"Distinct active invasion signatures"`
+	Lures               []ApiPokestopLureAvailable     `json:"lures" doc:"Distinct active lure module ids"`
+	Showcases           []ApiPokestopShowcaseAvailable `json:"showcases" doc:"Distinct active showcase focuses"`
 }
 
 // buildAvailablePokestops assembles the pokestop availability snapshot from
@@ -66,10 +69,11 @@ type ApiAvailablePokestops struct {
 // combined log line instead of logging again here).
 func buildAvailablePokestops(now int64) *ApiAvailablePokestops {
 	res := &ApiAvailablePokestops{
-		Quests:    []ApiPokestopQuestAvailable{},
-		Invasions: readInvasions(now),
-		Lures:     readLures(now),
-		Showcases: readShowcases(now),
+		ShowcaseFocusFilter: true,
+		Quests:              []ApiPokestopQuestAvailable{},
+		Invasions:           readInvasions(now),
+		Lures:               readLures(now),
+		Showcases:           readShowcases(now),
 	}
 	for _, c := range GetAvailableQuestConditions() {
 		res.Quests = append(res.Quests, ApiPokestopQuestAvailable(c))

--- a/decoder/api_pokestop_available_test.go
+++ b/decoder/api_pokestop_available_test.go
@@ -1,6 +1,9 @@
 package decoder
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 // TestGetAvailablePokestops seeds the maintained lure/showcase/invasion maps
 // via the observe hooks (not fortLookupCache — GetAvailablePokestops no
@@ -15,11 +18,14 @@ func TestGetAvailablePokestops(t *testing.T) {
 	observePokestop(&FortLookup{
 		LureId: 501, LureExpireTimestamp: now + 100,
 		ContestPokemonId: 1, ShowcaseExpiry: now - 1, // expired -> excluded
-	}, now)
+	}, nil, now)
 	// active grunt incident
 	observeInvasion(&FortLookupIncident{DisplayType: 1, Character: 5, Confirmed: true, Slot1PokemonId: 41, ExpireTimestamp: now + 100}, now)
 
 	res := GetAvailablePokestops(now)
+	if !res.ShowcaseFocusFilter {
+		t.Fatal("showcase_focus_filter capability must be true even when no showcases are active")
+	}
 	if len(res.Lures) != 1 || res.Lures[0].LureId != 501 {
 		t.Fatalf("lure: %+v", res.Lures)
 	}
@@ -31,5 +37,17 @@ func TestGetAvailablePokestops(t *testing.T) {
 	}
 	if len(res.Invasions) != 1 || res.Invasions[0].Character != 5 {
 		t.Fatalf("invasion: %+v", res.Invasions)
+	}
+
+	raw, err := json.Marshal(res)
+	if err != nil {
+		t.Fatalf("marshal availability: %v", err)
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode availability: %v", err)
+	}
+	if got := string(body["showcase_focus_filter"]); got != "true" {
+		t.Fatalf("showcase_focus_filter wire value = %s, want true", got)
 	}
 }

--- a/decoder/api_showcase_focus.go
+++ b/decoder/api_showcase_focus.go
@@ -1,0 +1,95 @@
+package decoder
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// ApiShowcaseFocus is the canonical JSON representation Golbat persists for a
+// showcase focus. It remains a comparable string internally so the maintained
+// availability index can use it as a key, while MarshalJSON exposes the focus
+// as a native object on the API.
+type ApiShowcaseFocus string
+
+// MarshalJSON emits the canonical focus object rather than a quoted JSON
+// string. ApiShowcaseFocus values are created by parseShowcaseFocus, but keep a
+// validity check here so a zero or manually-constructed invalid value can never
+// corrupt an API response.
+func (f ApiShowcaseFocus) MarshalJSON() ([]byte, error) {
+	if f == "" {
+		return []byte("null"), nil
+	}
+	raw := []byte(f)
+	if !json.Valid(raw) || raw[0] != '{' {
+		return nil, fmt.Errorf("showcase focus must be a JSON object")
+	}
+	return raw, nil
+}
+
+// Schema documents the stored flat focus object. Different contest focus
+// types carry different attributes, so additional properties are intentional.
+func (ApiShowcaseFocus) Schema(huma.Registry) *huma.Schema {
+	return &huma.Schema{
+		Type:                 huma.TypeObject,
+		Description:          "Structured showcase focus. For Buddy showcases, type is buddy and min_level is the required Buddy level.",
+		AdditionalProperties: true,
+		Properties: map[string]*huma.Schema{
+			"type": {
+				Type:        huma.TypeString,
+				Description: "Focus type (pokemon, type, alignment, class, family, buddy, generation, hatched, mega, or shiny)",
+			},
+			"min_level": {
+				Type:        huma.TypeInteger,
+				Format:      "int32",
+				Description: "Minimum Buddy level when type is buddy",
+			},
+		},
+		Required: []string{"type"},
+		Examples: []any{
+			map[string]any{"type": "buddy", "min_level": 3},
+		},
+	}
+}
+
+// parseShowcaseFocus validates and canonicalizes the stored focus once when a
+// Pokestop enters the fort lookup. The returned Buddy projection is the only
+// focus data needed on the hot scan path; the canonical object is retained only
+// by the much smaller active-showcase availability index.
+func parseShowcaseFocus(raw string) (*ApiShowcaseFocus, int8, error) {
+	var value map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &value); err != nil {
+		return nil, 0, fmt.Errorf("decode showcase focus: %w", err)
+	}
+	if value == nil {
+		return nil, 0, fmt.Errorf("showcase focus must be an object")
+	}
+
+	var focusType string
+	if typeRaw, ok := value["type"]; !ok {
+		return nil, 0, fmt.Errorf("showcase focus is missing type")
+	} else if err := json.Unmarshal(typeRaw, &focusType); err != nil || focusType == "" {
+		return nil, 0, fmt.Errorf("showcase focus type must be a non-empty string")
+	}
+
+	canonical, err := json.Marshal(value)
+	if err != nil {
+		return nil, 0, fmt.Errorf("encode showcase focus: %w", err)
+	}
+	focus := ApiShowcaseFocus(canonical)
+
+	if contestFocusType(focusType) != focusBuddy {
+		return &focus, 0, nil
+	}
+
+	var minLevel int8
+	levelRaw, ok := value["min_level"]
+	if !ok {
+		return nil, 0, fmt.Errorf("buddy showcase focus is missing min_level")
+	}
+	if err := json.Unmarshal(levelRaw, &minLevel); err != nil || minLevel <= 0 {
+		return nil, 0, fmt.Errorf("buddy showcase min_level must be a positive int8")
+	}
+	return &focus, minLevel, nil
+}

--- a/decoder/api_showcase_focus_test.go
+++ b/decoder/api_showcase_focus_test.go
@@ -1,0 +1,72 @@
+package decoder
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParseShowcaseFocusCanonicalizesAndProjectsBuddyLevel(t *testing.T) {
+	focus, level, err := parseShowcaseFocus(`{ "type": "buddy", "min_level": 3 }`)
+	if err != nil {
+		t.Fatalf("parse focus: %v", err)
+	}
+	if level != 3 {
+		t.Fatalf("Buddy level = %d, want 3", level)
+	}
+	if got, want := string(*focus), `{"min_level":3,"type":"buddy"}`; got != want {
+		t.Fatalf("canonical focus = %s, want %s", got, want)
+	}
+
+	reordered, reorderedLevel, err := parseShowcaseFocus(`{"min_level":3,"type":"buddy"}`)
+	if err != nil {
+		t.Fatalf("parse reordered focus: %v", err)
+	}
+	if *reordered != *focus || reorderedLevel != level {
+		t.Fatalf("equivalent objects diverged: (%s, %d) vs (%s, %d)", *focus, level, *reordered, reorderedLevel)
+	}
+
+	raw, err := json.Marshal(focus)
+	if err != nil {
+		t.Fatalf("marshal focus: %v", err)
+	}
+	if len(raw) == 0 || raw[0] != '{' || strings.Contains(string(raw), `"{\"`) {
+		t.Fatalf("focus must marshal as a native object, got %s", raw)
+	}
+}
+
+func TestParseShowcaseFocusPreservesNonBuddyFocus(t *testing.T) {
+	focus, level, err := parseShowcaseFocus(`{"pokemon_id":25,"type":"pokemon"}`)
+	if err != nil {
+		t.Fatalf("parse focus: %v", err)
+	}
+	if focus == nil || level != 0 {
+		t.Fatalf("non-Buddy focus = (%v, %d), want a focus with no Buddy projection", focus, level)
+	}
+}
+
+func TestParseShowcaseFocusRejectsMalformedValues(t *testing.T) {
+	tests := map[string]string{
+		"invalid JSON":        `{`,
+		"null":                `null`,
+		"array":               `[]`,
+		"missing type":        `{"min_level":3}`,
+		"non-string type":     `{"type":3,"min_level":3}`,
+		"missing Buddy level": `{"type":"buddy"}`,
+		"zero Buddy level":    `{"type":"buddy","min_level":0}`,
+		"fractional level":    `{"type":"buddy","min_level":3.5}`,
+	}
+	for name, raw := range tests {
+		t.Run(name, func(t *testing.T) {
+			if focus, _, err := parseShowcaseFocus(raw); err == nil || focus != nil {
+				t.Fatalf("parseShowcaseFocus(%s) = (%v, %v), want nil + error", raw, focus, err)
+			}
+		})
+	}
+}
+
+func TestPokestopSelectColumnsIncludesShowcaseFocus(t *testing.T) {
+	if !strings.Contains(pokestopSelectColumns, "description, showcase_focus, showcase_pokemon_id") {
+		t.Fatalf("pokestopSelectColumns must load showcase_focus for cache misses and preload: %s", pokestopSelectColumns)
+	}
+}

--- a/decoder/fortRtree.go
+++ b/decoder/fortRtree.go
@@ -48,10 +48,11 @@ type FortLookup struct {
 	Incidents []FortLookupIncident
 
 	// Pokestop - contest
-	ContestPokemonId   int16
-	ContestPokemonForm int16
-	ContestPokemonType int8
-	ShowcaseExpiry     int64 // used to check expiry at filter time
+	ContestPokemonId      int16
+	ContestPokemonForm    int16
+	ContestPokemonType    int8
+	ShowcaseBuddyMinLevel int8
+	ShowcaseExpiry        int64 // used to check expiry at filter time
 
 	// Station
 	StationEndTimestamp int64 // station end_time; liveness gate at filter time
@@ -184,6 +185,16 @@ func fortRtreeUpdateStationOnGet(station *Station) {
 }
 
 func updatePokestopLookup(pokestop *Pokestop) {
+	var showcaseFocus *ApiShowcaseFocus
+	var showcaseBuddyMinLevel int8
+	if pokestop.ShowcaseFocus.Valid {
+		var err error
+		showcaseFocus, showcaseBuddyMinLevel, err = parseShowcaseFocus(pokestop.ShowcaseFocus.ValueOrZero())
+		if err != nil {
+			log.Warnf("SHOWCASE: Stop '%s' - Invalid showcase_focus: %v", pokestop.Id, err)
+		}
+	}
+
 	// Atomic per-key read-modify-write via Compute: this writer (under the
 	// POKESTOP entity lock) and updatePokestopIncidentLookup (under the
 	// INCIDENT entity lock) update the same key from different lock domains,
@@ -211,6 +222,7 @@ func updatePokestopLookup(pokestop *Pokestop) {
 			ContestPokemonId:           int16(pokestop.ShowcasePokemon.ValueOrZero()),
 			ContestPokemonForm:         int16(pokestop.ShowcasePokemonForm.ValueOrZero()),
 			ContestPokemonType:         int8(pokestop.ShowcasePokemonType.ValueOrZero()),
+			ShowcaseBuddyMinLevel:      showcaseBuddyMinLevel,
 			ShowcaseExpiry:             pokestop.ShowcaseExpiry.ValueOrZero(),
 		}
 		if loaded {
@@ -220,13 +232,14 @@ func updatePokestopLookup(pokestop *Pokestop) {
 	})
 
 	observePokestop(&FortLookup{
-		LureId:              pokestop.LureId,
-		LureExpireTimestamp: pokestop.LureExpireTimestamp.ValueOrZero(),
-		ContestPokemonId:    int16(pokestop.ShowcasePokemon.ValueOrZero()),
-		ContestPokemonForm:  int16(pokestop.ShowcasePokemonForm.ValueOrZero()),
-		ContestPokemonType:  int8(pokestop.ShowcasePokemonType.ValueOrZero()),
-		ShowcaseExpiry:      pokestop.ShowcaseExpiry.ValueOrZero(),
-	}, time.Now().Unix())
+		LureId:                pokestop.LureId,
+		LureExpireTimestamp:   pokestop.LureExpireTimestamp.ValueOrZero(),
+		ContestPokemonId:      int16(pokestop.ShowcasePokemon.ValueOrZero()),
+		ContestPokemonForm:    int16(pokestop.ShowcasePokemonForm.ValueOrZero()),
+		ContestPokemonType:    int8(pokestop.ShowcasePokemonType.ValueOrZero()),
+		ShowcaseBuddyMinLevel: showcaseBuddyMinLevel,
+		ShowcaseExpiry:        pokestop.ShowcaseExpiry.ValueOrZero(),
+	}, showcaseFocus, time.Now().Unix())
 
 	// This is the sole writer of a pokestop's FortLookup entry, so it is also
 	// the single place quest-condition counts are reconciled: it fires on

--- a/decoder/fort_availability.go
+++ b/decoder/fort_availability.go
@@ -15,6 +15,7 @@ type showcaseKey struct {
 	PokemonId int16
 	Form      int16
 	TypeId    int8
+	Focus     ApiShowcaseFocus
 }
 
 type invasionKey struct {
@@ -157,16 +158,22 @@ func readBattles(now int64) []ApiStationBattleAvailable {
 }
 
 // observePokestop records the lure and showcase options active on a pokestop.
-// LureId 0 means no lure; ContestPokemonId 0 means no active showcase — both
-// are gated here since observeExpiry only gates on expiry, not these sentinels.
-func observePokestop(fl *FortLookup, now int64) {
+// LureId 0 means no lure. A showcase requires either a structured focus or one
+// of the legacy pokemon/type mirrors; those sentinels are gated here because
+// observeExpiry itself only checks expiry.
+func observePokestop(fl *FortLookup, focus *ApiShowcaseFocus, now int64) {
 	if fl.LureId != 0 {
 		observeExpiry(lureExpiry, fl.LureId, fl.LureExpireTimestamp, now)
 	}
-	// A showcase is either pokemon-based (ContestPokemonId) or type-based
-	// (ContestPokemonType, pokemon id 0 -> consumer key `h<type>`); surface both.
-	if fl.ContestPokemonId != 0 || fl.ContestPokemonType != 0 {
-		observeExpiry(showcaseExpiry, showcaseKey{fl.ContestPokemonId, fl.ContestPokemonForm, fl.ContestPokemonType}, fl.ShowcaseExpiry, now)
+	// Modern focuses are indexed directly. Keep the legacy pokemon/type mirrors
+	// for old rows and consumers; Buddy focuses intentionally have all three
+	// legacy values unset.
+	if focus != nil || fl.ContestPokemonId != 0 || fl.ContestPokemonType != 0 {
+		key := showcaseKey{PokemonId: fl.ContestPokemonId, Form: fl.ContestPokemonForm, TypeId: fl.ContestPokemonType}
+		if focus != nil {
+			key.Focus = *focus
+		}
+		observeExpiry(showcaseExpiry, key, fl.ShowcaseExpiry, now)
 	}
 }
 
@@ -186,17 +193,20 @@ func readLures(now int64) []ApiPokestopLureAvailable {
 
 func readShowcases(now int64) []ApiPokestopShowcaseAvailable {
 	return readAvailable(showcaseExpiry, now, func(k showcaseKey) ApiPokestopShowcaseAvailable {
-		// A showcase is exactly one of pokemon-based or type-based (observePokestop
-		// gates on ContestPokemonId != 0 || ContestPokemonType != 0). Mirror the DB:
-		// pokemon-based -> pokemon/form set, type null; type-based -> pokemon/form
-		// null, type set.
+		// Reverse the nullable legacy tuple while also returning the structured
+		// focus when the source row carried one.
 		id, form := nullablePokemonForm(k.PokemonId, k.Form)
 		var typeId *int8
 		if k.TypeId != 0 {
 			t := k.TypeId
 			typeId = &t
 		}
-		return ApiPokestopShowcaseAvailable{PokemonId: id, Form: form, TypeId: typeId}
+		var focus *ApiShowcaseFocus
+		if k.Focus != "" {
+			f := k.Focus
+			focus = &f
+		}
+		return ApiPokestopShowcaseAvailable{PokemonId: id, Form: form, TypeId: typeId, ShowcaseFocus: focus}
 	})
 }
 

--- a/decoder/fort_availability_hooks_test.go
+++ b/decoder/fort_availability_hooks_test.go
@@ -128,6 +128,43 @@ func TestUpdatePokestopLookupHookWiresLureAndShowcaseAvailability(t *testing.T) 
 	}
 }
 
+func TestUpdatePokestopLookupHookWiresBuddyShowcaseFocus(t *testing.T) {
+	initFortAvailability()
+	initQuestConditions()
+	now := time.Now().Unix()
+
+	stop := &Pokestop{PokestopData: PokestopData{
+		Id:             "hook-stop-buddy-showcase",
+		Lat:            1,
+		Lon:            2,
+		ShowcaseFocus:  null.StringFrom(`{"type":"buddy","min_level":3}`),
+		ShowcaseExpiry: null.IntFrom(now + 1800),
+	}}
+	updatePokestopLookup(stop)
+
+	lookup, ok := fortLookupCache.Load(stop.Id)
+	if !ok || lookup.ShowcaseBuddyMinLevel != 3 {
+		t.Fatalf("FortLookup Buddy projection = %+v, want min level 3", lookup)
+	}
+
+	want, _, err := parseShowcaseFocus(stop.ShowcaseFocus.String)
+	if err != nil {
+		t.Fatalf("parse expected focus: %v", err)
+	}
+	found := false
+	for _, showcase := range GetAvailablePokestops(now).Showcases {
+		if showcase.ShowcaseFocus != nil && *showcase.ShowcaseFocus == *want {
+			found = true
+			if showcase.PokemonId != nil || showcase.Form != nil || showcase.TypeId != nil {
+				t.Fatalf("Buddy focus should not require legacy mirrors: %+v", showcase)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected Buddy focus from updatePokestopLookup to surface via availability")
+	}
+}
+
 // TestUpdatePokestopIncidentLookupHookWiresInvasionAvailability must fail if
 // updatePokestopIncidentLookup's observeInvasion(...) call is removed. The
 // pokestop's FortLookup is seeded resident first (as fort_incident_id_test.go

--- a/decoder/fort_availability_test.go
+++ b/decoder/fort_availability_test.go
@@ -1,6 +1,9 @@
 package decoder
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestObserveExpiryAndReadRaids(t *testing.T) {
 	initFortAvailability()
@@ -80,11 +83,11 @@ func TestObservePokestopAggregatesAndRead(t *testing.T) {
 	observePokestop(&FortLookup{
 		LureId: 501, LureExpireTimestamp: 2000,
 		ContestPokemonId: 25, ContestPokemonForm: 0, ContestPokemonType: 0, ShowcaseExpiry: 2000,
-	}, now)
+	}, nil, now)
 	// type-based showcase (pokemon id 0, type set) -> must also surface
-	observePokestop(&FortLookup{ContestPokemonId: 0, ContestPokemonType: 12, ShowcaseExpiry: 2000}, now)
+	observePokestop(&FortLookup{ContestPokemonId: 0, ContestPokemonType: 12, ShowcaseExpiry: 2000}, nil, now)
 	// expired lure + no showcase (all zero) -> both ignored
-	observePokestop(&FortLookup{LureId: 502, LureExpireTimestamp: 500}, now)
+	observePokestop(&FortLookup{LureId: 502, LureExpireTimestamp: 500}, nil, now)
 
 	// invasions (per incident) — confirmed lineup carries all three slots
 	observeInvasion(&FortLookupIncident{Character: 5, DisplayType: 1, Confirmed: true, Slot1PokemonId: 41, Slot2PokemonId: 42, Slot2Form: 1, Slot3PokemonId: 43, ExpireTimestamp: 2000}, now)
@@ -131,5 +134,90 @@ func TestObservePokestopAggregatesAndRead(t *testing.T) {
 	// everything expires
 	if len(readLures(3000)) != 0 || len(readShowcases(3000)) != 0 || len(readInvasions(3000)) != 0 {
 		t.Fatal("all pokestop aggregates should expire to empty")
+	}
+}
+
+func TestObserveBuddyShowcaseFocusAndRead(t *testing.T) {
+	initFortAvailability()
+	now := int64(1000)
+	good, _, err := parseShowcaseFocus(`{"type":"buddy","min_level":2}`)
+	if err != nil {
+		t.Fatalf("parse Good Buddy focus: %v", err)
+	}
+	great, _, err := parseShowcaseFocus(`{"min_level":3,"type":"buddy"}`)
+	if err != nil {
+		t.Fatalf("parse Great Buddy focus: %v", err)
+	}
+
+	// Buddy showcases have no legacy pokemon/type mirrors. Re-observing Good
+	// Buddy with a later expiry must coalesce into the same availability key.
+	observePokestop(&FortLookup{ShowcaseExpiry: 1500}, good, now)
+	observePokestop(&FortLookup{ShowcaseExpiry: 2500}, good, now)
+	observePokestop(&FortLookup{ShowcaseExpiry: 2000}, great, now)
+
+	got := readShowcases(now)
+	if len(got) != 2 {
+		t.Fatalf("want distinct Good + Great Buddy focuses, got %d: %+v", len(got), got)
+	}
+	seen := map[ApiShowcaseFocus]bool{}
+	for _, sc := range got {
+		if sc.PokemonId != nil || sc.Form != nil || sc.TypeId != nil || sc.ShowcaseFocus == nil {
+			t.Fatalf("Buddy availability should have only structured focus, got %+v", sc)
+		}
+		seen[*sc.ShowcaseFocus] = true
+	}
+	if !seen[*good] || !seen[*great] {
+		t.Fatalf("missing Good or Great Buddy focus: %+v", got)
+	}
+
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal showcases: %v", err)
+	}
+	var decoded []struct {
+		ShowcaseFocus json.RawMessage `json:"showcase_focus"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("decode showcases: %v", err)
+	}
+	for _, sc := range decoded {
+		if len(sc.ShowcaseFocus) == 0 || sc.ShowcaseFocus[0] != '{' {
+			t.Fatalf("showcase_focus must be a native object, got %s", sc.ShowcaseFocus)
+		}
+	}
+
+	// The later Good observation survives its first expiry; Great does not.
+	remaining := readShowcases(2200)
+	if len(remaining) != 1 || remaining[0].ShowcaseFocus == nil || *remaining[0].ShowcaseFocus != *good {
+		t.Fatalf("coalesced Good Buddy focus should remain after Great expires: %+v", remaining)
+	}
+	if len(readShowcases(3000)) != 0 {
+		t.Fatal("all Buddy showcases should expire")
+	}
+}
+
+func TestModernPokemonShowcasePreservesLegacyMirrors(t *testing.T) {
+	initFortAvailability()
+	now := int64(1000)
+	focus, _, err := parseShowcaseFocus(`{"type":"pokemon","pokemon_id":25,"pokemon_form":0}`)
+	if err != nil {
+		t.Fatalf("parse Pokemon focus: %v", err)
+	}
+	observePokestop(&FortLookup{
+		ContestPokemonId:   25,
+		ContestPokemonForm: 0,
+		ShowcaseExpiry:     2000,
+	}, focus, now)
+
+	got := readShowcases(now)
+	if len(got) != 1 {
+		t.Fatalf("want one Pokemon showcase, got %+v", got)
+	}
+	showcase := got[0]
+	if showcase.PokemonId == nil || *showcase.PokemonId != 25 || showcase.Form == nil || *showcase.Form != 0 || showcase.TypeId != nil {
+		t.Fatalf("legacy Pokemon/form mirrors changed: %+v", showcase)
+	}
+	if showcase.ShowcaseFocus == nil || *showcase.ShowcaseFocus != *focus {
+		t.Fatalf("structured focus missing from modern Pokemon showcase: %+v", showcase)
 	}
 }

--- a/decoder/fort_expiry_test.go
+++ b/decoder/fort_expiry_test.go
@@ -27,3 +27,33 @@ func TestFortDnfMatch_ShowcaseExpiry(t *testing.T) {
 		t.Fatal("expired showcase should NOT match")
 	}
 }
+
+func TestFortDnfMatch_BuddyShowcaseFocus(t *testing.T) {
+	now := int64(1_000_000)
+	good := int8(2)
+	great := int8(3)
+	active := &FortLookup{FortType: POKESTOP, ShowcaseBuddyMinLevel: great, ShowcaseExpiry: now + 100}
+	expired := &FortLookup{FortType: POKESTOP, ShowcaseBuddyMinLevel: great, ShowcaseExpiry: now - 100}
+
+	if !isFortDnfMatch(POKESTOP, active, &ApiFortDnfFilter{}, now) {
+		t.Fatal("omitted contest_focus should not constrain the showcase")
+	}
+	if isFortDnfMatch(POKESTOP, active, &ApiFortDnfFilter{ContestFocus: []ApiFortDnfContestFocus{}}, now) {
+		t.Fatal("explicitly empty contest_focus should match nothing")
+	}
+	if !isFortDnfMatch(POKESTOP, active, &ApiFortDnfFilter{ContestFocus: []ApiFortDnfContestFocus{{Type: "buddy", MinLevel: &great}}}, now) {
+		t.Fatal("active Great Buddy showcase should match its exact focus")
+	}
+	if isFortDnfMatch(POKESTOP, active, &ApiFortDnfFilter{ContestFocus: []ApiFortDnfContestFocus{{Type: "buddy", MinLevel: &good}}}, now) {
+		t.Fatal("Great Buddy showcase must not match a Good Buddy selector")
+	}
+	if isFortDnfMatch(POKESTOP, active, &ApiFortDnfFilter{ContestFocus: []ApiFortDnfContestFocus{{Type: "buddy"}}}, now) {
+		t.Fatal("Buddy selector without min_level must match nothing")
+	}
+	if isFortDnfMatch(POKESTOP, active, &ApiFortDnfFilter{ContestFocus: []ApiFortDnfContestFocus{{Type: "pokemon", MinLevel: &great}}}, now) {
+		t.Fatal("unsupported focus types must match nothing")
+	}
+	if isFortDnfMatch(POKESTOP, expired, &ApiFortDnfFilter{ContestFocus: []ApiFortDnfContestFocus{{Type: "buddy", MinLevel: &great}}}, now) {
+		t.Fatal("expired Buddy showcase must not match")
+	}
+}

--- a/decoder/pokestop_state.go
+++ b/decoder/pokestop_state.go
@@ -30,7 +30,7 @@ const pokestopSelectColumns = `id, lat, lon, name, url, enabled, lure_expire_tim
 	alternative_quest_pokemon_id, alternative_quest_pokemon_form_id,
 	cell_id, deleted, lure_id, sponsor_id, partner_id,
 	ar_scan_eligible, power_up_points, power_up_level, power_up_end_timestamp,
-	description, showcase_pokemon_id, showcase_pokemon_form_id,
+	description, showcase_focus, showcase_pokemon_id, showcase_pokemon_form_id,
 	showcase_pokemon_type_id, showcase_ranking_standard, showcase_expiry, showcase_rankings`
 
 func loadPokestopFromDatabase(ctx context.Context, db db.DbDetails, fortId string, pokestop *Pokestop) error {

--- a/huma_api_test.go
+++ b/huma_api_test.go
@@ -169,7 +169,10 @@ func TestScanRequestRequiredFields(t *testing.T) {
 	var doc struct {
 		Components struct {
 			Schemas map[string]struct {
-				Required []string `json:"required"`
+				Required   []string `json:"required"`
+				Properties map[string]struct {
+					Type any `json:"type"`
+				} `json:"properties"`
 			} `json:"schemas"`
 		} `json:"components"`
 	}
@@ -223,6 +226,15 @@ func TestScanRequestRequiredFields(t *testing.T) {
 	wantExactly("ApiPokemonDnfId", "id")
 	// Fort ranges mirror the pokemon ranges.
 	wantExactly("ApiFortDnfMinMax")
+	wantExactly("ApiFortDnfFilter")
+	// Structured focus clauses require a type; min_level remains optional so
+	// future non-Buddy focus types can reuse the object.
+	wantExactly("ApiFortDnfContestFocus", "type")
+	showcaseFocusType := doc.Components.Schemas["ApiPokestopShowcaseAvailable"].Properties["showcase_focus"].Type
+	types, ok := showcaseFocusType.([]any)
+	if !ok || len(types) != 2 || types[0] != "object" || types[1] != "null" {
+		t.Errorf("ApiPokestopShowcaseAvailable.showcase_focus type = %v, want [object null]", showcaseFocusType)
+	}
 	// Gym search: limit and every filter field are optional (each filter field is
 	// an independent alternative); the handler enforces "at least one filter".
 	wantExactly("ApiGymSearch")

--- a/huma_routes_test.go
+++ b/huma_routes_test.go
@@ -322,6 +322,50 @@ func TestFortScanEndpoints(t *testing.T) {
 		}
 	})
 
+	t.Run("structured Buddy focus binds on pokestop scan", func(t *testing.T) {
+		body := `{"min":{"lat":0,"lon":0},"max":{"lat":1,"lon":1},"filters":[{"contest_focus":[{"type":"buddy","min_level":3}]}]}`
+		resp := api.Post("/api/pokestop/scan", strings.NewReader(body))
+		if resp.Code != http.StatusOK {
+			t.Fatalf("got %d, want 200; body=%s", resp.Code, resp.Body.String())
+		}
+	})
+
+	t.Run("structured Buddy focus binds on combined scan", func(t *testing.T) {
+		body := `{"min":{"lat":0,"lon":0},"max":{"lat":1,"lon":1},"pokestops":{"filters":[{"contest_focus":[{"type":"buddy","min_level":3}]}]}}`
+		resp := api.Post("/api/fort/scan", strings.NewReader(body))
+		if resp.Code != http.StatusOK {
+			t.Fatalf("got %d, want 200; body=%s", resp.Code, resp.Body.String())
+		}
+	})
+
+	t.Run("availability advertises showcase focus filtering", func(t *testing.T) {
+		resp := api.Get("/api/pokestop/available")
+		if resp.Code != http.StatusOK {
+			t.Fatalf("pokestop availability got %d, want 200; body=%s", resp.Code, resp.Body.String())
+		}
+		var pokestops map[string]any
+		if err := gojson.Unmarshal(resp.Body.Bytes(), &pokestops); err != nil {
+			t.Fatalf("decode pokestop availability: %v", err)
+		}
+		if supported, ok := pokestops["showcase_focus_filter"].(bool); !ok || !supported {
+			t.Fatalf("pokestop availability capability = %v, want true", pokestops["showcase_focus_filter"])
+		}
+
+		resp = api.Get("/api/fort/available")
+		if resp.Code != http.StatusOK {
+			t.Fatalf("fort availability got %d, want 200; body=%s", resp.Code, resp.Body.String())
+		}
+		var forts struct {
+			Pokestops map[string]any `json:"pokestops"`
+		}
+		if err := gojson.Unmarshal(resp.Body.Bytes(), &forts); err != nil {
+			t.Fatalf("decode fort availability: %v", err)
+		}
+		if supported, ok := forts.Pokestops["showcase_focus_filter"].(bool); !ok || !supported {
+			t.Fatalf("nested pokestop capability = %v, want true", forts.Pokestops["showcase_focus_filter"])
+		}
+	})
+
 	t.Run("503 when fort_in_memory disabled", func(t *testing.T) {
 		config.Config.FortInMemory = false
 		defer func() { config.Config.FortInMemory = true }()


### PR DESCRIPTION
## Summary

- add an exact Buddy Showcase `contest_focus` selector to Pokéstop and combined fort-scan DNF filters
- apply the structured focus predicate before `max_fort_results`, so unrelated Showcases cannot consume the endpoint cap
- expose active `showcase_focus` values as native JSON objects and advertise `showcase_focus_filter: true` through both availability endpoints
- load `showcase_focus` during cache-miss/startup population and keep only a compact Buddy-level projection in the hot fort lookup

Example filter:

```json
{
  "contest_focus": [
    {
      "type": "buddy",
      "min_level": 3
    }
  ]
}
```

## Compatibility

- existing `contest_pokemon` and `contest_pokemon_type` filters are unchanged
- existing availability `pokemon_id`, `form`, and `type_id` mirrors remain available
- legacy rows without structured focus return `showcase_focus: null`
- the existing per-stop `showcase_focus` wire representation is unchanged
- clients can treat a missing or false `showcase_focus_filter` capability as an older Golbat

Related to WatWowMap/ReactMap#1090.

## Verification

- `go test -tags go_json ./...`
- `go build -tags go_json ./...`
- focused `go test -race ./decoder/` coverage for parsing, indexing, DNF matching, cap ordering, and availability
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — 0 issues
- `git diff --check origin/main...HEAD`