### PR TITLE
Do not index deleted forts loaded from the database

### DIFF
--- a/decoder/fortRtree.go
+++ b/decoder/fortRtree.go
@@ -158,6 +158,14 @@ func fortRtreeUpdateStationOnSave(station *Station) {
 
 // fortRtreeUpdatePokestopOnGet updates rtree when a pokestop is loaded from DB (cache miss)
 func fortRtreeUpdatePokestopOnGet(pokestop *Pokestop) {
+	// A deleted row still carries its enabled flag and quest fields, and the
+	// load-by-id query has no deleted filter, so indexing one here would put a
+	// deleted fort into the lookup cache and the tree as a live fort, where
+	// fort scans would return it. The save path already skips deleted forts;
+	// match it.
+	if pokestop.Deleted {
+		return
+	}
 	_, inMap := fortLookupCache.Load(pokestop.Id)
 	if !inMap {
 		addFortToTree(pokestop.Id, pokestop.Lat, pokestop.Lon)
@@ -167,6 +175,10 @@ func fortRtreeUpdatePokestopOnGet(pokestop *Pokestop) {
 
 // fortRtreeUpdateGymOnGet updates rtree when a gym is loaded from DB (cache miss)
 func fortRtreeUpdateGymOnGet(gym *Gym) {
+	// See fortRtreeUpdatePokestopOnGet.
+	if gym.Deleted {
+		return
+	}
 	_, inMap := fortLookupCache.Load(gym.Id)
 	if !inMap {
 		addFortToTree(gym.Id, gym.Lat, gym.Lon)

--- a/decoder/fortRtree_deleted_test.go
+++ b/decoder/fortRtree_deleted_test.go
@@ -1,0 +1,58 @@
+package decoder
+
+import (
+	"testing"
+
+	"github.com/guregu/null/v6"
+
+	"golbat/config"
+)
+
+// TestDeletedFortsNotIndexedOnLoad locks that a fort already marked deleted is
+// not indexed when it reaches the cache-miss load path. The load-by-id queries
+// have no deleted filter, and deletion leaves enabled and the quest fields
+// intact, so an indexed deleted fort would be returned by fort scans.
+func TestDeletedFortsNotIndexedOnLoad(t *testing.T) {
+	prev := config.Config.FortInMemory
+	config.Config.FortInMemory = true
+	t.Cleanup(func() { config.Config.FortInMemory = prev })
+
+	t.Run("pokestop", func(t *testing.T) {
+		const id = "deleted-pokestop-on-load"
+		t.Cleanup(func() { fortLookupCache.Delete(id) })
+
+		fortRtreeUpdatePokestopOnGet(&Pokestop{PokestopData: PokestopData{
+			Id: id, Lat: 5, Lon: 5, Enabled: null.BoolFrom(true), Deleted: true,
+		}})
+
+		if _, found := fortLookupCache.Load(id); found {
+			t.Fatal("deleted pokestop was indexed into the fort lookup cache")
+		}
+	})
+
+	t.Run("gym", func(t *testing.T) {
+		const id = "deleted-gym-on-load"
+		t.Cleanup(func() { fortLookupCache.Delete(id) })
+
+		fortRtreeUpdateGymOnGet(&Gym{GymData: GymData{
+			Id: id, Lat: 6, Lon: 6, Deleted: true,
+		}})
+
+		if _, found := fortLookupCache.Load(id); found {
+			t.Fatal("deleted gym was indexed into the fort lookup cache")
+		}
+	})
+
+	t.Run("a live pokestop is still indexed", func(t *testing.T) {
+		const id = "live-pokestop-on-load"
+		t.Cleanup(func() { fortLookupCache.Delete(id) })
+
+		fortRtreeUpdatePokestopOnGet(&Pokestop{PokestopData: PokestopData{
+			Id: id, Lat: 7, Lon: 7, Enabled: null.BoolFrom(true),
+		}})
+
+		if _, found := fortLookupCache.Load(id); !found {
+			t.Fatal("live pokestop was not indexed, so the guard is too broad")
+		}
+	})
+}


### PR DESCRIPTION
This PR started as an in-memory rewrite of the geofence endpoints and has been reduced to the one bug it turned up along the way. The timeout it was chasing is fixed in #400 instead, on the database path, so nothing here depends on `fort_in_memory`.

## Problem

`fortRtreeUpdatePokestopOnGet` and `fortRtreeUpdateGymOnGet` index every fort they are handed. The load-by-id queries carry no `deleted` filter, and deleting a fort leaves `enabled` and the quest fields intact, so a deleted row arriving through the cache-miss path was added to the lookup cache and the fort tree as a live fort. `/api/pokestop/scan` and `/api/gym/scan` would then return it.

The save path (`fortRtreeUpdatePokestopOnSave` into `genericUpdateFort`) has always skipped deleted forts. The load path now matches it.

## Why the rest went away

The original approach walked the fort lookup index instead of querying the database, and measurement did not support it. Against 1,000,000 rows and a 2000-vertex fence, the in-memory walk and the database path spend most of their time in the same place: testing candidate points against the polygon. Moving that test out of SQL takes the query from 55 s to roughly 4 s, and the in-memory version saves only the second or so of query and transfer on top of that. The numbers are in #400.

That is not worth what it cost. Serving these endpoints from the index meant treating it as a census of the table, which it was not: the fort caches expire entries untouched for 25 to 27 hours and preload only runs at boot, so a region that stopped being scanned quietly dropped out of the answers. Keeping it complete meant holding every fort's index entry for the process lifetime, and the invariant had no test behind it. All of that to avoid a second of query time, on instances with `fort_in_memory` enabled and nowhere else.

@jfberry's read was right, and the database is the correct place for this. #400 keeps it there.

## Testing

`TestDeletedFortsNotIndexedOnLoad` covers a deleted pokestop, a deleted gym, and a live pokestop that must still be indexed so the guard cannot pass by rejecting everything. It fails with either guard removed.

`go build -tags go_json ./...` and `golangci-lint run` are clean, and the `decoder` and root suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
