### PR TITLE
fix: rebuild ohbem on masterfile reload instead of mutating the live instance

### DIFF
--- a/decoder/api_pokemon_response.go
+++ b/decoder/api_pokemon_response.go
@@ -130,12 +130,13 @@ func buildApiPokemonResult(pokemon *Pokemon) ApiPokemonResult {
 }
 
 // buildApiPvpRankings queries ohbem for PVP rankings. Returns a zero value when
-// PVP is disabled (ohbem == nil) or on query error.
+// PVP is disabled (no ohbem instance) or on query error.
 func buildApiPvpRankings(pokemon *Pokemon) ApiPvpRankings {
-	if ohbem == nil {
+	o := ohbem.Load()
+	if o == nil {
 		return ApiPvpRankings{}
 	}
-	pvp, err := ohbem.QueryPvPRank(int(pokemon.PokemonId),
+	pvp, err := o.QueryPvPRank(int(pokemon.PokemonId),
 		int(pokemon.Form.ValueOrZero()),
 		int(pokemon.Costume.ValueOrZero()),
 		int(pokemon.Gender.ValueOrZero()),
@@ -147,7 +148,7 @@ func buildApiPvpRankings(pokemon *Pokemon) ApiPvpRankings {
 		return ApiPvpRankings{}
 	}
 	// The hardcoded little/great/ultra keys correspond to the leagues configured
-	// in the ohbem init in decoder/main.go (~line 209). Adding a league there must
+	// in newOhbemInstance in decoder/main.go. Adding a league there must
 	// also be reflected here (and in the ApiPvpRankings struct).
 	return ApiPvpRankings{
 		Little: convertApiPvpEntries(pvp["little"]),

--- a/decoder/api_pokemon_response_test.go
+++ b/decoder/api_pokemon_response_test.go
@@ -105,7 +105,7 @@ func goldenSnapshotPokemon() *Pokemon {
 // by every pokemon endpoint (v1/v2/v3/search), so any accidental change to a json
 // tag, field type, pointer/null handling, or field order will fail this test.
 func TestBuildApiPokemonResult_GoldenSnapshot(t *testing.T) {
-	if ohbem != nil {
+	if ohbem.Load() != nil {
 		t.Fatalf("expected ohbem to be nil in tests")
 	}
 

--- a/decoder/main.go
+++ b/decoder/main.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"math/rand/v2"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/UnownHash/gohbem"
@@ -76,7 +77,12 @@ var getMapFortsCache *ottercache.OtterCache[string, *pogo.GetMapFortsOutProto_Fo
 
 var ProactiveIVSwitchSem chan bool
 
-var ohbem *gohbem.Ohbem
+// ohbem readers Load() once per operation and take no lock, so the instance
+// behind the pointer must never be mutated once published — gohbem's
+// LoadPokemonData unmarshals into the live masterfile maps in place, which
+// raced with QueryPvPRank as a fatal concurrent map read/write in production.
+// Reloads build a fresh instance and Store() it instead.
+var ohbem atomic.Pointer[gohbem.Ohbem]
 
 func init() {
 	// initLiveStats is config-independent, so package-init timing is fine.
@@ -234,34 +240,8 @@ func InitialiseOhbem() {
 			log.Errorf("PVP level caps not configured")
 			return
 		}
-		leagues := map[string]gohbem.League{
-			"little": {
-				Cap:            500,
-				LittleCupRules: false,
-			},
-			"great": {
-				Cap:            1500,
-				LittleCupRules: false,
-			},
-			"ultra": {
-				Cap:            2500,
-				LittleCupRules: false,
-			},
-		}
-
-		gohbemLogger := &gohbemLogger{}
 		cacheFileLocation := masterFileCachePath
-		o := &gohbem.Ohbem{Leagues: leagues, LevelCaps: config.Config.Pvp.LevelCaps,
-			IncludeHundosUnderCap: config.Config.Pvp.IncludeHundosUnderCap,
-			MasterFileCachePath:   cacheFileLocation, Logger: gohbemLogger}
-		switch config.Config.Pvp.RankingComparator {
-		case "prefer_higher_cp":
-			o.RankingComparator = gohbem.RankingComparatorPreferHigherCp
-		case "prefer_lower_cp":
-			o.RankingComparator = gohbem.RankingComparatorPreferLowerCp
-		default:
-			o.RankingComparator = gohbem.RankingComparatorDefault
-		}
+		o := newOhbemInstance()
 
 		if err := o.LoadPokemonData(cacheFileLocation); err != nil {
 			log.Warnf("ohbem.LoadPokemonData from cache failed: %v", err)
@@ -277,19 +257,52 @@ func InitialiseOhbem() {
 			}
 		}
 
-		ohbem = o
+		ohbem.Store(o)
 	}
 }
 
+// newOhbemInstance builds a configured Ohbem with no masterfile data loaded.
+func newOhbemInstance() *gohbem.Ohbem {
+	leagues := map[string]gohbem.League{
+		"little": {
+			Cap:            500,
+			LittleCupRules: false,
+		},
+		"great": {
+			Cap:            1500,
+			LittleCupRules: false,
+		},
+		"ultra": {
+			Cap:            2500,
+			LittleCupRules: false,
+		},
+	}
+
+	o := &gohbem.Ohbem{Leagues: leagues, LevelCaps: config.Config.Pvp.LevelCaps,
+		IncludeHundosUnderCap: config.Config.Pvp.IncludeHundosUnderCap,
+		MasterFileCachePath:   masterFileCachePath, Logger: &gohbemLogger{}}
+	switch config.Config.Pvp.RankingComparator {
+	case "prefer_higher_cp":
+		o.RankingComparator = gohbem.RankingComparatorPreferHigherCp
+	case "prefer_lower_cp":
+		o.RankingComparator = gohbem.RankingComparatorPreferLowerCp
+	default:
+		o.RankingComparator = gohbem.RankingComparatorDefault
+	}
+	return o
+}
+
 func reloadOhbemFromMasterFile() {
-	if ohbem == nil {
+	if ohbem.Load() == nil {
 		return
 	}
-	if err := ohbem.LoadPokemonData(masterFileCachePath); err != nil {
+	o := newOhbemInstance()
+	if err := o.LoadPokemonData(masterFileCachePath); err != nil {
 		log.Warnf("ohbem reload from MasterFile failed: %v", err)
-	} else {
-		log.Infof("ohbem reloaded from MasterFile cache")
+		return
 	}
+	ohbem.Store(o)
+	log.Infof("ohbem reloaded from MasterFile cache")
 }
 
 const floatTolerance = 0.000001

--- a/decoder/ohbem_reload_race_test.go
+++ b/decoder/ohbem_reload_race_test.go
@@ -1,0 +1,65 @@
+package decoder
+
+import (
+	"sync"
+	"testing"
+
+	"golbat/config"
+)
+
+// TestReloadOhbemFromMasterFile_ConcurrentQuery reproduces the production
+// fatal "concurrent map read and map write": the masterfile watcher calls
+// reloadOhbemFromMasterFile while API and decode goroutines are inside
+// QueryPvPRank reading the live masterfile maps. Run under -race this fails
+// unless reload publishes a fresh instance instead of mutating the live one.
+func TestReloadOhbemFromMasterFile_ConcurrentQuery(t *testing.T) {
+	oldPath := masterFileCachePath
+	oldPvp := config.Config.Pvp
+	defer func() {
+		masterFileCachePath = oldPath
+		config.Config.Pvp = oldPvp
+		ohbem.Store(nil) // other tests rely on ohbem being nil
+	}()
+
+	masterFileCachePath = "../pogo/master-latest-basics.json"
+	config.Config.Pvp.Enabled = true
+	config.Config.Pvp.LevelCaps = []int{50, 51}
+
+	InitialiseOhbem()
+	if ohbem.Load() == nil {
+		t.Fatal("InitialiseOhbem did not initialise ohbem")
+	}
+
+	// Sanity check: the query must reach the masterfile maps, otherwise the
+	// concurrent phase below would be vacuous.
+	if pvp, err := ohbem.Load().QueryPvPRank(1, 0, 0, 1, 15, 15, 15, 20); err != nil || len(pvp) == 0 {
+		t.Fatalf("QueryPvPRank sanity check failed: pvp=%v err=%v", pvp, err)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				// Load once per query, like the production read sites.
+				if _, err := ohbem.Load().QueryPvPRank(1, 0, 0, 1, 15, 15, 15, 20); err != nil {
+					t.Errorf("QueryPvPRank failed during reload: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < 5; i++ {
+		reloadOhbemFromMasterFile()
+	}
+	close(stop)
+	wg.Wait()
+}

--- a/decoder/pokemon_decode.go
+++ b/decoder/pokemon_decode.go
@@ -988,7 +988,8 @@ func (pokemon *Pokemon) repopulateIv(weather int64, isStrong bool) {
 }
 
 func (pokemon *Pokemon) recomputeCpIfNeeded(ctx context.Context, db db.DbDetails, weather map[int64]pogo.GameplayWeatherProto_WeatherCondition) {
-	if pokemon.Cp.Valid || ohbem == nil {
+	o := ohbem.Load()
+	if pokemon.Cp.Valid || o == nil {
 		return
 	}
 	var displayPokemon int
@@ -1033,13 +1034,13 @@ func (pokemon *Pokemon) recomputeCpIfNeeded(ctx context.Context, db db.DbDetails
 			return
 		}
 		// You should see boosted IV for 0P Ditto
-		cp, err = ohbem.CalculateCp(displayPokemon, displayPokemonForm, 0,
+		cp, err = o.CalculateCp(displayPokemon, displayPokemonForm, 0,
 			int(overrideIv.Attack), int(overrideIv.Defense), int(overrideIv.Stamina), float64(overrideIv.Level))
 	} else {
 		if !pokemon.AtkIv.Valid || !pokemon.Level.Valid {
 			return
 		}
-		cp, err = ohbem.CalculateCp(displayPokemon, displayPokemonForm, 0,
+		cp, err = o.CalculateCp(displayPokemon, displayPokemonForm, 0,
 			int(pokemon.AtkIv.Int64), int(pokemon.DefIv.Int64), int(pokemon.StaIv.Int64),
 			float64(pokemon.Level.Int64))
 	}

--- a/decoder/pokemon_state.go
+++ b/decoder/pokemon_state.go
@@ -159,12 +159,12 @@ func savePokemonRecordAsAtTime(ctx context.Context, db db.DbDetails, pokemon *Po
 
 	changePvpField := false
 	var pvpResults map[string][]gohbem.PokemonEntry
-	if ohbem != nil {
+	if o := ohbem.Load(); o != nil {
 		// Calculating PVP data - check for changes in pokemon properties that affect PVP rankings
 		// For new records, always calculate; for existing, check if relevant fields changed
 		shouldCalculatePvp := pokemon.AtkIv.Valid && (pokemon.isNewRecord() || pokemon.IsDirty())
 		if shouldCalculatePvp {
-			pvp, err := ohbem.QueryPvPRank(int(pokemon.PokemonId),
+			pvp, err := o.QueryPvPRank(int(pokemon.PokemonId),
 				int(pokemon.Form.ValueOrZero()),
 				int(pokemon.Costume.ValueOrZero()),
 				int(pokemon.Gender.ValueOrZero()),


### PR DESCRIPTION
## Problem

Production crashed with:

```
fatal error: concurrent map read and map write
  github.com/UnownHash/gohbem.(*Ohbem).QueryPvPRank ohbem.go:408
  golbat/decoder.buildApiPvpRankings ...
```

`reloadOhbemFromMasterFile` (called by the hourly masterfile watcher whenever upstream publishes a changed masterfile) invoked `gohbem.LoadPokemonData` on the **live** `Ohbem` instance. That unmarshals into the existing `PokemonData` struct, and `encoding/json` reuses non-nil maps — so it writes into the very `Pokemon` map that `QueryPvPRank` readers (API scans and pokemon saves) walk with no lock. The crash window is the few ms of unmarshal, once per masterfile release, which is why it was rare.

## Fix

The `ohbem` singleton is now an `atomic.Pointer[gohbem.Ohbem]`:

- Reloads build a fresh configured instance (`newOhbemInstance`), load the masterfile into it, and publish it with `Store`. A failed reload keeps the old instance.
- All read sites `Load()` once per logical operation (`buildApiPvpRankings`, `savePokemonRecordAsAtTime`, `recomputeCpIfNeeded`).
- The live instance is never mutated after publication, which also removes two adjacent races in the same event: the unsynchronized `Initialized` flag write and `ClearCache`'s `sync.Map` replacement.

No behavior change: reload already cleared the rank cache, so a fresh instance's empty cache matches existing semantics. The atomic load is a plain acquire-load on a cache line that only changes on reload — no new contention on the decode or API paths.

## Test

`decoder/ohbem_reload_race_test.go` reproduces the production race under `-race` (readers querying concurrently with `reloadOhbemFromMasterFile`); it failed on the exact line from the crash (`ohbem.go:408`) before the fix and passes after.

Note: `go test -race ./decoder/` has a pre-existing unrelated failure on main (`TestCreateStationWebhooksEmitsFutureBattle` racing the stats worker, `station_battle_test.go:330` vs `stats.go:418`) — not addressed here.

gohbem's own `WatchPokemonData`/`LoadPokemonData` carry the same bug for other consumers; worth an upstream issue separately. Golbat no longer exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMJMXHUiq6Pnce9KshgFTC